### PR TITLE
クロール: ソースが0件のとき失敗させ、欠落データのコミットを防ぐ（取得は一過性エラーをリトライ）

### DIFF
--- a/scripts/crawl.js
+++ b/scripts/crawl.js
@@ -33,6 +33,8 @@ const OUT_DIR = path.join(ROOT, 'api', 'facilities');
 
 const DRY_RUN = process.argv.includes('--dry-run');
 const NO_GEOCODE = process.argv.includes('--no-geocode');
+// 施設0件のソースがあっても失敗させない（部分実行や意図的な空ソースの動作確認用）。
+const ALLOW_EMPTY_SOURCES = process.argv.includes('--allow-empty-sources');
 
 // --only=key1,key2 で処理対象ソースを絞る（動作確認・部分再生成用）
 const ONLY = (() => {
@@ -357,6 +359,37 @@ const DEFAULT_HEADERS = {
   Accept: '*/*',
 };
 
+// HTTP GET/POST をリトライ付きで実行し、本文を ArrayBuffer で返す。
+// 一過性の失敗（ネットワーク例外・5xx・429）は指数バックオフで再試行する。
+// 4xx（429 を除く）は恒久的な失敗として即座に投げる（再試行しても無駄なため）。
+// 週次クロールは 90+ の自治体サーバを叩くため、瞬断で1ソースが丸ごと欠落するのを防ぐ。
+async function fetchWithRetry(url, opts = {}, { retries = 3, baseDelayMs = 1000 } = {}) {
+  let lastErr;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    if (attempt > 0) {
+      const delay = baseDelayMs * 2 ** (attempt - 1);
+      console.log(`    リトライ ${attempt}/${retries}（${delay}ms 待機）: ${lastErr.message}`);
+      await sleep(delay);
+    }
+    try {
+      const res = await fetch(url, opts);
+      if (res.ok) return await res.arrayBuffer();
+      // 4xx（429 以外）は恒久的な失敗。再試行しても無駄なので即座に投げる。
+      if (res.status >= 400 && res.status < 500 && res.status !== 429) {
+        const err = new Error(`ダウンロード失敗: ${res.status} ${res.statusText}`);
+        err.permanent = true;
+        throw err;
+      }
+      // 5xx / 429 は一過性とみなし再試行対象にする
+      lastErr = new Error(`ダウンロード失敗: ${res.status} ${res.statusText}`);
+    } catch (e) {
+      if (e.permanent) throw e; // 恒久的な失敗は再試行しない
+      lastErr = e; // ネットワーク例外・タイムアウト等は再試行
+    }
+  }
+  throw lastErr;
+}
+
 // ZIP バイト列から対象の csv/xlsx/xls を取り出す。
 // entryPattern（正規表現文字列）に一致するエントリ、無ければ最初の csv/xlsx/xls。
 async function extractFromZip(zipBuf, entryPattern) {
@@ -426,11 +459,7 @@ async function acquire(source) {
     }
 
     console.log(`  ダウンロード中: ${downloadUrl}`);
-    const res = await fetch(downloadUrl, fetchOpts);
-    if (!res.ok) {
-      throw new Error(`ダウンロード失敗: ${res.status} ${res.statusText}`);
-    }
-    let buf = Buffer.from(await res.arrayBuffer());
+    let buf = Buffer.from(await fetchWithRetry(downloadUrl, fetchOpts));
 
     // format: 'zip' のとき、中の csv/xlsx/xls を取り出す。
     // （xlsx/xls も実体は ZIP なので、マジックバイトでなく明示指定で判定する。）
@@ -803,6 +832,12 @@ async function enrichWithGeocoding(facilities) {
   );
 }
 
+// 施設を1件も取り込めなかったソースを返す。
+// keptBySource に載っていない（＝処理前に落ちた）ソースも 0 件扱いにする。
+function findEmptySources(sources, keptBySource) {
+  return sources.filter((s) => (keptBySource.get(s.key) || 0) === 0);
+}
+
 // ---------------------------------------------------------------------------
 // メイン
 // ---------------------------------------------------------------------------
@@ -812,9 +847,11 @@ async function main() {
   console.log(`対象ソース: ${sources.length}件${ONLY ? `（--only=${[...ONLY].join(',')}）` : ''}\n`);
 
   const facilities = [];
+  const keptBySource = new Map(); // source.key -> 取り込めた施設数
 
   for (const source of sources) {
     console.log(`▼ ${source.key}: ${source.source}`);
+    let kept = 0;
     try {
       const files = await acquire(source);
       const rawRecords = [];
@@ -823,7 +860,6 @@ async function main() {
       }
       console.log(`  ${rawRecords.length}行を読み込み (${files.map((f) => f.format).join('+')})`);
 
-      let kept = 0;
       for (const raw of rawRecords) {
         const rec = mapRecord(raw);
         const facility = toFacility(rec);
@@ -842,9 +878,28 @@ async function main() {
     } catch (err) {
       console.error(`  ⚠ ${source.key} をスキップ: ${err.message}`);
     }
+    keptBySource.set(source.key, kept);
   }
 
   console.log(`\n有効な施設: 合計 ${facilities.length}件`);
+
+  // 施設を1件も取り込めなかったソースがあれば失敗させ、api/ を書き換えない。
+  // クロールはソースごとに try/catch で握り潰すため、取得失敗が黙って欠落データに
+  // 化けやすい（別ソースが同じ都道府県を埋めると気づけない）。ここで検知して
+  // 「壊れた（欠落した）データをコミットする」のを防ぐ。--allow-empty-sources で無効化。
+  const emptySources = findEmptySources(sources, keptBySource);
+  if (emptySources.length > 0) {
+    const list = emptySources.map((s) => `${s.key}（${s.source}）`).join('\n    - ');
+    const msg =
+      `施設を1件も取り込めなかったソースが ${emptySources.length}件 あります:\n    - ${list}\n` +
+      `  取得/パースの一時的な失敗の可能性があります。再実行するか、意図的な場合は ` +
+      `--allow-empty-sources を付けてください（欠落データのコミットを防ぐため中断しました）。`;
+    if (ALLOW_EMPTY_SOURCES) {
+      console.warn(`\n⚠ ${msg}`);
+    } else {
+      throw new Error(msg);
+    }
+  }
 
   // 緯度経度の無い施設を住所からジオコーディングして補完
   if (NO_GEOCODE) {
@@ -951,4 +1006,4 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 }
 
 // テスト用に純粋関数をエクスポートする。
-export { normalizeDate, sanitizeLatLng, resolvePrefecture, resolveCity, mapRecord, toFacility, parseCSVText, splitPrefCity };
+export { normalizeDate, sanitizeLatLng, resolvePrefecture, resolveCity, mapRecord, toFacility, parseCSVText, splitPrefCity, findEmptySources, fetchWithRetry };

--- a/scripts/crawl.test.js
+++ b/scripts/crawl.test.js
@@ -13,6 +13,8 @@ import {
   toFacility,
   parseCSVText,
   splitPrefCity,
+  findEmptySources,
+  fetchWithRetry,
 } from './crawl.js';
 
 let passed = 0;
@@ -20,6 +22,11 @@ function test(name, fn) {
   fn();
   passed++;
   console.log(`  ✓ ${name}`);
+}
+
+const asyncTests = [];
+function testAsync(name, fn) {
+  asyncTests.push({ name, fn });
 }
 
 // --- normalizeDate: 和暦・西暦の正規化 ---
@@ -141,4 +148,89 @@ test('splitPrefCity: 都道府県で始まらなければ null', () => {
   assert.deepEqual(splitPrefCity(''), [null, null]);
 });
 
-console.log(`\n✅ crawl.js ユニットテスト: ${passed}件すべて合格`);
+// --- findEmptySources: 施設0件のソース検知 ---
+test('findEmptySources: 0件・未処理のソースを返す', () => {
+  const sources = [{ key: 'a' }, { key: 'b' }, { key: 'c' }];
+  const kept = new Map([
+    ['a', 10],
+    ['b', 0],
+    // c は未処理（取得前に落ちた） → Map に無い
+  ]);
+  assert.deepEqual(findEmptySources(sources, kept), [{ key: 'b' }, { key: 'c' }]);
+});
+test('findEmptySources: 全ソースに施設があれば空配列', () => {
+  const sources = [{ key: 'a' }, { key: 'b' }];
+  const kept = new Map([['a', 1], ['b', 5]]);
+  assert.deepEqual(findEmptySources(sources, kept), []);
+});
+
+// --- fetchWithRetry: 一過性の失敗はリトライ、恒久的な失敗は即失敗 ---
+// テスト用に global fetch を差し替える。バックオフは baseDelayMs=1 で高速化。
+function withMockFetch(impl, run) {
+  const orig = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = async (...args) => {
+    calls++;
+    return impl(calls, ...args);
+  };
+  return Promise.resolve(run(() => calls)).finally(() => {
+    globalThis.fetch = orig;
+  });
+}
+const okRes = (body) => ({ ok: true, status: 200, statusText: 'OK', arrayBuffer: async () => Buffer.from(body) });
+const errRes = (status) => ({ ok: false, status, statusText: 'x', arrayBuffer: async () => Buffer.from('') });
+
+testAsync('fetchWithRetry: 5xx を経て成功', () =>
+  withMockFetch(
+    (n) => (n < 3 ? errRes(503) : okRes('good')),
+    async (calls) => {
+      const buf = await fetchWithRetry('u', {}, { retries: 3, baseDelayMs: 1 });
+      assert.equal(Buffer.from(buf).toString(), 'good');
+      assert.equal(calls(), 3);
+    },
+  ));
+
+testAsync('fetchWithRetry: ネットワーク例外を経て成功', () =>
+  withMockFetch(
+    (n) => {
+      if (n < 2) throw new Error('ECONNRESET');
+      return okRes('recovered');
+    },
+    async (calls) => {
+      const buf = await fetchWithRetry('u', {}, { retries: 3, baseDelayMs: 1 });
+      assert.equal(Buffer.from(buf).toString(), 'recovered');
+      assert.equal(calls(), 2);
+    },
+  ));
+
+testAsync('fetchWithRetry: 404 は再試行せず即失敗', () =>
+  withMockFetch(
+    () => errRes(404),
+    async (calls) => {
+      await assert.rejects(() => fetchWithRetry('u', {}, { retries: 3, baseDelayMs: 1 }), /404/);
+      assert.equal(calls(), 1); // 恒久的な失敗なのでリトライしない
+    },
+  ));
+
+testAsync('fetchWithRetry: リトライ上限を超えたら失敗', () =>
+  withMockFetch(
+    () => errRes(500),
+    async (calls) => {
+      await assert.rejects(() => fetchWithRetry('u', {}, { retries: 2, baseDelayMs: 1 }), /500/);
+      assert.equal(calls(), 3); // 初回 + リトライ2回
+    },
+  ));
+
+const runAsync = async () => {
+  for (const { name, fn } of asyncTests) {
+    await fn();
+    passed++;
+    console.log(`  ✓ ${name}`);
+  }
+  console.log(`\n✅ crawl.js ユニットテスト: ${passed}件すべて合格`);
+};
+
+runAsync().catch((err) => {
+  console.error('\n❌ テスト失敗:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## 背景・解決したい課題

奈良県のオープンデータ（`nara-pref` / xlsx）に含まれる「コザ　タコス」等のレコードが API に入っていない、という調査から発覚した構造的な問題への対処です。

- 原因は「奈良県 xlsx ソースが、最新クロール（2026-07-09）で**丸ごとスキップされていた**」こと。取得・パース・ジオコーディングは今テストすると全て正常に通るため、当時の一過性の取得失敗が疑われる。
- `crawl.js` はソースごとに `try/catch` で握り潰す設計のため、**1ソースの取得失敗が黙って欠落データに化ける**。しかも奈良県は i2fas（厚労省）が別途データを供給しているため県ページは埋まって見え、欠落に誰も気づけなかった。

## 変更内容

- **施設0件のソース検知（`findEmptySources`）**: クロール後、施設を1件も取り込めなかったソースがあれば、`api/` を書き換える前に中断（非ゼロ終了）。CI では以降の Deploy/Commit が走らず、**欠落したデータがコミットされない**。`--allow-empty-sources` で無効化可能。
- **取得の一過性エラーをリトライ（`fetchWithRetry`）**: ネットワーク例外・5xx・429 を指数バックオフで最大3回再試行。4xx（429除く）は恒久的失敗として即中断。今回の根本原因である「瞬断で1ソースが丸ごと落ちる」を自己回復させる。

## 採用したアプローチと意図

- 「前回の `meta.sources` と比較して消えたソースを検知する」案も検討したが、今回のように**新規追加ソースの初回クロールで失敗するケースを取りこぼす**ため不採用。「configで定義したソースが0件」を直接の検知条件にした。
- 検知（中断）だけだと 90+ の自治体サーバのどれか1つの瞬断で毎回ビルドが赤くなり形骸化する恐れがあるため、**リトライで一過性の失敗を自己回復**させ、中断が本当に恒久的な問題のときだけ発火するようにした。データの完全性 > 更新の鮮度、というトレードオフ判断。

## テスト

- ユニットテスト（`scripts/crawl.test.js`）を追加:
  - `findEmptySources`: 0件・未処理（取得前に落ちた）ソースを検知 / 全件ありなら空
  - `fetchWithRetry`: 5xx を経て成功 / ネットワーク例外を経て成功 / 404 は再試行せず即失敗 / リトライ上限超過で失敗（`global fetch` をモック、バックオフは短縮）
- 手動確認: `node scripts/crawl.js --only=nara-pref --dry-run` で検知が発火し**非ゼロ終了**、かつ `api/` が無傷であることを確認。

## 確認してほしいポイント

- 検知の発火条件を「ソース単位で施設0件」にした点。特に **i2fas はキャッシュ運用**のため、万一キャッシュミスすると 0件 → ビルド中断になり得ます。この挙動を許容するか（＝欠落を防ぐため中断が正しい、という判断でよいか）、それとも i2fas だけ緩めるか、レビューでご意見ください。`--allow-empty-sources` の逃げ道は用意済みです。
