### PR TITLE
CI: gh-pages配信を先行＋main pushをrebaseリトライ（競合で配信スキップを防止）

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -57,20 +57,8 @@ jobs:
       - name: Validate
         run: npm test
 
-      # 生成物 api/ と README 統計を main にコミットする。
-      - name: Commit data
-        run: |
-          if git diff --quiet api/ README.md; then
-            echo "変更なし"
-          else
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add api/ README.md
-            git commit -m "chore: update facilities data"
-            git push
-          fi
-
-      # 生成した api/ を gh-pages へも配信する。
+      # 先に gh-pages へ配信する（orphan ブランチへの force push なので main の
+      # 進行と競合しない＝後続の main コミットが失敗しても配信は成立する）。
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
@@ -78,3 +66,24 @@ jobs:
           publish_dir: .
           publish_branch: gh-pages
           exclude_assets: 'node_modules,.cache,scripts,.github'
+
+      # 生成物 api/ と README 統計を main にコミットする。
+      # クロール中に他の push で main が進むことがあるため、rebase してリトライする。
+      - name: Commit data
+        run: |
+          if git diff --quiet api/ README.md; then
+            echo "変更なし"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add api/ README.md
+          git commit -m "chore: update facilities data"
+          for i in 1 2 3; do
+            if git pull --rebase --autostash origin main && git push; then
+              echo "pushed"; exit 0
+            fi
+            echo "push retry $i..."; sleep 5
+          done
+          echo "::error::main への push に失敗（gh-pages への配信は完了しています）"
+          exit 1


### PR DESCRIPTION
クロール中に他のマージで main が進むと、データpushが非fast-forwardで失敗し、連鎖で gh-pages 配信までスキップされていた（実際に発生）。gh-pages配信を先に実行し、main へのコミットは rebase+リトライする。Refs #11