### PR TITLE
GeonicDB 取り込み用の NGSI-LD 変換・投入スクリプトを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 .cache/
+build/
 *.log
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
     "build": "node scripts/crawl.js",
     "build:dry": "node scripts/crawl.js --dry-run",
     "build:search-index": "node scripts/gen-search-index.js",
-    "test": "node scripts/test.js"
+    "build:ngsild": "node scripts/gen-ngsild.js",
+    "import:geonicdb": "node scripts/import-geonicdb.js",
+    "test": "node scripts/test.js && node scripts/gen-ngsild.test.js",
+    "test:ngsild": "node scripts/gen-ngsild.test.js"
   },
   "dependencies": {
     "@geolonia/normalize-japanese-addresses": "^3.1.3",

--- a/scripts/gen-ngsild.js
+++ b/scripts/gen-ngsild.js
@@ -1,0 +1,151 @@
+// ---------------------------------------------------------------------------
+// api/facilities 配下の施設データを GeonicDB（FIWARE / NGSI-LD）へ投入するための
+// NGSI-LD エンティティ（type: PointOfInterest）に変換し、チャンク分割して書き出す。
+//
+// - 型は Smart Data Model の PointOfInterest に寄せる（name / category / address /
+//   location(GeoProperty)）。location を持たせることで GeonicDB の geo-query
+//   （georel near 等）が効くようになる。
+// - id は「名前+座標」の安定ハッシュにするので、再クロール後に投入し直しても
+//   upsert が冪等（同じ施設は重複しない）。search-index.json と同じ粒度で重複排除する。
+// - 全国スケール前提: 都道府県フォルダ名を address.addressRegion に流用するので、
+//   沖縄県以外を api/ に足しても変換側は無改修で動く。
+//
+// 出力: build/ngsild/entities-NNNN.json（NGSI-LD エンティティ配列。gitignore 対象）
+//
+// 使い方:
+//   node scripts/gen-ngsild.js                 既定チャンクサイズ(1000)で生成
+//   node scripts/gen-ngsild.js --chunk 500     チャンクサイズ指定
+// ---------------------------------------------------------------------------
+
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const FACILITIES_DIR = path.join(ROOT, 'api', 'facilities');
+const OUT_DIR = path.join(ROOT, 'build', 'ngsild');
+
+/** 座標を 6 桁に丸める（約 0.1m 精度で十分。search-index.json と同じ丸め）。 */
+function round6(n) {
+  return Math.round(n * 1e6) / 1e6;
+}
+
+/** 名前+座標から安定した URN を作る（冪等 upsert 用）。 */
+function entityId(name, lat, lng) {
+  const hash = crypto.createHash('sha1').update(`${name}|${lat}|${lng}`).digest('hex').slice(0, 16);
+  return `urn:ngsi-ld:PointOfInterest:${hash}`;
+}
+
+/**
+ * 重複排除済みの施設 1 件を NGSI-LD エンティティに変換する。
+ * category は業種（business_type）の配列、address は都道府県・市区町村つきの構造化住所。
+ */
+export function facilityToEntity(f, pref, city) {
+  const lat = round6(f.lat);
+  const lng = round6(f.lng);
+  const entity = {
+    id: entityId(f.name, lat, lng),
+    type: 'PointOfInterest',
+    name: { type: 'Property', value: f.name },
+    category: { type: 'Property', value: f.categories },
+    address: {
+      type: 'Property',
+      value: {
+        addressCountry: 'JP',
+        addressRegion: pref,
+        addressLocality: city,
+        streetAddress: f.address ?? '',
+      },
+    },
+    location: {
+      type: 'GeoProperty',
+      value: { type: 'Point', coordinates: [lng, lat] },
+    },
+    // データセット出所（全国で複数ソースを混ぜても由来を辿れるように）。
+    source: { type: 'Property', value: 'japan-facilities-address' },
+  };
+  if (f.geocoding_level != null) {
+    entity.geocodingLevel = { type: 'Property', value: f.geocoding_level };
+  }
+  if (f.phone) entity.telephone = { type: 'Property', value: f.phone };
+  return entity;
+}
+
+/**
+ * api/facilities 配下の全 data.json を読み、NGSI-LD エンティティ配列を返す。
+ * 同一施設（業種違いで複数行）は「名前+丸め座標」で 1 エンティティに統合し、
+ * business_type は category 配列にまとめる。座標・名前が無い行は捨てる。
+ */
+export function buildEntities() {
+  if (!fs.existsSync(FACILITIES_DIR)) {
+    console.warn('  api/facilities が無いため変換をスキップ');
+    return [];
+  }
+
+  // key(名前+座標) -> { 施設 + categories集合 + pref/city }
+  const merged = new Map();
+
+  for (const pref of fs.readdirSync(FACILITIES_DIR).sort()) {
+    const prefDir = path.join(FACILITIES_DIR, pref);
+    if (!fs.statSync(prefDir).isDirectory()) continue;
+
+    for (const city of fs.readdirSync(prefDir).sort()) {
+      const dataPath = path.join(prefDir, city, 'data.json');
+      if (!fs.existsSync(dataPath)) continue;
+
+      const json = JSON.parse(fs.readFileSync(dataPath, 'utf-8'));
+      for (const f of json.data ?? []) {
+        if (typeof f.lat !== 'number' || typeof f.lng !== 'number') continue;
+        if (!f.name) continue;
+
+        const lat = round6(f.lat);
+        const lng = round6(f.lng);
+        const key = `${f.name}|${lat}|${lng}`;
+
+        let e = merged.get(key);
+        if (!e) {
+          e = { ...f, categories: new Set(), _pref: pref, _city: city };
+          merged.set(key, e);
+        }
+        if (f.business_type) e.categories.add(f.business_type);
+      }
+    }
+  }
+
+  const entities = [];
+  for (const e of merged.values()) {
+    entities.push(
+      facilityToEntity({ ...e, categories: [...e.categories] }, e._pref, e._city),
+    );
+  }
+  return entities;
+}
+
+/** エンティティ配列を chunkSize 件ずつ build/ngsild/entities-NNNN.json に書き出す。 */
+export function writeChunks(entities, chunkSize) {
+  fs.rmSync(OUT_DIR, { recursive: true, force: true });
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  let n = 0;
+  for (let i = 0; i < entities.length; i += chunkSize) {
+    const chunk = entities.slice(i, i + chunkSize);
+    const file = path.join(OUT_DIR, `entities-${String(n).padStart(4, '0')}.json`);
+    fs.writeFileSync(file, JSON.stringify(chunk));
+    n += 1;
+  }
+  return n;
+}
+
+// 直接実行された場合は変換して書き出す。
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const argv = process.argv.slice(2);
+  const ci = argv.indexOf('--chunk');
+  const chunkSize = ci >= 0 ? Number(argv[ci + 1]) : 1000;
+
+  const entities = buildEntities();
+  const chunks = writeChunks(entities, chunkSize);
+  console.log(
+    `  NGSI-LD: ${entities.length}件 → ${path.relative(ROOT, OUT_DIR)}/ (${chunks}チャンク × ${chunkSize})`,
+  );
+}

--- a/scripts/gen-ngsild.test.js
+++ b/scripts/gen-ngsild.test.js
@@ -1,0 +1,76 @@
+// gen-ngsild.js の変換ロジック（施設 → NGSI-LD PointOfInterest）を検証する。
+// api/ の生成物に依存しない純粋関数テストなので、単体で実行できる。
+//
+//   node scripts/gen-ngsild.test.js
+
+import { facilityToEntity } from './gen-ngsild.js';
+
+let failures = 0;
+function assert(cond, msg) {
+  if (cond) {
+    console.log(`  ✓ ${msg}`);
+  } else {
+    console.error(`  ✗ ${msg}`);
+    failures++;
+  }
+}
+
+console.log('gen-ngsild 変換テスト\n');
+
+// 代表的な施設 1 件（業種は categories 配列で渡す形に正規化済み）。
+const sample = {
+  name: 'ステーキハウス○○',
+  categories: ['飲食店営業', '喫茶店営業'],
+  address: '那覇市松山1-9-9',
+  lat: 26.216965935,
+  lng: 127.678060421,
+  geocoding_level: 8,
+  phone: '098-000-0000',
+};
+const e = facilityToEntity(sample, '沖縄県', '那覇市');
+
+assert(e.type === 'PointOfInterest', 'type は PointOfInterest');
+assert(e.id.startsWith('urn:ngsi-ld:PointOfInterest:'), 'id は PointOfInterest の URN');
+assert(e.name?.type === 'Property' && e.name.value === 'ステーキハウス○○', 'name が Property で入る');
+assert(
+  e.category?.type === 'Property' && JSON.stringify(e.category.value) === JSON.stringify(['飲食店営業', '喫茶店営業']),
+  'category は業種の配列',
+);
+assert(
+  e.address?.value?.addressRegion === '沖縄県' && e.address.value.addressLocality === '那覇市',
+  'address に都道府県・市区町村が入る',
+);
+assert(e.address?.value?.streetAddress === '那覇市松山1-9-9', 'address.streetAddress が入る');
+
+// location は GeoProperty / GeoJSON Point。coordinates は [lng, lat] で 6 桁丸め。
+assert(e.location?.type === 'GeoProperty', 'location は GeoProperty');
+assert(e.location?.value?.type === 'Point', 'location は Point');
+assert(
+  Array.isArray(e.location?.value?.coordinates) &&
+    e.location.value.coordinates[0] === 127.67806 &&
+    e.location.value.coordinates[1] === 26.216966,
+  'coordinates は [lng, lat] で 6 桁に丸められる',
+);
+assert(e.geocodingLevel?.value === 8, 'geocodingLevel が入る');
+assert(e.telephone?.value === '098-000-0000', 'phone があれば telephone が入る');
+assert(e.source?.value === 'japan-facilities-address', 'source にデータセット名が入る');
+
+// id は「名前+丸め座標」の安定ハッシュ = 冪等（同入力で同 id、丸め前の座標差は吸収）。
+const e2 = facilityToEntity({ ...sample, lat: 26.2169659, lng: 127.6780604 }, '沖縄県', '那覇市');
+assert(e.id === e2.id, '丸めて同座標になる同名施設は同じ id（冪等 upsert 用）');
+const e3 = facilityToEntity({ ...sample, name: '別の店' }, '沖縄県', '那覇市');
+assert(e.id !== e3.id, '名前が違えば id も違う');
+
+// phone が空なら telephone は付けない。
+const noPhone = facilityToEntity({ ...sample, phone: '' }, '沖縄県', '那覇市');
+assert(!('telephone' in noPhone), 'phone が空なら telephone を付けない');
+
+// geocoding_level が null なら geocodingLevel は付けない。
+const noLevel = facilityToEntity({ ...sample, geocoding_level: null }, '沖縄県', '那覇市');
+assert(!('geocodingLevel' in noLevel), 'geocoding_level が null なら geocodingLevel を付けない');
+
+if (failures > 0) {
+  console.error(`\n❌ ${failures}件のチェックに失敗`);
+  process.exit(1);
+}
+console.log('\n✅ gen-ngsild 変換テストに合格');

--- a/scripts/import-geonicdb.js
+++ b/scripts/import-geonicdb.js
@@ -1,0 +1,123 @@
+// ---------------------------------------------------------------------------
+// build/ngsild/ のエンティティチャンクを GeonicDB に一括投入する。
+//
+// 認証は geonicdb-pulse と同じ Bearer JWT 方式（POST /auth/login でトークン取得）。
+// 投入は NGSI-LD の batch upsert（POST /ngsi-ld/v1/entityOperations/upsert、
+// geonic CLI の `entityOperations upsert` と同じエンドポイント）。id が安定ハッシュ
+// なので upsert は冪等（再投入で重複しない）。
+//
+// 認証情報は環境変数で渡す（履歴・ログに残さない）:
+//   GEONICDB_URL       例) https://geonicdb.geolonia.com
+//   GEONICDB_TENANT    例) ohashi
+//   GEONICDB_EMAIL     例) naoki@geolonia.com
+//   GEONICDB_PASSWORD  パスワード
+//
+// 使い方:
+//   node scripts/gen-ngsild.js                       まずチャンクを生成
+//   GEONICDB_URL=... GEONICDB_TENANT=ohashi \
+//   GEONICDB_EMAIL=... GEONICDB_PASSWORD=... \
+//     node scripts/import-geonicdb.js                投入
+//   ... node scripts/import-geonicdb.js --limit 1    先頭1チャンクだけ（動作確認用）
+//   ... node scripts/import-geonicdb.js --dry-run    ログインだけして投入しない
+// ---------------------------------------------------------------------------
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const OUT_DIR = path.join(ROOT, 'build', 'ngsild');
+
+// GeonicDB の batch upsert は 1 リクエスト 100 件が上限。チャンクファイルが
+// それより大きくても、送信時に 100 件ずつに分割して投げる。
+const BATCH_SIZE = 100;
+
+function requireEnv(name) {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`環境変数 ${name} が未設定です`);
+    process.exit(1);
+  }
+  return v;
+}
+
+/** POST /auth/login で Bearer トークンを取得する（pulse と同じログインフロー）。 */
+async function login(url, tenant, email, password) {
+  const res = await fetch(`${url}/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password, tenantName: tenant }),
+  });
+  if (!res.ok) {
+    throw new Error(`ログイン失敗: HTTP ${res.status} ${await res.text()}`);
+  }
+  const json = await res.json();
+  const token = json.accessToken || json.token;
+  if (!token) throw new Error('ログイン応答にトークンがありません');
+  return token;
+}
+
+/** 1 チャンクを batch upsert する。 */
+async function upsertChunk(url, tenant, token, entities) {
+  const res = await fetch(`${url}/ngsi-ld/v1/entityOperations/upsert`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+      'NGSILD-Tenant': tenant,
+    },
+    body: JSON.stringify(entities),
+  });
+  if (!res.ok) {
+    throw new Error(`upsert 失敗: HTTP ${res.status} ${await res.text()}`);
+  }
+  return res.status;
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const dryRun = argv.includes('--dry-run');
+  const li = argv.indexOf('--limit');
+  const limit = li >= 0 ? Number(argv[li + 1]) : Infinity;
+
+  const url = requireEnv('GEONICDB_URL').replace(/\/$/, '');
+  const tenant = requireEnv('GEONICDB_TENANT');
+  const email = requireEnv('GEONICDB_EMAIL');
+  const password = requireEnv('GEONICDB_PASSWORD');
+
+  if (!fs.existsSync(OUT_DIR)) {
+    console.error(`${path.relative(ROOT, OUT_DIR)} がありません。先に gen-ngsild.js を実行してください`);
+    process.exit(1);
+  }
+  const files = fs.readdirSync(OUT_DIR).filter((f) => f.endsWith('.json')).sort();
+  console.log(`チャンク: ${files.length}件 (${url}, tenant=${tenant})`);
+
+  const token = await login(url, tenant, email, password);
+  console.log('ログイン成功');
+  if (dryRun) {
+    console.log('--dry-run のため投入しません');
+    return;
+  }
+
+  let done = 0;
+  let total = 0;
+  for (const file of files) {
+    if (done >= limit) break;
+    const entities = JSON.parse(fs.readFileSync(path.join(OUT_DIR, file), 'utf-8'));
+    // 1 ファイルを 100 件ずつに分けて upsert（サーバのバッチ上限に合わせる）。
+    for (let i = 0; i < entities.length; i += BATCH_SIZE) {
+      const batch = entities.slice(i, i + BATCH_SIZE);
+      await upsertChunk(url, tenant, token, batch);
+      total += batch.length;
+    }
+    done += 1;
+    console.log(`  ${file}: ${entities.length}件 upsert  [${done}/${Math.min(files.length, limit)}]`);
+  }
+  console.log(`完了: ${total}件を投入しました`);
+}
+
+main().catch((err) => {
+  console.error(err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## 背景・解決したい課題
- BA-SHARE の施設名検索を、静的索引（`search-index.json`）配信から **GeonicDB（FIWARE / NGSI-LD Context Broker）経由**に切り替えたい。
- そのために japan-facilities-address の施設データを GeonicDB へ取り込む手段（変換＋投入）が必要。

## 変更内容
- `scripts/gen-ngsild.js`: `api/facilities/**/data.json` を NGSI-LD の `PointOfInterest` エンティティ配列に変換し、チャンク分割して `build/ngsild/`（gitignore）へ出力。
- `scripts/import-geonicdb.js`: `POST /auth/login` で Bearer トークンを取得し、`entityOperations/upsert` へ 100 件/リクエストで一括投入。
- `package.json` に `build:ngsild` / `import:geonicdb` / `test:ngsild` を追加。`build/` を gitignore。

## 採用したアプローチと意図
- 型は Smart Data Model の **`PointOfInterest`** に寄せ、`location`（GeoProperty）を持たせることで GeonicDB の geo-query を効かせる。
- **id は「名前＋丸め座標」の安定ハッシュ**にし、業種違いで重複する行は 1 エンティティに統合（業種は `category` 配列）。これで再クロール後の再投入が **冪等**になり重複しない。
- **全国スケール前提**の設計（都道府県フォルダ名を `addressRegion` に流用）で、沖縄以外を足しても変換は無改修。データは差し当たり沖縄県から開始。
- 投入は CLI（`geonic entityOperations upsert`）と同じ NGSI-LD API を使うため、認証・バッチ上限（100件）に素直に従う実装にした。

## テスト
- ユニットテスト `scripts/gen-ngsild.test.js`（`npm test` / `npm run test:ngsild`）: `facilityToEntity` の変換（型・id・category配列・構造化住所・[lng,lat]の6桁丸め・telephone/geocodingLevelの有無）と、**id の冪等性**（同名＋近接座標で同id、名前違いで別id）を検証。
- 手動確認: 実データを本 scripts で変換し、GeonicDB（テナント ohashi）へ投入 → 件数・名前検索・geo検索が返ることを確認済み。

## 確認してほしいポイント
- エンティティのスキーマ設計（`PointOfInterest` / 属性名 `category` / `geocodingLevel` / `telephone` / `source`）が妥当か。
- id ハッシュ方針（名前＋6桁丸め座標）で意図しない衝突・重複が起きないか。

> 注: 本リポジトリには PR 用 CI ワークフローが無いため、CI チェックは走りません（`crawl.yml` はスケジュール実行のみ）。
