### PR TITLE
fix(geocode): 一過性エラーをキャッシュに焼き付けず次回再試行する

### DIFF
--- a/scripts/crawl.js
+++ b/scripts/crawl.js
@@ -391,19 +391,24 @@ async function enrichWithGeocoding(facilities) {
   njaConfig.cacheSize = 2000;
 
   let done = 0;
-  let failed = 0;
+  let failed = 0; // 住所として解決できなかった（恒久的な失敗）
+  let errored = 0; // ネットワーク障害・レート制限等の一過性エラー（キャッシュせず次回再試行）
   await runPool(toFetch, GEOCODE_CONCURRENCY, async (query) => {
     try {
       const r = await normalize(query);
       if (r && r.point && Number.isFinite(r.point.lat) && Number.isFinite(r.point.lng)) {
         cache[query] = { lat: r.point.lat, lng: r.point.lng, level: r.point.level ?? null };
       } else {
-        cache[query] = null; // 解決できなかった住所も記録し再試行を避ける
+        // 住所として解決できなかった恒久的な失敗。null を記録し再試行を避ける。
+        cache[query] = null;
         failed++;
       }
     } catch {
-      cache[query] = null;
-      failed++;
+      // ネットワーク障害・レート制限・タイムアウト等の一過性エラー。
+      // 恒久的な失敗（null 記録）とは区別し、キャッシュには書かないことで
+      // 次回実行時（`!(q in cache)`）に再試行されるようにする。一時的な障害が
+      // キャッシュに焼き付いて座標が永久に null になるのを防ぐ。
+      errored++;
     }
     done++;
     if (done % 1000 === 0) {
@@ -424,7 +429,10 @@ async function enrichWithGeocoding(facilities) {
       filled++;
     }
   }
-  console.log(`  座標を補完: ${filled}/${targets.length}施設（住所解決失敗 ${failed}件）`);
+  console.log(
+    `  座標を補完: ${filled}/${targets.length}施設` +
+      `（住所解決失敗 ${failed}件、一時エラーで未取得 ${errored}件は次回再試行）`,
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -112,6 +112,15 @@ for (const pref of prefectures) {
           withCoords++;
         }
       }
+
+      // geocoding_level は null または 1〜8 の整数であること
+      if (
+        f.geocoding_level != null &&
+        (!Number.isInteger(f.geocoding_level) || f.geocoding_level < 1 || f.geocoding_level > 8)
+      ) {
+        console.error(`  ✗ ${pref}/${city}: 不正な geocoding_level (${f.geocoding_level}) - ${f.name}`);
+        failures++;
+      }
     }
 
     if (!checkedFacilitySample && cityData.data.length > 0) {


### PR DESCRIPTION
PR #3 のレビューで見つかったキャッシュ汚染バグの修正です。base は #3 のブランチ `feat/geocode-missing-latlng` に向けています（#3 にスタック）。

## 背景・解決したい課題

`enrichWithGeocoding` の `catch` 節が、**ネットワーク障害・レート制限・タイムアウト等の一過性エラー**を、**住所として解決できなかった恒久的な失敗と全く同じ** `cache[query] = null` として永続化していました。

次回実行時の `toFetch = uniqueQueries.filter((q) => !(q in cache))` は、値が `null` でもキーが存在すれば再取得対象から外すため、以下の不具合が発生します。

- 週次クロール中に geolonia 側で一時的な障害が起きると、その間に処理された住所が `null` でキャッシュに焼き付く
- GH Actions が `.cache` を復元するため、**翌週以降も再試行されず、該当施設の `lat/lng` が永久に `null` のまま**になる
- 唯一のガードである `assert(withCoords > 0)` は1件でも成功すれば通るため、部分的なデータ劣化に気づけない

## 変更内容

- **`scripts/crawl.js`**: 例外（一過性エラー）はキャッシュに書かず `errored` として集計。次回実行（`!(q in cache)`）で再試行されるようにし、恒久的な解決失敗（`null` 記録）と区別。完了ログに「一時エラーで未取得 N件は次回再試行」を表示。
- **`scripts/test.js`**: `geocoding_level` が `null` または `1〜8` の整数であることの検証を追加。

データ生成物（`api/**`）は変更していません（ロジック修正のみ）。

## 動作確認基準

- 通常時（全件解決）の挙動は従来どおりであること → 既存コミット済みデータに対し `npm test` が合格
- 一過性エラーが発生した住所はキャッシュに `null` 記録されず、再クロール時に再試行対象（`toFetch`）へ含まれること
- `geocoding_level` に不正値（非整数・0・9以上）が混入したらテストが失敗すること

## レビュー観点

- 恒久的失敗（解決不能）と一過性エラー（例外）の区別が妥当か
- 例外をキャッシュしないことで、毎回必ず再試行される＝公開APIへの負荷が増えないか（解決済み住所はキャッシュ済みのため再試行対象は未解決＋エラー分のみ。設計上問題なしと判断）

## テスト

- `node --check` 構文チェック合格
- `npm test`（既存データに対する検証）合格: 施設総数 35,039件 / 座標あり 100.0% / `geocoding_level` 全件妥当