### PR TITLE
クロール: 掲載ページ経由で最新ファイルを追従する 'resolve' 取得タイプを追加（奈良県を移行）

### DIFF
--- a/scripts/crawl.js
+++ b/scripts/crawl.js
@@ -390,6 +390,41 @@ async function fetchWithRetry(url, opts = {}, { retries = 3, baseDelayMs = 1000 
   throw lastErr;
 }
 
+// HTML から、リンク文言が pattern に一致する <a href> を1件解決する。
+//   pattern  リンクの表示テキストにマッチさせる正規表現文字列（省略時は文言で絞らない）
+//   format   拡張子でも絞り込む（'xlsx' 等。省略可）
+//   baseUrl  相対 href を絶対URL化する基準（掲載ページのURL）
+// 返り値: { url, text, count }（一致0件なら null。count は一致総数で、複数時は先頭を採用）
+function resolveLinkFromHtml(htmlText, { pattern, format, baseUrl } = {}) {
+  const textRe = pattern ? new RegExp(pattern, 'i') : null;
+  const extRe = format ? new RegExp(`\\.${format}(?:$|[?#])`, 'i') : null;
+  const anchorRe = /<a\b[^>]*\shref="([^"]+)"[^>]*>([\s\S]*?)<\/a>/gi;
+  const candidates = [];
+  let m;
+  while ((m = anchorRe.exec(htmlText))) {
+    const href = decodeHtmlEntities(m[1]);
+    const text = decodeHtmlEntities(m[2].replace(/<[^>]+>/g, '')).replace(/\s+/g, ' ').trim();
+    if (extRe && !extRe.test(href)) continue;
+    if (textRe && !textRe.test(text)) continue;
+    candidates.push({ href, text });
+  }
+  if (candidates.length === 0) return null;
+  const { href, text } = candidates[0];
+  const url = baseUrl ? new URL(href, baseUrl).toString() : href;
+  return { url, text, count: candidates.length };
+}
+
+// href/リンク文言中の基本的な HTML 実体参照を復元する（&amp; 等）。
+function decodeHtmlEntities(s) {
+  return String(s)
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, ' ');
+}
+
 // ZIP バイト列から対象の csv/xlsx/xls を取り出す。
 // entryPattern（正規表現文字列）に一致するエントリ、無ければ最初の csv/xlsx/xls。
 async function extractFromZip(zipBuf, entryPattern) {
@@ -444,6 +479,27 @@ async function acquire(source) {
       const info = await fetchCkanResourceInfo(a.ckanBase, a.resourceId);
       downloadUrl = info.url;
       if (!format) format = (info.format || '').toLowerCase();
+    }
+    // resolve: 掲載ページ(pageUrl)を取得し、リンク文言が linkPattern に一致する
+    // <a href> を実ダウンロードURLとして解決する。ファイル名に日時が入る等で
+    // 直リンクURLが更新のたびに変わる自治体（例: 奈良県）で最新版を追従するため。
+    if (a.type === 'resolve') {
+      console.log(`  リンク解決中: ${a.pageUrl}`);
+      const html = Buffer.from(
+        await fetchWithRetry(a.pageUrl, { headers: { ...DEFAULT_HEADERS } }),
+      ).toString('utf-8');
+      const hit = resolveLinkFromHtml(html, { pattern: a.linkPattern, format, baseUrl: a.pageUrl });
+      if (!hit) {
+        throw new Error(
+          `リンク解決に失敗: ${a.pageUrl} に「${a.linkPattern || '(指定なし)'}」に一致する` +
+            `${format ? ` .${format}` : ''} リンクが見つかりません`,
+        );
+      }
+      if (hit.count > 1) {
+        console.log(`  ⚠ ${hit.count}件一致。先頭を採用: 「${hit.text}」`);
+      }
+      console.log(`  リンク解決: 「${hit.text}」 -> ${hit.url}`);
+      downloadUrl = hit.url;
     }
     if (!format) {
       const m = String(downloadUrl).toLowerCase().match(/\.(csv|tsv|txt|xlsx|xls|zip)(?:$|\?)/);
@@ -1006,4 +1062,4 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 }
 
 // テスト用に純粋関数をエクスポートする。
-export { normalizeDate, sanitizeLatLng, resolvePrefecture, resolveCity, mapRecord, toFacility, parseCSVText, splitPrefCity, findEmptySources, fetchWithRetry };
+export { normalizeDate, sanitizeLatLng, resolvePrefecture, resolveCity, mapRecord, toFacility, parseCSVText, splitPrefCity, findEmptySources, fetchWithRetry, resolveLinkFromHtml };

--- a/scripts/crawl.test.js
+++ b/scripts/crawl.test.js
@@ -15,6 +15,7 @@ import {
   splitPrefCity,
   findEmptySources,
   fetchWithRetry,
+  resolveLinkFromHtml,
 } from './crawl.js';
 
 let passed = 0;
@@ -220,6 +221,45 @@ testAsync('fetchWithRetry: リトライ上限を超えたら失敗', () =>
       assert.equal(calls(), 3); // 初回 + リトライ2回
     },
   ));
+
+// --- resolveLinkFromHtml: 掲載ページからリンクを解決 ---
+// 奈良県の掲載ページを模した HTML（全件1本＋差分複数）。
+const NARA_HTML = `
+<ul>
+  <li><a href="/documents/4585/20260527103326.xlsx">食品営業許可施設一覧【令和8年3月末時点の全許可施設一覧】（エクセル：1,105KB）</a></li>
+  <li><a href="/documents/4585/20260130165931_1.xlsx">食品営業許可施設一覧【令和7年4月～5月の新規許可施設】（エクセル：35KB）</a></li>
+  <li><a href="/documents/4585/keisair0802-0803.xlsx">食品営業許可施設一覧【令和8年2月～3月の新規許可施設一覧】（エクセル：42KB）</a></li>
+  <li><a href="/n086/other.html">関連ページ</a></li>
+</ul>`;
+
+test('resolveLinkFromHtml: 文言一致リンクを相対→絶対URLで解決', () => {
+  const hit = resolveLinkFromHtml(NARA_HTML, {
+    pattern: '全許可施設',
+    format: 'xlsx',
+    baseUrl: 'https://www.pref.nara.lg.jp/n086/52413.html',
+  });
+  assert.equal(hit.url, 'https://www.pref.nara.lg.jp/documents/4585/20260527103326.xlsx');
+  assert.equal(hit.count, 1); // 差分（新規許可施設）とは区別され1件に絞れる
+  assert.match(hit.text, /全許可施設/);
+});
+test('resolveLinkFromHtml: format 拡張子で絞り込む', () => {
+  // pattern を緩めても .xlsx 以外（.html）は候補から除外される
+  const hit = resolveLinkFromHtml(NARA_HTML, { pattern: '関連', format: 'xlsx', baseUrl: 'https://x/' });
+  assert.equal(hit, null);
+});
+test('resolveLinkFromHtml: 複数一致は総数を返し先頭を採用', () => {
+  const hit = resolveLinkFromHtml(NARA_HTML, { pattern: '新規許可施設', format: 'xlsx', baseUrl: 'https://x/' });
+  assert.equal(hit.count, 2);
+  assert.equal(hit.url, 'https://x/documents/4585/20260130165931_1.xlsx');
+});
+test('resolveLinkFromHtml: 一致なしは null', () => {
+  assert.equal(resolveLinkFromHtml(NARA_HTML, { pattern: '存在しない', format: 'xlsx' }), null);
+});
+test('resolveLinkFromHtml: href の &amp; を復元', () => {
+  const html = '<a href="/dl?id=1&amp;t=x.csv">最新データ</a>';
+  const hit = resolveLinkFromHtml(html, { pattern: '最新', baseUrl: 'https://x/' });
+  assert.equal(hit.url, 'https://x/dl?id=1&t=x.csv');
+});
 
 const runAsync = async () => {
   for (const { name, fn } of asyncTests) {

--- a/scripts/sources.js
+++ b/scripts/sources.js
@@ -9,6 +9,9 @@
 //               { type: 'ckan', ckanBase, resourceId }  CKAN resource_show でURL解決
 //               { type: 'get',  url, format?, encoding? } URLを直接GET
 //               { type: 'post', url, body, format?, encoding? } フォームPOSTで取得（京都市等）
+//               { type: 'resolve', pageUrl, linkPattern, format } 掲載ページを取得し、
+//                 リンク文言が linkPattern に一致する <a href> を実URLとして解決してGET。
+//                 ファイル名に日時が入る等で直リンクURLが更新のたびに変わる自治体（奈良県等）向け。
 //               format:   'csv' | 'xlsx' | 'xls'（省略時はURL拡張子/CKAN情報から推定）
 //               encoding: CSVの文字コード 'utf-8' | 'shift_jis' | 'auto'（既定auto）
 //   source      出典表示名（attribution）
@@ -77,15 +80,19 @@ export const SOURCES = [
   },
 
   // -------------------------------------------------------------------------
-  // 奈良県 食品営業許可施設一覧（令和8年3月末時点の全許可施設・奈良市を除く）
+  // 奈良県 食品営業許可施設一覧（全許可施設・奈良市を除く）
   // XLSX。都道府県・市区町村カラムなし → 市区町村はジオコーディングで補完。
+  // ファイル名に日時が入り更新のたびに直リンクURLが変わるため、掲載ページから
+  // 「全許可施設」を含むリンクを解決して最新の全件データを取得する（差分ファイルは
+  // 「新規許可施設」という別リンクなので linkPattern で確実に区別できる）。
   // https://www.pref.nara.lg.jp/n086/52413.html
   // -------------------------------------------------------------------------
   {
     key: 'nara-pref',
     acquire: {
-      type: 'get',
-      url: 'https://www.pref.nara.lg.jp/documents/4585/20260527103326.xlsx',
+      type: 'resolve',
+      pageUrl: 'https://www.pref.nara.lg.jp/n086/52413.html',
+      linkPattern: '全許可施設',
       format: 'xlsx',
     },
     source: '奈良県食品営業許可施設一覧（奈良市を除く）',


### PR DESCRIPTION
## 背景・解決したい課題

奈良県のソース URL はファイル名に日時が埋まる方式（`documents/4585/20260527103326.xlsx`）で、**県がデータを更新するたびに URL が変わる**。現状はこの URL をハードコードしているため、更新後は「古い版を取り続ける」か「404 で丸ごと欠落」になる。

- 実際、直近の「コザ タコスが入っていない」問題（奈良県ソースの丸ごと欠落）と同じ穴を踏み続ける構造。
- 掲載ページ https://www.pref.nara.lg.jp/n086/52413.html には常に最新版が載り、**全件データはリンク文言に「全許可施設」が入る**（差分データは「新規許可施設」で明確に区別可能）。

## 変更内容

- **`acquire` に `type: 'resolve'` を新設**（`scripts/crawl.js`）: `pageUrl` を取得し、リンク文言が `linkPattern` に一致する `<a href>` を実ダウンロード URL として解決してから、従来の取得フローに乗せる。相対 href は掲載ページ URL を基準に絶対化。
- **純粋関数 `resolveLinkFromHtml` に切り出し**、テスト可能にした。
- **奈良県ソースを `resolve` に移行**（`scripts/sources.js`）: `linkPattern: '全許可施設'` で全件データのリンクを特定。ハードコード URL を廃止。

## 採用したアプローチと意図

- 安定した「最新版」直リンク URL は存在しない（`documents/4585/` は 403）。掲載ページ経由でしか最新を辿れないため、クロール時にページを見てリンクを解決する方式にした。
- 汎用の `type: 'resolve'` として実装したのは、同種の「直リンクだが更新で URL が変わる」自治体が他にもあり使い回せるため。奈良県専用ロジックにはしなかった。
- 全件と差分の区別はファイルサイズ等ではなく**リンク文言**で行う（表示名が安定した識別子のため）。

## テスト

- ユニットテスト（`scripts/crawl.test.js`）を追加:
  - 文言一致リンクを相対→絶対 URL で解決 / `format` 拡張子での絞り込み / 複数一致時は総数を返し先頭採用 / 一致なしは null / href の `&amp;` 復元
- 手動E2E確認: `node scripts/crawl.js --only=nara-pref --no-geocode` を実行し、掲載ページから正しい全件 xlsx（`20260527103326.xlsx`）を解決 → 13,010 件をパース、**「コザ　タコス」が出力に含まれる**ことを確認（実行後 `api/` は復元済み）。

## 確認してほしいポイント

- 複数リンクが `linkPattern` に一致した場合、警告ログを出しつつ**先頭を採用**する挙動でよいか（現状の奈良県は1件に絞れている）。厳密に1件でなければ失敗させる案もあり得ます。

## 補足

- 「ソースが0件なら失敗させる」再発防止（別テーマ）は #23 で対応中。本 PR はそのURL追従側の対処で、独立してマージ可能です。
