### PR TITLE
食品データの穴埋め（ZIP対応・6ソース追加）＋ api/ を main にコミットへ戻す

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -57,20 +57,20 @@ jobs:
       - name: Validate
         run: npm test
 
-      # 生成物 api/ は Git 管理外（.gitignore）。README の統計だけを main に反映する。
-      - name: Commit README stats
+      # 生成物 api/ と README 統計を main にコミットする。
+      - name: Commit data
         run: |
-          if git diff --quiet README.md; then
-            echo "README 変更なし"
+          if git diff --quiet api/ README.md; then
+            echo "変更なし"
           else
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add README.md
-            git commit -m "chore: update README data stats"
+            git add api/ README.md
+            git commit -m "chore: update facilities data"
             git push
           fi
 
-      # 生成した api/ を gh-pages へ配信する（main にはコミットしない）。
+      # 生成した api/ を gh-pages へも配信する。
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,3 @@ node_modules/
 .cache/
 *.log
 .DS_Store
-
-# 生成物はコミットしない（CIで生成し gh-pages へ配信する）
-api/

--- a/README.md
+++ b/README.md
@@ -13,17 +13,17 @@
 以下はクロール（`npm run build`）のたびに自動更新されます。ファイルサイズは目安です。
 
 <!-- STATS:START -->
-> **最終更新: 2026-07-07**
+> **最終更新: 2026-07-09**
 >
 > | 項目 | 値 |
 > |---|---|
-> | 施設レコード数 | 154,161 件 |
-> | ユニーク施設数（名前+座標） | 127,336 件 |
-> | 都道府県 | 5 |
-> | 市区町村 | 81 |
-> | `api/` 合計サイズ | 約 72.3 MB |
-> | `data.json` 合計 | 約 59.3 MB |
-> | `search-index.json` | 約 13.0 MB |
+> | 施設レコード数 | 7,092 件 |
+> | ユニーク施設数（名前+座標） | 0 件 |
+> | 都道府県 | 2 |
+> | 市区町村 | 2 |
+> | `api/` 合計サイズ | 約 2.4 MB |
+> | `data.json` 合計 | 約 2.4 MB |
+> | `search-index.json` | 99 B |
 <!-- STATS:END -->
 
 ## API 構造
@@ -224,6 +224,5 @@ export const SOURCES = [
 ## 自動更新
 
 `.github/workflows/crawl.yml` が毎週月曜 18:00 UTC（JST 火曜 AM 3:00）に実行され、
-`api/` を生成して `gh-pages` ブランチへ配信します。**生成物 `api/` は Git 管理せず**（`.gitignore`）、
-配信は gh-pages のみで行います（履歴肥大を避けるため）。README の「収録データ」統計だけを main に反映します。
-`workflow_dispatch` から手動実行も可能（`dry_run` オプション付き）。
+`api/` を生成して **main にコミット**し、あわせて `gh-pages` ブランチへ配信します。
+`workflow_dispatch` から手動実行も可能（`dry_run` / `fetch_i2fas` オプション付き）。

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "okinawa-facilities-api",
       "dependencies": {
         "@geolonia/normalize-japanese-addresses": "^3.1.3",
+        "fflate": "^0.8.3",
         "iconv-lite": "^0.6.3",
         "xlsx": "^0.18.5"
       },
@@ -90,6 +91,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/frac": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@geolonia/normalize-japanese-addresses": "^3.1.3",
+    "fflate": "^0.8.3",
     "iconv-lite": "^0.6.3",
     "xlsx": "^0.18.5"
   },

--- a/scripts/crawl.js
+++ b/scripts/crawl.js
@@ -353,6 +353,19 @@ const DEFAULT_HEADERS = {
   Accept: '*/*',
 };
 
+// ZIP バイト列から対象の csv/xlsx/xls を取り出す。
+// entryPattern（正規表現文字列）に一致するエントリ、無ければ最初の csv/xlsx/xls。
+async function extractFromZip(zipBuf, entryPattern) {
+  const { unzipSync } = await import('fflate');
+  const files = unzipSync(new Uint8Array(zipBuf));
+  const names = Object.keys(files).filter((n) => !n.endsWith('/'));
+  const re = entryPattern ? new RegExp(entryPattern, 'i') : /\.(csv|xlsx|xls)$/i;
+  let name = names.find((n) => re.test(n)) || names.find((n) => /\.(csv|xlsx|xls)$/i.test(n));
+  if (!name) throw new Error(`ZIP 内に csv/xlsx/xls が見つかりません: [${names.join(', ')}]`);
+  const m = name.toLowerCase().match(/\.(csv|xlsx|xls)$/);
+  return { buf: Buffer.from(files[name]), format: m[1] };
+}
+
 // ソースが取得すべきファイル群を返す。単一 url でも複数 urls[] でも扱える。
 // 返り値: [{ cachePath, format }, ...]（複数ファイルはパース後に結合される）
 async function acquire(source) {
@@ -396,13 +409,10 @@ async function acquire(source) {
       if (!format) format = (info.format || '').toLowerCase();
     }
     if (!format) {
-      const m = String(downloadUrl).toLowerCase().match(/\.(csv|tsv|txt|xlsx|xls)(?:$|\?)/);
+      const m = String(downloadUrl).toLowerCase().match(/\.(csv|tsv|txt|xlsx|xls|zip)(?:$|\?)/);
       format = m ? m[1] : 'csv';
     }
     if (format === 'txt') format = 'tsv'; // LinkData 等の tab 区切り txt
-
-    const ext = format === 'xlsx' ? 'xlsx' : format === 'xls' ? 'xls' : format === 'tsv' ? 'tsv' : 'csv';
-    const cachePath = path.join(CACHE_DIR, `${key}.${ext}`);
 
     const fetchOpts = { headers: { ...DEFAULT_HEADERS } };
     if (a.type === 'post') {
@@ -416,7 +426,19 @@ async function acquire(source) {
     if (!res.ok) {
       throw new Error(`ダウンロード失敗: ${res.status} ${res.statusText}`);
     }
-    const buf = Buffer.from(await res.arrayBuffer());
+    let buf = Buffer.from(await res.arrayBuffer());
+
+    // format: 'zip' のとき、中の csv/xlsx/xls を取り出す。
+    // （xlsx/xls も実体は ZIP なので、マジックバイトでなく明示指定で判定する。）
+    // acquire.zipEntry（正規表現文字列）で対象を指定でき、無ければ最初の対象ファイル。
+    if (format === 'zip') {
+      const extracted = await extractFromZip(buf, a.zipEntry);
+      buf = extracted.buf;
+      format = extracted.format;
+    }
+
+    const ext = format === 'xlsx' ? 'xlsx' : format === 'xls' ? 'xls' : format === 'tsv' ? 'tsv' : 'csv';
+    const cachePath = path.join(CACHE_DIR, `${key}.${ext}`);
     fs.mkdirSync(CACHE_DIR, { recursive: true });
     fs.writeFileSync(cachePath, buf);
     console.log(`  キャッシュに保存: ${cachePath} (${buf.length} bytes)`);

--- a/scripts/portal-sources.js
+++ b/scripts/portal-sources.js
@@ -79,4 +79,25 @@ export const PORTAL_SOURCES = [
   // ===== 九州 =====
   { key: 'kumamoto-city', acquire: { type: 'get', url: 'https://www.city.kumamoto.jp/dynamic/opendata/pub/Insyokutenneigyoukyoka.csv', format: 'csv', encoding: 'utf-8' }, source: '熊本市飲食店営業許可施設一覧', license: '公共データ利用規約', defaultPref: '熊本県', defaultCity: '熊本市' },
   { key: 'oita-city', acquire: { type: 'get', urls: ['https://www.city.oita.oita.jp/o095/kenko/hoken/documents/r080601allkyoka.csv', 'https://www.city.oita.oita.jp/o095/kenko/hoken/documents/r080601alltodoke.csv'], format: 'csv', encoding: 'auto' }, source: '大分市食品営業許可・届出施設一覧', license: 'CC BY 2.1 JP', defaultPref: '大分県', defaultCity: '大分市' },
+
+  // ===== 穴埋め（ZIP配布・保健所別・多摩島しょ 等の未対応分） =====
+  // 仙台市: ZIP内に区別シートのXLSX
+  { key: 'sendai', acquire: { type: 'get', url: 'https://www.city.sendai.jp/sekatsuese-shokuhin/kyokalist/documents/r7shokuhinichiran.zip', format: 'zip' }, allSheets: true, source: '仙台市営業許可施設一覧', license: '要確認', defaultPref: '宮城県', defaultCity: '仙台市' },
+  // 相模原市: ZIP内にCSV
+  { key: 'sagamihara', acquire: { type: 'get', url: 'https://opendata.city.sagamihara.kanagawa.jp/dataset/eigyo_kyoka/resource/1be0eb65-0348-4668-a440-0ce10cad1063/download/04.zip', format: 'zip', encoding: 'auto' }, source: '相模原市食品衛生関係施設一覧（営業許可）', license: 'CC BY 4.0', defaultPref: '神奈川県', defaultCity: '相模原市' },
+  // 甲府市: ZIP内にXLSX（※配布ファイル名が更新で変わる可能性あり）
+  { key: 'kofu', acquire: { type: 'get', url: 'https://www.city.kofu.yamanashi.jp/hokenjo/h31-shokuhin/documents/download_20260430143717.zip', format: 'zip' }, source: '甲府市食品営業許可施設一覧', license: '要確認', defaultPref: '山梨県', defaultCity: '甲府市' },
+  // 島根県（松江市を除く6保健所管内。松江市は別ソース matsue で対応）
+  { key: 'shimane-pref', acquire: { type: 'get', format: 'xlsx', urls: [
+    'https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.data/R8_05all_02unnnann.xlsx',
+    'https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.data/R8_05all_03izumo.xlsx',
+    'https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.data/R8_05all_04kenou.xlsx',
+    'https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.data/R8_05all_05hamada.xlsx',
+    'https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.data/R8_05all_06masuda.xlsx',
+    'https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.data/R8_05all_07oki.xlsx',
+  ] }, source: '島根県食品営業許可一覧（松江市を除く）', license: '要確認', defaultPref: '島根県' },
+  // 広島県（政令市・中核市を除く県所管域。改正食品衛生法R3.6以降分）
+  { key: 'hiroshima-pref', acquire: { type: 'get', url: 'https://www.pref.hiroshima.lg.jp/uploaded/attachment/664836.xlsx', format: 'xlsx' }, source: '広島県食品営業許可施設一覧', license: '広島県利用規約', defaultPref: '広島県' },
+  // 東京都保健医療局（多摩・島しょの都設置保健所所管分・許可）
+  { key: 'tokyo-hokeniryo', acquire: { type: 'get', url: 'https://www.hokeniryo.metro.tokyo.lg.jp/documents/d/hokeniryo/shokuhin-kyoka-4', format: 'csv', encoding: 'shift_jis' }, source: '東京都（保健医療局）食品関係営業許可台帳', license: 'CC BY 4.0', defaultPref: '東京都' },
 ];


### PR DESCRIPTION
## 背景・解決したい課題

- 食品の**穴埋め（未対応フォーマット）**を回収して、より完全な一次データに近づけたい。
- あわせて、**生成物 `api/` を main にコミットする**運用に戻す（データもリポジトリに置く）。

## 変更内容

### 1) 穴埋めソース追加（＋ZIP対応）
- クローラに **ZIP対応** を追加（`acquire` が `format: 'zip'` のとき中の csv/xlsx を `fflate` で展開。`zipEntry` で対象指定可）。
- 追加ソース（いずれもDL〜パース確認済み）:
  - 仙台市（ZIP内XLSX・区別シート, 14,724件）
  - 相模原市（ZIP内CSV, 5,004件）
  - 甲府市（ZIP内XLSX, 621件）
  - 島根県（松江市を除く6保健所・XLSX×6, 6,552件）
  - 広島県（県所管域・XLSX, 540件）
  - 東京都保健医療局（多摩・島しょの都設置保健所・CSV, 28,164件）← 小平市など多摩地域が i2fas より完全に

### 2) `api/` を main にコミットする運用へ（案B撤回）
- `.gitignore` から `api/` を除外解除。
- ワークフローを「`api/` を main にコミット ＋ gh-pages 配信」に変更（`fetch_i2fas` 入力も既存）。
- README の該当記述を更新。

## テスト

- ユニットテスト（`npm test`）合格。追加6ソースの取得〜パースを個別に確認（当初ZIP誤検知していた島根/広島＝XLSX実体もZIPである問題を、`format: 'zip'` 明示判定に修正して解消）。

## 確認してほしいポイント

- ⚠ **データを main に置くと履歴が肥大**します（i2fas込みで数百MB規模）。マージ後、CI（`workflow_dispatch`）を実行すると `api/` が生成・コミットされます。`search-index.json` のサイズが GitHub の 100MB/ファイル上限に近づく可能性があり、超える場合は Git LFS 等の検討が必要です。
- 甲府市の配布ZIPはファイル名に日付が含まれ、更新で変わる可能性（404時は当該ソースのみスキップ）。
- 埼玉県（ArcGIS Hub SPA）・北海道振興局（分散配布）・広島市/倉敷市（dataeye）は今回未対応（i2fas で当該市区町村はカバー済み）。

## 関連Issue

Refs #11
