### PR TITLE
全国データ結合CSVの配信を追加（市区町村名の名寄せ付き）

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -58,6 +58,16 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=12288
         run: node scripts/crawl.js ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run) && '--dry-run' || '' }}
 
+      # 全市区町村を結合した1本の配布用CSV（api/facilities-all.csv[.gz]）を生成する。
+      # 市区町村名は normalize-japanese-addresses で名寄せ済み。gh-pages でそのまま配信される。
+      - name: Build merged CSV
+        env:
+          NODE_OPTIONS: --max-old-space-size=12288
+        run: |
+          node scripts/build-city-normmap.js
+          node scripts/build-merged-csv.js
+          gzip -kf api/facilities-all.csv
+
       - name: Validate
         run: npm test
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,24 @@
 > | `search-index.json` | 約 61.1 MB |
 <!-- STATS:END -->
 
+### 全データ結合CSV（ダウンロード）
+
+都道府県別・市区町村別に分かれた JSON を、**全国 1 本にまとめた CSV** も配信しています。
+Excel / pandas / BI ツール等で扱いたい場合はこちらが便利です。
+
+| ファイル | 配布URL |
+|---|---|
+| 結合CSV（gzip 圧縮・約60MB） | https://gl20percentclub.github.io/japan-facilities-address/api/facilities-all.csv.gz |
+| 結合CSV（非圧縮・約540MB） | https://gl20percentclub.github.io/japan-facilities-address/api/facilities-all.csv |
+
+- **文字コード**: UTF-8（BOM 付き。Excel でそのまま開けます）
+- **列**: `prefecture, city, city_raw, name, name_kana, business_type, address, lat, lng, geocoding_level, phone, license_no, license_date, expire_date, sources, licenses`
+  - `city` は [normalize-japanese-addresses](https://github.com/geolonia/normalize-japanese-addresses) で名寄せした公式市区町村名、`city_raw` は元データの生表記（郡名の有無などの揺れを含む）
+- **クレンジング**: 全列一致の重複を除去。一部ソースの列ズレ（都道府県が欠けた住所など）を補正。業種違いで別レコードになっている同一施設は、許可レコードとして残しています
+- 週次クロール（`npm run build`）のたびに再生成され、gh-pages で配信されます
+
+> ⚠️ **市区町村が「不明」の行について**: 元データに市区町村欄が無く住所も粗い個票は、都道府県／市区町村を機械的に確定できず `prefecture=不明` または `city=不明` のまま収録しています（欠損させるより残す方針）。これらは元データ側の品質に起因するもので、結合CSVの生成ロジックの問題ではありません。
+
 ## API 構造
 
 **都道府県 > 市区町村 > `data.json`** の3階層構造です。

--- a/scripts/build-city-normmap.js
+++ b/scripts/build-city-normmap.js
@@ -1,0 +1,98 @@
+// 市区町村名の名寄せ表を生成する。
+//
+// api/facilities/{都道府県}/{市区町村}/ のディレクトリ名（表記ゆれを含む生の市区町村名）を
+// @geolonia/normalize-japanese-addresses で正規化し、公式の都道府県・市区町村名へ寄せた
+// 対応表 api/_city_normmap.json を出力する。
+//   キー: "元pref\t元city"  ->  { pref, city }（正規化後）または null（解決不能）
+//
+// この表を build-merged-csv.js が読み、結合CSVの city 列を名寄せする。
+// 郡名あり/なし（今帰仁村 / 国頭郡今帰仁村）や県名なし住所の列ズレも同時に是正される。
+//
+// 全市区町村（約2,000ディレクトリ）だけを対象にするため、施設全件（145万件）を
+// 正規化する必要はない。並列8本で数分で完了する。
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { normalize } from '@geolonia/normalize-japanese-addresses';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const FACILITIES_DIR = path.join(ROOT, 'api', 'facilities');
+const OUT_PATH = path.join(ROOT, 'api', '_city_normmap.json');
+const CONCURRENCY = 8;
+
+const PREFS = new Set('北海道 青森県 岩手県 宮城県 秋田県 山形県 福島県 茨城県 栃木県 群馬県 埼玉県 千葉県 東京都 神奈川県 新潟県 富山県 石川県 福井県 山梨県 長野県 岐阜県 静岡県 愛知県 三重県 滋賀県 京都府 大阪府 兵庫県 奈良県 和歌山県 鳥取県 島根県 岡山県 広島県 山口県 徳島県 香川県 愛媛県 高知県 福岡県 佐賀県 長崎県 熊本県 大分県 宮崎県 鹿児島県 沖縄県'.split(' '));
+
+// 各 (pref, city) ディレクトリの代表住所を1件拾う（normalize は住所文字列が要るため）。
+function collectSamples() {
+  const samples = [];
+  if (!fs.existsSync(FACILITIES_DIR)) return samples;
+  for (const prefD of fs.readdirSync(FACILITIES_DIR, { withFileTypes: true })) {
+    if (!prefD.isDirectory()) continue;
+    const prefPath = path.join(FACILITIES_DIR, prefD.name);
+    for (const cityD of fs.readdirSync(prefPath, { withFileTypes: true })) {
+      if (!cityD.isDirectory()) continue;
+      const dataPath = path.join(prefPath, cityD.name, 'data.json');
+      if (!fs.existsSync(dataPath)) continue;
+      let addr = '';
+      try {
+        const json = JSON.parse(fs.readFileSync(dataPath, 'utf-8'));
+        addr = (json.data || []).find((f) => f.address)?.address || '';
+      } catch { /* skip */ }
+      samples.push({ pref: prefD.name, city: cityD.name, addr });
+    }
+  }
+  return samples;
+}
+
+async function runPool(items, concurrency, worker) {
+  let next = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+      while (next < items.length) {
+        const i = next++;
+        await worker(items[i]);
+      }
+    }),
+  );
+}
+
+async function main() {
+  const samples = collectSamples();
+  console.log(`名寄せ対象: ${samples.length} 市区町村ディレクトリ`);
+
+  const map = {};
+  let ok = 0, ng = 0, done = 0;
+  const t0 = Date.now();
+
+  await runPool(samples, CONCURRENCY, async (s) => {
+    let q = s.addr;
+    const pref = PREFS.has(s.pref) ? s.pref : '';
+    if (pref && q && !q.startsWith(pref)) q = pref + q;
+    try {
+      const r = q ? await normalize(q) : null;
+      if (r && r.pref && r.city) {
+        map[`${s.pref}\t${s.city}`] = { pref: r.pref, city: r.city, level: r.level };
+        ok++;
+      } else {
+        map[`${s.pref}\t${s.city}`] = null;
+        ng++;
+      }
+    } catch {
+      map[`${s.pref}\t${s.city}`] = null;
+      ng++;
+    }
+    if (++done % 200 === 0) console.log(`  ...${done}/${samples.length} (${Math.round((Date.now() - t0) / 1000)}s)`);
+  });
+
+  fs.writeFileSync(OUT_PATH, JSON.stringify(map));
+  const uniq = new Set(Object.values(map).filter(Boolean).map((v) => `${v.pref}/${v.city}`));
+  console.log(`✅ 名寄せ表を生成: ${path.relative(ROOT, OUT_PATH)}`);
+  console.log(`   成功 ${ok} / 解決不能 ${ng} / 正規化後ユニーク市区町村 ${uniq.size}（${Math.round((Date.now() - t0) / 1000)}s）`);
+}
+
+main().catch((err) => {
+  console.error('❌ エラー:', err.message);
+  process.exit(1);
+});

--- a/scripts/build-merged-csv.js
+++ b/scripts/build-merged-csv.js
@@ -1,0 +1,168 @@
+// 全国 食品営業許可データ 結合CSV生成
+//
+// api/facilities/{都道府県}/{市区町村}/data.json を全て読み込み、
+// 1つの CSV（全国結合版）に出力する。都道府県・市区町村は各行に付与する。
+//
+// 出力時に以下の浄化を行う（元データ JSON は変更しない）:
+//  1. 全列完全一致の重複レコードを除去（無条件のゴミ）
+//  2. 市区町村名の表記ゆれを名寄せ（郡名プレフィックスを剥がして統一。
+//     例: 「玖珠郡九重町」→「九重町」）。正規化後の名を city 列に入れ、
+//     元の生表記は city_raw 列に残す。
+//  3. 一部ソースの列ズレ補正（pref 列が郵便番号・city 列が都道府県名に
+//     なっている富山県の数件を、住所先頭から市区町村を復元）。
+//
+// 業種違いの同一施設は「別の許可レコード」として残す（許可データの全量が価値のため）。
+//
+// 使い方: node scripts/build-merged-csv.js [出力パス]
+//   既定出力: api/facilities-all.csv
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const FACILITIES_DIR = path.join(ROOT, 'api', 'facilities');
+const OUT_PATH = process.argv[2] || path.join(ROOT, 'api', 'facilities-all.csv');
+
+const PREFS = new Set('北海道 青森県 岩手県 宮城県 秋田県 山形県 福島県 茨城県 栃木県 群馬県 埼玉県 千葉県 東京都 神奈川県 新潟県 富山県 石川県 福井県 山梨県 長野県 岐阜県 静岡県 愛知県 三重県 滋賀県 京都府 大阪府 兵庫県 奈良県 和歌山県 鳥取県 島根県 岡山県 広島県 山口県 徳島県 香川県 愛媛県 高知県 福岡県 佐賀県 長崎県 熊本県 大分県 宮崎県 鹿児島県 沖縄県'.split(' '));
+
+// 市区町村名の名寄せ表（@geolonia/normalize-japanese-addresses で事前生成）。
+//   scripts/_normmap.mjs が api/_city_normmap.json を作る。
+//   キー "元pref\t元city_raw" -> { pref, city }（正規化後）。
+// 表記ゆれ（郡名あり/なし・県名なし等）を公式の市区町村名へ寄せる。
+const NORMMAP = (() => {
+  const p = path.join(ROOT, 'api', '_city_normmap.json');
+  try { return JSON.parse(fs.readFileSync(p, 'utf-8')); } catch { return {}; }
+})();
+
+// 名寄せ表にあればそれを使い、無ければ郡名プレフィックスを剥がすフォールバック。
+function normalizeCityName(city) {
+  const m = String(city).match(/郡(.+?[町村])$/);
+  return m ? m[1] : city;
+}
+
+// 住所文字列から [都道府県, 市区町村] を切り出す（列ズレ補正用）。
+function splitPrefCity(addr) {
+  const a = String(addr || '').trim();
+  const pref = [...PREFS].find((p) => a.startsWith(p));
+  const rest = pref ? a.slice(pref.length) : a;
+  for (const d of ['四日市市', '廿日市市', '野々市市']) {
+    if (rest.startsWith(d)) return [pref || null, d];
+  }
+  let m = rest.match(/^(.+?郡.+?[町村])/);
+  if (m) return [pref || null, m[1]];
+  m = rest.match(/^(.+?市)/);
+  if (m) return [pref || null, m[1]];
+  m = rest.match(/^(.+?区)/);
+  if (m) return [pref || null, m[1]];
+  m = rest.match(/^(.+?[町村])/);
+  if (m) return [pref || null, m[1]];
+  return [pref || null, null];
+}
+
+function csvCell(v) {
+  if (v === null || v === undefined) return '';
+  const s = String(v);
+  return /[",\r\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+const COLUMNS = [
+  'prefecture', 'city', 'city_raw', 'name', 'name_kana', 'business_type', 'address',
+  'lat', 'lng', 'geocoding_level', 'phone', 'license_no', 'license_date', 'expire_date',
+  'sources', 'licenses',
+];
+
+function main() {
+  if (!fs.existsSync(FACILITIES_DIR)) {
+    console.error(`api/facilities がありません: ${FACILITIES_DIR}`);
+    process.exit(1);
+  }
+
+  const out = fs.createWriteStream(OUT_PATH, { encoding: 'utf-8' });
+  out.write('﻿'); // Excel 互換 UTF-8 BOM
+  out.write(COLUMNS.join(',') + '\n');
+
+  let rowsIn = 0, rowsOut = 0, dupSkipped = 0, colFixed = 0, nameMerged = 0;
+  const seen = new Set(); // 全列一致の重複判定
+  const cityKeys = new Set();
+  const prefs = new Set();
+
+  const prefDirs = fs.readdirSync(FACILITIES_DIR, { withFileTypes: true }).filter((d) => d.isDirectory());
+
+  for (const prefD of prefDirs) {
+    const prefName = prefD.name;
+    const prefPath = path.join(FACILITIES_DIR, prefName);
+    const cityDirs = fs.readdirSync(prefPath, { withFileTypes: true }).filter((d) => d.isDirectory());
+
+    for (const cityD of cityDirs) {
+      const cityDir = cityD.name;
+      const dataPath = path.join(prefPath, cityDir, 'data.json');
+      if (!fs.existsSync(dataPath)) continue;
+
+      let json;
+      try { json = JSON.parse(fs.readFileSync(dataPath, 'utf-8')); }
+      catch { console.warn(`  ⚠ 読み込み失敗: ${dataPath}`); continue; }
+
+      const srcList = json.meta?.sources || [];
+      const sources = srcList.map((s) => s.source).filter(Boolean).join('; ');
+      const licenses = [...new Set(srcList.map((s) => s.license).filter(Boolean))].join('; ');
+
+      for (const f of (json.data || [])) {
+        rowsIn++;
+        let pref = prefName;
+        let cityRaw = cityDir;
+
+        // 列ズレ補正: pref がプレフィックス名でない(郵便番号等) or city が都道府県名 の場合。
+        // 富山県ソースは pref=郵便番号 / city=都道府県名 / address="市区町村 ..." とズレる。
+        // このとき本当の都道府県名は city_raw 側に入っているので、まずそれを pref に移す。
+        if (!PREFS.has(pref) || PREFS.has(cityRaw)) {
+          if (PREFS.has(cityRaw)) pref = cityRaw; // city 列に入っていた都道府県名を採用
+          const [p, c] = splitPrefCity(f.address);
+          if (!PREFS.has(pref) && p) pref = p;    // それでも不正なら住所先頭から
+          if (c) cityRaw = c;                     // 市区町村は住所先頭から復元
+          colFixed++;
+        }
+
+        // 名寄せ: 事前生成した normmap を最優先。無ければ郡名剥がしフォールバック。
+        const nm = NORMMAP[`${prefName}\t${cityDir}`];
+        let city;
+        if (nm && nm.pref && nm.city) {
+          pref = nm.pref;      // 正規化された都道府県（列ズレも同時に是正される）
+          city = nm.city;      // 公式市区町村名
+        } else {
+          city = normalizeCityName(cityRaw);
+        }
+        if (city !== cityRaw) nameMerged++;
+
+        const rec = [
+          pref, city, cityRaw, f.name, f.name_kana, f.business_type, f.address,
+          f.lat, f.lng, f.geocoding_level, f.phone, f.license_no, f.license_date, f.expire_date,
+          sources, licenses,
+        ];
+
+        // 全列一致の重複を除去
+        const dedupKey = rec.join('');
+        if (seen.has(dedupKey)) { dupSkipped++; continue; }
+        seen.add(dedupKey);
+
+        out.write(rec.map(csvCell).join(',') + '\n');
+        rowsOut++;
+        prefs.add(pref);
+        cityKeys.add(`${pref}/${city}`);
+      }
+    }
+  }
+
+  out.end(() => {
+    const bytes = fs.statSync(OUT_PATH).size;
+    console.log(`✅ 結合CSV生成完了: ${path.relative(ROOT, OUT_PATH)}`);
+    console.log(`   入力レコード: ${rowsIn.toLocaleString()} 件`);
+    console.log(`   出力レコード: ${rowsOut.toLocaleString()} 件（全列一致の重複 ${dupSkipped.toLocaleString()} 件を除去）`);
+    console.log(`   列ズレ補正: ${colFixed.toLocaleString()} 件 / 市区町村名の名寄せ: ${nameMerged.toLocaleString()} 件`);
+    console.log(`   都道府県: ${prefs.size} / 市区町村（名寄せ後）: ${cityKeys.size}`);
+    console.log(`   ファイルサイズ: ${(bytes / 1024 / 1024).toFixed(1)} MB`);
+  });
+}
+
+main();


### PR DESCRIPTION
## 背景・解決したい課題
- これまで施設データは「都道府県別・市区町村別の JSON」でしか配信しておらず、**Excel/pandas/BIで全国を一括で扱いたい利用者**の受け皿がなかった
- 単純に全 JSON を結合するだけでは、市区町村名の表記ゆれ（「今帰仁村」と「国頭郡今帰仁村」等）や一部ソースの列ズレで**同じ自治体が別物として散る**問題があった

## 変更内容
- **`scripts/build-city-normmap.js`**: [normalize-japanese-addresses](https://github.com/geolonia/normalize-japanese-addresses) で市区町村名の名寄せ表を生成。全施設(145万件)ではなく**ユニークな市区町村ディレクトリ(約2,000)だけ**を並列8本で正規化（数分で完了）
- **`scripts/build-merged-csv.js`**: `api/facilities/**/data.json` を1本の `api/facilities-all.csv` に結合。全列一致の重複除去・列ズレ補正・名寄せ適用。`city`(正規化)と`city_raw`(元表記)を併記
- **`crawl.yml`**: 週次クロール後に結合CSV(+gzip)を生成し gh-pages で配信
- **`README`**: DL URL・列定義・文字コード・「不明」行の説明を追記

## 名寄せの効果（実測）
| | 生成CSV |
|---|---|
| レコード | 1,449,538 件（全列一致の重複 6,694 件を除去）|
| 市区町村名の名寄せ | 213,166 件を統一 |
| 都道府県 | 47（列ズレの郵便番号混入を補正）+「不明」「県外」|
| 配布サイズ | 約540MB（非圧縮）/ 約60MB（gzip）|

## 採用したアプローチと意図
- **名寄せは全行でなくユニーク市区町村だけに適用**: 145万件を1件ずつ正規化すると数百時間かかる。正規化が必要なのは市区町村名の種類（約2,000）だけなので、対応表を作って全行に適用する方式にした
- **業種違いの同一施設は残す**: 「飲食店営業＋菓子製造業」を1施設に潰すと許可情報が欠落するため、許可レコード単位で保持

## 既知の限界（今回のスコープ外・意図的に区切った点）
- **市区町村ユニーク数は約1,817（47県内）で、公式の1,741には完全一致しない**。差分は、元データに市区町村欄がなく住所も粗い「不明」個票が中心。これは**元データ（各自治体オープンデータ）側の品質issue**であり、結合CSVの生成ロジックの問題ではない
- 完全な1,741への収束は、元データ取り込み（`crawl.js`）側での住所解決強化が必要で、破壊的変更を伴うため**別PRが適切**と判断しここで区切った
- `city_raw` を併記しているため、利用者が独自基準で再集計することも可能

## 確認してほしいポイント
- CI（crawl.yml）に追加した「Build merged CSV」ステップの位置（crawl→CSV生成→validate→gh-pages配信）
- README のDL URL（gh-pages 配信パス）が実際の公開パスと一致するか