### PR TITLE
CI: crawl のNodeヒープ上限を引き上げ（全ソース＋i2fasでOOM）

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -52,6 +52,10 @@ jobs:
         continue-on-error: true
 
       - name: Crawl
+        # 全ソース＋i2fas で施設が100万件超になりメモリを要するため、
+        # Node のヒープ上限を引き上げる（GitHub Linux ランナーは 16GB RAM）。
+        env:
+          NODE_OPTIONS: --max-old-space-size=12288
         run: node scripts/crawl.js ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run) && '--dry-run' || '' }}
 
       - name: Validate


### PR DESCRIPTION
全ソース＋i2fasで施設100万件超となりCrawlがJSヒープOOM（既定約4GB）で失敗した。GitHub Linuxランナー(16GB RAM)で NODE_OPTIONS=--max-old-space-size=12288 を指定。Refs #11