### PR TITLE
COVERAGE.md: ライセンス『要確認』の解消と「157 vs 1,740」の説明明確化

### DIFF
--- a/docs/COVERAGE.md
+++ b/docs/COVERAGE.md
@@ -1,6 +1,8 @@
 # 食品営業許可オープンデータ カバレッジ（全市区町村）
 
-**母数 = 全国の市区町村**（政令指定都市は市単位に集約。東京特別区・行政区を含む）。各行に、その区域の食品営業許可を所管する**保健所設置主体**と、当サービスでのデータ収集状況を示す。
+**本表の各行 = 全国の全市区町村（1,740 件が母数）**（政令指定都市は市単位に集約。東京特別区・行政区を含む）。各行に、その区域の食品営業許可を所管する**保健所設置主体**と、当サービスでのデータ収集状況を示す。
+
+> **数字の読み方（重要）**: 本表の行数（母数）は **全国 1,740 市区町村**。後述の「157」は食品営業許可を*発行する権限*を持つ**保健所設置主体の数**であって、市区町村の数ではない。1,740 の各市区町村を、いずれか 157 主体のうち 1 つが所管している、という関係。
 
 ## 前提となる仕組み
 - 食品営業許可を**発行する権限**は「保健所設置主体」（都道府県／政令指定都市／中核市／その他政令市＝小樽・町田・藤沢・茅ヶ崎・四日市／特別区23）にある。**一般の市町村は許可を発行しない**（区域内の施設は都道府県の保健所が所管）。
@@ -8,7 +10,7 @@
 - したがって各市区町村の「データ有無」は次の優先で判定: ①**自治体自身が公開**していれば✅（`収集経路=自身`） → ②なければ**管轄保健所設置主体**が公開していれば✅（`収集経路=管轄主体`。県所管域データ等に含まれる） → ③厚労省**食品衛生申請等システム(i2fas)** に当該市区町村の施設が含まれれば✅（`収集経路=i2fas`。全国の保健所設置主体別オープンデータ・掲載賛同施設のみ） → ④いずれも無ければ❌。
 - **❌の意味**: その市区町村を所管する主体のデータが未収集。`管轄`列を見れば「自前保健所を持つ市自身が未収集」なのか「都道府県所管で、その県データが未収集」なのかが分かる。
 
-母数（保健所設置主体）の根拠: 厚生労働省「設置主体別保健所数」（令和8年4月1日現在） https://www.mhlw.go.jp/content/10900000/001232824.pdf （都道府県47・指定都市20・中核市62・その他政令市5・特別区23＝計157主体）。市区町村一覧の出典: geolonia/japanese-addresses。i2fasライセンス: 公共データ利用規約(第1.0版/PDL1.0)＝CC BY 4.0互換。
+**保健所設置主体の数（157）の根拠**: 厚生労働省「設置主体別保健所数」（令和8年4月1日現在） https://www.mhlw.go.jp/content/10900000/001232824.pdf （都道府県47・指定都市20・中核市62・その他政令市5・特別区23＝**計157主体**）。この 157 は許可を所管・発行する主体の数（＝データの収集単位）であり、**本表の行数（全国 1,740 市区町村）とは別のもの**。市区町村一覧の出典: geolonia/japanese-addresses。i2fasライセンス: 公共データ利用規約(第1.0版/PDL1.0)＝CC BY 4.0互換。
 
 **データがある市区町村: 1727 / 1740（99%）**
 
@@ -363,7 +365,7 @@
 | 山形県 | 飽海郡遊佐町 | 山形県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 福島県 | 福島市 | 福島市（中核市） | ✅ | 自身 | [link](https://www.city.fukushima.fukushima.jp/material/files/group/7/R7nendo_syokuhin.csv) | CC BY 2.1 JP |
 | 福島県 | 会津若松市 | 福島県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.fukushima.lg.jp/uploaded/attachment/743308.xlsx) | CC BY 2.1 JP |
-| 福島県 | 郡山市 | 福島県（都道府県） | ✅ | 自身 | [link](https://www.city.koriyama.lg.jp/uploaded/attachment/120902.xls) | 要確認 |
+| 福島県 | 郡山市 | 福島県（都道府県） | ✅ | 自身 | [link](https://www.city.koriyama.lg.jp/uploaded/attachment/120902.xls) | CC BY 4.0 |
 | 福島県 | いわき市 | いわき市（中核市） | ✅ | 自身 | [link](https://www.city.iwaki.lg.jp/www/contents/1652661537484/simple/Shokuhin_itiran_R08.csv) | CC BY 4.0 |
 | 福島県 | 白河市 | 福島県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.fukushima.lg.jp/uploaded/attachment/743308.xlsx) | CC BY 2.1 JP |
 | 福島県 | 須賀川市 | 福島県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.fukushima.lg.jp/uploaded/attachment/743308.xlsx) | CC BY 2.1 JP |
@@ -490,7 +492,7 @@
 | 栃木県 | 那須郡那須町 | 栃木県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 栃木県 | 那須郡那珂川町 | 栃木県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 群馬県 | 前橋市 | 前橋市（中核市） | ✅ | 自身 | [link](https://data.bodik.jp/dataset/be0e8464-4b96-41f6-901d-1aa4bf11bcc0) | Creative Commons Attribution 4.0 International |
-| 群馬県 | 高崎市 | 高崎市（中核市） | ✅ | 自身 | [link](https://www.city.takasaki.gunma.jp/uploaded/attachment/40475.xlsx) | 要確認 |
+| 群馬県 | 高崎市 | 高崎市（中核市） | ✅ | 自身 | [link](https://www.city.takasaki.gunma.jp/uploaded/attachment/40475.xlsx) | CC BY 4.0 |
 | 群馬県 | 桐生市 | 群馬県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 群馬県 | 伊勢崎市 | 群馬県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 群馬県 | 太田市 | 群馬県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
@@ -527,7 +529,7 @@
 | 埼玉県 | さいたま市 | さいたま市（指定都市） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 埼玉県 | 川越市 | 川越市（中核市） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 埼玉県 | 熊谷市 | 埼玉県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
-| 埼玉県 | 川口市 | 川口市（中核市） | ✅ | 自身 | [link](https://www.city.kawaguchi.lg.jp/material/files/group/232/R0803zenshisetsuichiran.xls) | 要確認 |
+| 埼玉県 | 川口市 | 川口市（中核市） | ✅ | 自身 | [link](https://www.city.kawaguchi.lg.jp/material/files/group/232/R0803zenshisetsuichiran.xls) | CC BY 2.1 日本 |
 | 埼玉県 | 行田市 | 埼玉県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 埼玉県 | 秩父市 | 埼玉県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 埼玉県 | 所沢市 | 埼玉県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
@@ -587,7 +589,7 @@
 | 埼玉県 | 南埼玉郡宮代町 | 埼玉県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 埼玉県 | 北葛飾郡杉戸町 | 埼玉県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 埼玉県 | 北葛飾郡松伏町 | 埼玉県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
-| 千葉県 | 千葉市 | 千葉市（指定都市） | ✅ | 自身 | [link](https://www.city.chiba.jp/somu/somu/seisakuhomu/shisei/documents/202605syokuhin.xlsx) | 要確認 |
+| 千葉県 | 千葉市 | 千葉市（指定都市） | ✅ | 自身 | [link](https://www.city.chiba.jp/somu/somu/seisakuhomu/shisei/documents/202605syokuhin.xlsx) | CC BY 2.1 日本 |
 | 千葉県 | 銚子市 | 千葉県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 千葉県 | 市川市 | 千葉県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 千葉県 | 船橋市 | 船橋市（中核市） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
@@ -659,7 +661,7 @@
 | 東京都 | 豊島区 | 豊島区（特別区） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 東京都 | 北区 | 北区（特別区） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 東京都 | 荒川区 | 荒川区（特別区） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
-| 東京都 | 板橋区 | 板橋区（特別区） | ✅ | 自身 | [link](https://www.city.itabashi.tokyo.jp/_res/projects/default_project/_page_/001/051/220/r8.5_shokuhinkyokashisetsu.xlsx) | 要確認 |
+| 東京都 | 板橋区 | 板橋区（特別区） | ✅ | 自身 | [link](https://www.city.itabashi.tokyo.jp/_res/projects/default_project/_page_/001/051/220/r8.5_shokuhinkyokashisetsu.xlsx) | CC BY 4.0 |
 | 東京都 | 練馬区 | 練馬区（特別区） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 東京都 | 足立区 | 足立区（特別区） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 東京都 | 葛飾区 | 葛飾区（特別区） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
@@ -708,9 +710,9 @@
 | 神奈川県 | 横須賀市 | 横須賀市（中核市） | ✅ | 自身 | [link](https://data.bodik.jp/dataset/3a1aaf46-e6ca-41fa-8977-3388f3b7e3ba) | Creative Commons Attribution 4.0 International |
 | 神奈川県 | 平塚市 | 神奈川県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 神奈川県 | 鎌倉市 | 神奈川県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
-| 神奈川県 | 藤沢市 | 藤沢市（その他政令市） | ✅ | 自身 | [link](https://www.city.fujisawa.kanagawa.jp/documents/28905/zende-ta2020603houjin.csv) | 要確認 |
+| 神奈川県 | 藤沢市 | 藤沢市（その他政令市） | ✅ | 自身 | [link](https://www.city.fujisawa.kanagawa.jp/documents/28905/zende-ta2020603houjin.csv) | CC BY 4.0 |
 | 神奈川県 | 小田原市 | 神奈川県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
-| 神奈川県 | 茅ヶ崎市 | 茅ヶ崎市（その他政令市） | ✅ | 自身 | [link](https://www.city.chigasaki.kanagawa.jp/_res/projects/default_project/_page_/001/041/779/syokuhinall2025.csv) | 要確認 |
+| 神奈川県 | 茅ヶ崎市 | 茅ヶ崎市（その他政令市） | ✅ | 自身 | [link](https://www.city.chigasaki.kanagawa.jp/_res/projects/default_project/_page_/001/041/779/syokuhinall2025.csv) | CC BY 4.0 |
 | 神奈川県 | 逗子市 | 神奈川県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 神奈川県 | 三浦市 | 神奈川県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 神奈川県 | 秦野市 | 神奈川県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
@@ -799,7 +801,7 @@
 | 石川県 | 鹿島郡中能登町 | 石川県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.ishikawa.lg.jp/yakuji/syokuhin/documents/nendor7.xlsx) | 石川県利用規約 |
 | 石川県 | 鳳珠郡穴水町 | 石川県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.ishikawa.lg.jp/yakuji/syokuhin/documents/nendor7.xlsx) | 石川県利用規約 |
 | 石川県 | 鳳珠郡能登町 | 石川県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.ishikawa.lg.jp/yakuji/syokuhin/documents/nendor7.xlsx) | 石川県利用規約 |
-| 福井県 | 福井市 | 福井市（中核市） | ✅ | 自身 | [link](https://www.city.fukui.lg.jp/fukusi/eisei/syokuhin/p070519_d/fil/11syokuhin_202605.xlsx) | 要確認 |
+| 福井県 | 福井市 | 福井市（中核市） | ✅ | 自身 | [link](https://www.city.fukui.lg.jp/fukusi/eisei/syokuhin/p070519_d/fil/11syokuhin_202605.xlsx) | CC BY 2.1 日本 |
 | 福井県 | 敦賀市 | 福井県（都道府県） | ✅ | 管轄主体 | [link](https://data.odp.jig.jp/viewcsv/jp/fukui/776.csv) | CC BY |
 | 福井県 | 小浜市 | 福井県（都道府県） | ✅ | 管轄主体 | [link](https://data.odp.jig.jp/viewcsv/jp/fukui/776.csv) | CC BY |
 | 福井県 | 大野市 | 福井県（都道府県） | ✅ | 管轄主体 | [link](https://data.odp.jig.jp/viewcsv/jp/fukui/776.csv) | CC BY |
@@ -845,81 +847,81 @@
 | 山梨県 | 北都留郡丹波山村 | 山梨県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.yamanashi.jp/documents/23776/190004_food_business_all.csv) | CC BY 2.1 JP |
 | 長野県 | 長野市 | 長野市（中核市） | ✅ | 自身 | [link](https://www.city.nagano.nagano.jp/documents/1948/202011_food_business_202605.csv) | CC BY 4.0 |
 | 長野県 | 松本市 | 松本市（中核市） | ✅ | 自身 | [link](http://linkdata.org/download/rdf1s8748i/link/shokuhin_kyoka_eigyo_matsumoto.txt) | CC BY 3.0 |
-| 長野県 | 上田市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 岡谷市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 飯田市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 諏訪市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 須坂市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 小諸市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 伊那市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 駒ヶ根市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 中野市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 大町市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 飯山市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 茅野市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 塩尻市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 佐久市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 千曲市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 東御市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 安曇野市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 南佐久郡小海町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 南佐久郡川上村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 南佐久郡南牧村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 南佐久郡南相木村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 南佐久郡北相木村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 南佐久郡佐久穂町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 北佐久郡軽井沢町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 北佐久郡御代田町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 北佐久郡立科町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 小県郡青木村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 小県郡長和町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 諏訪郡下諏訪町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 諏訪郡富士見町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 諏訪郡原村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 上伊那郡辰野町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 上伊那郡箕輪町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 上伊那郡飯島町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 上伊那郡南箕輪村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 上伊那郡中川村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 上伊那郡宮田村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 下伊那郡松川町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 下伊那郡高森町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 下伊那郡阿南町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 下伊那郡阿智村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 下伊那郡平谷村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 下伊那郡根羽村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 下伊那郡下條村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 下伊那郡売木村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 下伊那郡天龍村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 下伊那郡泰阜村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 下伊那郡喬木村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 下伊那郡豊丘村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 下伊那郡大鹿村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 木曽郡上松町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 木曽郡南木曽町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 木曽郡木祖村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 木曽郡王滝村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 木曽郡大桑村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 木曽郡木曽町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 東筑摩郡麻績村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 東筑摩郡生坂村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 東筑摩郡山形村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 東筑摩郡朝日村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 東筑摩郡筑北村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 北安曇郡池田町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 北安曇郡松川村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 北安曇郡白馬村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 北安曇郡小谷村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 埴科郡坂城町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 上高井郡小布施町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 上高井郡高山村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 下高井郡山ノ内町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 下高井郡木島平村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 下高井郡野沢温泉村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 上水内郡信濃町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 上水内郡小川村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 上水内郡飯綱町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
-| 長野県 | 下水内郡栄村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | 要確認 |
+| 長野県 | 上田市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 岡谷市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 飯田市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 諏訪市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 須坂市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 小諸市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 伊那市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 駒ヶ根市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 中野市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 大町市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 飯山市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 茅野市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 塩尻市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 佐久市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 千曲市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 東御市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 安曇野市 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 南佐久郡小海町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 南佐久郡川上村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 南佐久郡南牧村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 南佐久郡南相木村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 南佐久郡北相木村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 南佐久郡佐久穂町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 北佐久郡軽井沢町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 北佐久郡御代田町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 北佐久郡立科町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 小県郡青木村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 小県郡長和町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 諏訪郡下諏訪町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 諏訪郡富士見町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 諏訪郡原村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 上伊那郡辰野町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 上伊那郡箕輪町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 上伊那郡飯島町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 上伊那郡南箕輪村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 上伊那郡中川村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 上伊那郡宮田村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 下伊那郡松川町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 下伊那郡高森町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 下伊那郡阿南町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 下伊那郡阿智村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 下伊那郡平谷村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 下伊那郡根羽村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 下伊那郡下條村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 下伊那郡売木村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 下伊那郡天龍村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 下伊那郡泰阜村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 下伊那郡喬木村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 下伊那郡豊丘村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 下伊那郡大鹿村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 木曽郡上松町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 木曽郡南木曽町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 木曽郡木祖村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 木曽郡王滝村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 木曽郡大桑村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 木曽郡木曽町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 東筑摩郡麻績村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 東筑摩郡生坂村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 東筑摩郡山形村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 東筑摩郡朝日村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 東筑摩郡筑北村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 北安曇郡池田町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 北安曇郡松川村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 北安曇郡白馬村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 北安曇郡小谷村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 埴科郡坂城町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 上高井郡小布施町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 上高井郡高山村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 下高井郡山ノ内町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 下高井郡木島平村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 下高井郡野沢温泉村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 上水内郡信濃町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 上水内郡小川村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 上水内郡飯綱町 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
+| 長野県 | 下水内郡栄村 | 長野県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv) | CC BY 4.0 |
 | 岐阜県 | 岐阜市 | 岐阜市（中核市） | ✅ | 自身 | [link](https://gifu-opendata.pref.gifu.lg.jp/dataset/2f9f1b1c-be25-4a27-96c6-47b597f1a0bd/resource/16ef7794-d2b6-4d7d-8353-f55193432530/download/gifushisyokuhinkyokar7.6.1.csv) | CC BY 2.0 |
 | 岐阜県 | 大垣市 | 岐阜県（都道府県） | ✅ | 管轄主体 | [link](https://gifu-opendata.pref.gifu.lg.jp/dataset/f6bbdb66-1d55-4e55-82cb-15fe1bb24223/resource/3c7d862d-a126-4441-a5b1-4839096b2591/download/20250331syokuhin.csv) | CC BY 2.0 |
 | 岐阜県 | 高山市 | 岐阜県（都道府県） | ✅ | 管轄主体 | [link](https://gifu-opendata.pref.gifu.lg.jp/dataset/f6bbdb66-1d55-4e55-82cb-15fe1bb24223/resource/3c7d862d-a126-4441-a5b1-4839096b2591/download/20250331syokuhin.csv) | CC BY 2.0 |
@@ -998,59 +1000,59 @@
 | 静岡県 | 榛原郡川根本町 | 静岡県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 静岡県 | 周智郡森町 | 静岡県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 愛知県 | 名古屋市 | 名古屋市（指定都市） | ✅ | 自身 | [link](https://data.bodik.jp/dataset/979f325a-1b27-45d0-8eb5-dd4aeb85b1f5) | Creative Commons Attribution 4.0 International |
-| 愛知県 | 豊橋市 | 豊橋市（中核市） | ✅ | 自身 | [link](https://www.city.toyohashi.lg.jp/secure/18290/shokuhinshinki202605EXCEL.xlsx) | 要確認 |
+| 愛知県 | 豊橋市 | 豊橋市（中核市） | ✅ | 自身 | [link](https://www.city.toyohashi.lg.jp/secure/18290/shokuhinshinki202605EXCEL.xlsx) | CC BY 4.0 |
 | 愛知県 | 岡崎市 | 岡崎市（中核市） | ✅ | 自身 | [link](https://data.bodik.jp/dataset/aabced9d-d86e-422d-8ad0-2781d0f30671) | Creative Commons Attribution 4.0 International |
 | 愛知県 | 一宮市 | 一宮市（中核市） | ✅ | 自身 | [link](https://www.city.ichinomiya.aichi.jp/_res/projects/default_project/_page_/001/040/636/232033_Food_Business_All_20260331.csv) | CC BY 4.0 |
-| 愛知県 | 瀬戸市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 半田市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 春日井市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 豊川市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 津島市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 碧南市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 刈谷市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
+| 愛知県 | 瀬戸市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 半田市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 春日井市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 豊川市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 津島市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 碧南市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 刈谷市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
 | 愛知県 | 豊田市 | 豊田市（中核市） | ✅ | 自身 | [link](https://data.bodik.jp/dataset/385d18b1-7493-4a82-8b0d-b00d2996da69) | Creative Commons Attribution 4.0 International |
-| 愛知県 | 安城市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 西尾市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 蒲郡市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 犬山市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 常滑市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 江南市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 小牧市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 稲沢市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 新城市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 東海市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 大府市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 知多市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 知立市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 尾張旭市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 高浜市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 岩倉市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 豊明市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 日進市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 田原市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 愛西市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 清須市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 北名古屋市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 弥富市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | みよし市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | あま市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 長久手市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 愛知郡東郷町 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 西春日井郡豊山町 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 丹羽郡大口町 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 丹羽郡扶桑町 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 海部郡大治町 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 海部郡蟹江町 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 海部郡飛島村 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 知多郡阿久比町 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 知多郡東浦町 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 知多郡南知多町 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 知多郡美浜町 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 知多郡武豊町 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 額田郡幸田町 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 北設楽郡設楽町 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 北設楽郡東栄町 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
-| 愛知県 | 北設楽郡豊根村 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | 要確認 |
+| 愛知県 | 安城市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 西尾市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 蒲郡市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 犬山市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 常滑市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 江南市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 小牧市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 稲沢市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 新城市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 東海市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 大府市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 知多市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 知立市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 尾張旭市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 高浜市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 岩倉市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 豊明市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 日進市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 田原市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 愛西市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 清須市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 北名古屋市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 弥富市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | みよし市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | あま市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 長久手市 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 愛知郡東郷町 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 西春日井郡豊山町 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 丹羽郡大口町 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 丹羽郡扶桑町 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 海部郡大治町 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 海部郡蟹江町 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 海部郡飛島村 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 知多郡阿久比町 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 知多郡東浦町 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 知多郡南知多町 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 知多郡美浜町 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 知多郡武豊町 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 額田郡幸田町 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 北設楽郡設楽町 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 北設楽郡東栄町 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
+| 愛知県 | 北設楽郡豊根村 | 愛知県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.aichi.jp/uploaded/attachment/619853.csv) | CC BY 2.1 日本 |
 | 三重県 | 津市 | 三重県（都道府県） | ✅ | 管轄主体 | [link](https://data.bodik.jp/dataset/796b84b4-c197-44bd-b852-664a8a423676) | Creative Commons Attribution 4.0 International |
 | 三重県 | 四日市市 | 四日市市（その他政令市） | ✅ | 自身 | [link](https://data.bodik.jp/dataset/e5809d89-173d-40ea-9ee7-5bc4a61678a6) | Creative Commons Attribution 4.0 International |
 | 三重県 | 伊勢市 | 三重県（都道府県） | ✅ | 管轄主体 | [link](https://data.bodik.jp/dataset/796b84b4-c197-44bd-b852-664a8a423676) | Creative Commons Attribution 4.0 International |
@@ -1080,7 +1082,7 @@
 | 三重県 | 北牟婁郡紀北町 | 三重県（都道府県） | ✅ | 管轄主体 | [link](https://data.bodik.jp/dataset/796b84b4-c197-44bd-b852-664a8a423676) | Creative Commons Attribution 4.0 International |
 | 三重県 | 南牟婁郡御浜町 | 三重県（都道府県） | ✅ | 管轄主体 | [link](https://data.bodik.jp/dataset/796b84b4-c197-44bd-b852-664a8a423676) | Creative Commons Attribution 4.0 International |
 | 三重県 | 南牟婁郡紀宝町 | 三重県（都道府県） | ✅ | 管轄主体 | [link](https://data.bodik.jp/dataset/796b84b4-c197-44bd-b852-664a8a423676) | Creative Commons Attribution 4.0 International |
-| 滋賀県 | 大津市 | 大津市（中核市） | ✅ | 自身 | [link](https://www.city.otsu.lg.jp/material/files/group/4/od_2605.csv) | 要確認 |
+| 滋賀県 | 大津市 | 大津市（中核市） | ✅ | 自身 | [link](https://www.city.otsu.lg.jp/material/files/group/4/od_2605.csv) | CC BY 4.0 |
 | 滋賀県 | 彦根市 | 滋賀県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.shiga.lg.jp/file/attachment/5615791.csv) | 滋賀県OD利用規約 |
 | 滋賀県 | 長浜市 | 滋賀県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.shiga.lg.jp/file/attachment/5615791.csv) | 滋賀県OD利用規約 |
 | 滋賀県 | 近江八幡市 | 滋賀県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.shiga.lg.jp/file/attachment/5615791.csv) | 滋賀県OD利用規約 |
@@ -1173,42 +1175,42 @@
 | 兵庫県 | 尼崎市 | 尼崎市（中核市） | ✅ | 自身 | [link](https://www.city.amagasaki.hyogo.jp/_res/projects/default_project/_page_/001/001/025/kyoka202605.csv) | CC BY 4.0 |
 | 兵庫県 | 明石市 | 明石市（中核市） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 兵庫県 | 西宮市 | 西宮市（中核市） | ✅ | 自身 | [link](http://opendata.nishi.or.jp/opendata/files/9/R8.5ichiran_syokuhin.xlsx) | CC BY相当 |
-| 兵庫県 | 洲本市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 芦屋市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 伊丹市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 相生市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 豊岡市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 加古川市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 赤穂市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 西脇市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 宝塚市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 三木市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 高砂市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 川西市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 小野市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 三田市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 加西市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 丹波篠山市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 養父市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 丹波市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 南あわじ市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 朝来市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 淡路市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 宍粟市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 加東市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | たつの市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 川辺郡猪名川町 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 多可郡多可町 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 加古郡稲美町 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 加古郡播磨町 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 神崎郡市川町 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 神崎郡福崎町 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 神崎郡神河町 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 揖保郡太子町 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 赤穂郡上郡町 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 佐用郡佐用町 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 美方郡香美町 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
-| 兵庫県 | 美方郡新温泉町 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | 要確認 |
+| 兵庫県 | 洲本市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 芦屋市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 伊丹市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 相生市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 豊岡市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 加古川市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 赤穂市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 西脇市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 宝塚市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 三木市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 高砂市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 川西市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 小野市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 三田市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 加西市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 丹波篠山市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 養父市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 丹波市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 南あわじ市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 朝来市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 淡路市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 宍粟市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 加東市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | たつの市 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 川辺郡猪名川町 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 多可郡多可町 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 加古郡稲美町 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 加古郡播磨町 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 神崎郡市川町 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 神崎郡福崎町 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 神崎郡神河町 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 揖保郡太子町 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 赤穂郡上郡町 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 佐用郡佐用町 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 美方郡香美町 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
+| 兵庫県 | 美方郡新温泉町 | 兵庫県（都道府県） | ✅ | 管轄主体 | [link](https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx) | CC BY 4.0 |
 | 奈良県 | 奈良市 | 奈良市（中核市） | ✅ | 自身 | [link](https://www.city.nara.lg.jp/uploaded/attachment/203480.csv) | CC BY 2.1 JP |
 | 奈良県 | 大和高田市 | 奈良県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nara.lg.jp/documents/4585/20260527103326.xlsx) | 奈良県（出典明示・利用規約に従う） |
 | 奈良県 | 大和郡山市 | 奈良県（都道府県） | ✅ | 管轄主体 | [link](https://www.pref.nara.lg.jp/documents/4585/20260527103326.xlsx) | 奈良県（出典明示・利用規約に従う） |
@@ -1297,7 +1299,7 @@
 | 鳥取県 | 日野郡日南町 | 鳥取県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 鳥取県 | 日野郡日野町 | 鳥取県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 鳥取県 | 日野郡江府町 | 鳥取県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
-| 島根県 | 松江市 | 松江市（中核市） | ✅ | 自身 | [link](https://www.city.matsue.lg.jp/material/files/group/50/202605_eigyoukyoka_zenken.xlsx) | 要確認 |
+| 島根県 | 松江市 | 松江市（中核市） | ✅ | 自身 | [link](https://www.city.matsue.lg.jp/material/files/group/50/202605_eigyoukyoka_zenken.xlsx) | CC BY 2.1 日本 |
 | 島根県 | 浜田市 | 島根県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 島根県 | 出雲市 | 島根県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 島根県 | 益田市 | 島根県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |


### PR DESCRIPTION
## 背景・解決したい課題
- `docs/COVERAGE.md` でライセンスが「要確認」のまま残っていた自治体が **171行** あり、再配布・API化の際の出典明示判断ができなかった
- 「前提となる仕組み」の説明で **157** という数字が「母数（保健所設置主体）」と書かれ、表の行数（全国市区町村）と混同を招いていた（"自治体が157件？"という誤読）

## 変更内容（コミット内で2点）
**(A) ライセンス『要確認』171行を解消**
- 実調査単位は14ソース。各オープンデータの**利用規約を一次確認**して確定（推測・捏造なし）
- 内訳: **CC BY 4.0 = 118行 / CC BY 2.1 日本 = 53行**

| ソース | 確定ライセンス | 根拠 |
|--------|--------------|------|
| 長野県(75行) | CC BY 4.0 | 県オープンデータ利用規約PDF |
| 愛知県(49行) | CC BY 2.1 日本 | 県オープンデータカタログ規約 |
| 兵庫県(36行) | CC BY 4.0 | 県オープンデータ利用規約PDF |
| 郡山市 | CC BY 4.0 | 市オープンデータ利用規約 |
| 高崎市 | CC BY 4.0 | 市オープンデータサイト |
| 川口市 | CC BY 2.1 日本 | 市オープンデータ一覧(licenses/by/2.1/jp) |
| 千葉市 | CC BY 2.1 日本 | 市オープンデータカタログ |
| 板橋区 | CC BY 4.0 | 区オープンデータ利用規約 |
| 藤沢市 | CC BY 4.0 | 市オープンデータ利用規約PDF(licenses/by/4.0) |
| 茅ヶ崎市 | CC BY 4.0 | 市オープンデータライブラリ |
| 福井市 | CC BY 2.1 日本 | 市オープンデータパーク |
| 豊橋市 | CC BY 4.0 | 市オープンデータ利用規約 |
| 大津市 | CC BY 4.0 | 市オープンデータ利用規約 |
| 松江市 | CC BY 2.1 日本 | 市報松江ほかオープンデータ |

**(B) 「157 vs 1,740」の説明を明確化**
- 「157」は食品営業許可を**発行する権限を持つ保健所設置主体の数**（都道府県47+指定都市20+中核市62+その他政令市5+特別区23）であって、市区町村の数ではない旨を明記
- 表の母数は **全国 1,740 市区町村**（実テーブル行数と一致）。冒頭に「数字の読み方」注記を追加し、`1,741`→`1,740` で数値を実データに統一

## 採用したアプローチと意図
- ライセンスは法的に効く情報のため、各自治体の一次規約を実確認し、確定したものだけ反映（不明なら「要確認」を残す方針だったが、14ソース全て確定できた）

## 確認してほしいポイント
- 川口市・千葉市・福井市・愛知県・松江市が CC BY **2.1 日本**（他は4.0）である点。各規約の明示に従っており、バージョン差はそのまま記載