### PR TITLE
splitPrefCity: 市名が「市」で終わる市（四日市市/廿日市市/野々市市）の集約修正

### DIFF
--- a/scripts/crawl.js
+++ b/scripts/crawl.js
@@ -232,6 +232,10 @@ function splitPrefCity(addr) {
   const pref = PREFECTURE_NAMES.find((p) => a.startsWith(p));
   if (!pref) return [null, null];
   const rest = a.slice(pref.length);
+  // 市名自体が「市」で終わる市（二重の「市」）を先に確定させる（例: 四日市市・廿日市市・野々市市）
+  for (const d of ['四日市市', '廿日市市', '野々市市']) {
+    if (rest.startsWith(d)) return [pref, d];
+  }
   // 郡＋町村（「余市郡余市町」等、郡名に「市」を含むケースを先に処理）
   let m = rest.match(/^(.+?郡.+?[町村])/);
   if (m) return [pref, m[1]];

--- a/scripts/crawl.test.js
+++ b/scripts/crawl.test.js
@@ -131,6 +131,11 @@ test('splitPrefCity: 一般市・特別区', () => {
   assert.deepEqual(splitPrefCity('千葉県市川市八幡'), ['千葉県', '市川市']);
   assert.deepEqual(splitPrefCity('東京都千代田区丸の内'), ['東京都', '千代田区']);
 });
+test('splitPrefCity: 市名が「市」で終わる市（二重の市）', () => {
+  assert.deepEqual(splitPrefCity('三重県四日市市諏訪町'), ['三重県', '四日市市']);
+  assert.deepEqual(splitPrefCity('広島県廿日市市下平良'), ['広島県', '廿日市市']);
+  assert.deepEqual(splitPrefCity('石川県野々市市三納'), ['石川県', '野々市市']);
+});
 test('splitPrefCity: 都道府県で始まらなければ null', () => {
   assert.deepEqual(splitPrefCity('足寄町南三条'), [null, null]);
   assert.deepEqual(splitPrefCity(''), [null, null]);


### PR DESCRIPTION
PR #16→#18 のマージ後に取り残された修正コミットの取り込み。i2fas等の住所パースで「廿日市市→廿日市」等と誤集約されるのを修正（＋テスト）。Refs #11