### PR TITLE
fix(geocode): 市区町村名を前置して level 1（県代表点）転落を防ぐ

### DIFF
--- a/scripts/crawl.js
+++ b/scripts/crawl.js
@@ -778,11 +778,21 @@ function writeJSON(filePath, obj) {
 //   結果は .cache/geocode-cache.json に永続化し、再実行・週次クロールを高速化する。
 // ---------------------------------------------------------------------------
 
-// 住所が都道府県名で始まっていなければ前置し、正規化の精度を上げる
+// 住所が都道府県名・市区町村名で始まっていなければ前置し、正規化の精度を上げる。
+// 神戸市・仙台市・富山県等は住所列が区/町名始まり（市名は別列）のため、市名を前置しないと
+// ジオコーダーが市名なしの区を解決できず県代表点(level 1)へ転落する。_city を前置して補正する。
 function geocodeQuery(facility) {
   const addr = facility.address || '';
   const pref = facility._pref && facility._pref !== '不明' ? facility._pref : '';
-  return pref && !addr.startsWith(pref) ? `${pref}${addr}` : addr;
+  const city = facility._city && facility._city !== '不明' ? facility._city : '';
+  if (!city) return pref && !addr.startsWith(pref) ? `${pref}${addr}` : addr;
+  // 住所が政令市の区名で始まり city 末尾と重複する場合は剥がす（例: city=神戸市東灘区, addr=東灘区…）
+  let a = addr;
+  const wm = city.match(/(.+?[市])(.+?[区])$/);
+  if (wm && a.startsWith(wm[2])) a = a.slice(wm[2].length);
+  else if (a.startsWith(city)) a = a.slice(city.length);
+  const head = city.startsWith(pref) ? city : `${pref}${city}`;
+  return a.startsWith(head) ? a : `${head}${a}`;
 }
 
 function loadGeocodeCache() {


### PR DESCRIPTION
## 概要
`geocodeQuery`（`scripts/crawl.js`）が**都道府県のみ前置し市区町村を足さない**ため、住所列が区/町名で始まる自治体（神戸市・仙台市・富山県 等。市名は別カラム）で市名が欠落し、`normalize-japanese-addresses` が県代表点（`geocoding_level=1`）へ転落していました。

## 根本原因
```js
// 現行: 都道府県しか前置しない
return pref && !addr.startsWith(pref) ? `${pref}${addr}` : addr;
```
例：`city=神戸市`, `address=東灘区魚崎北町1丁目6-7` → クエリ `兵庫県東灘区魚崎北町…`（**神戸市欠落**）→ 区を解決できず level 1。

実証（normalize-japanese-addresses で同一住所を比較）：
- `兵庫県東灘区魚崎北町1丁目6‐7` → **level 1**（34.691, 135.183 ＝県代表点）
- `兵庫県神戸市東灘区魚崎北町1丁目6‐7` → **level 8**（34.718, 135.275 ＝街区精度、約3km改善）

## 修正
`_city` も前置する（政令市の区名が住所先頭と二重化する場合はガードして剥がす）。

## 効果（全国 `facilities-all.csv`, 1,437,799 行で実測）
| geocoding_level | before | after | 差 |
|---|--:|--:|--:|
| 1（県代表点） | 82,184 | **18,405** | **−63,779（−77.6%）** |
| 2（市区町村点） | 28,889 | 36,488 | +7,599 |
| 3（丁目重心） | 208,348 | 230,384 | +22,036 |
| 8（街区・地番） | 207,934 | **242,079** | +34,145 |
| 空（元座標） | 910,444 | 910,443 | −1 |

- level 1 の 63,779 件が解消、うち **約 56,181 件が丁目〜街区精度（level 3/8）へ回復**。
- **総行数・座標あり数は不変＝データ欠損ゼロ、精度のみ改善。**
- 残る level 1（18,405 件）は「県下一円/行商/自販機」等、本来点で表せないデータ。

## テスト
- `npm test` 全合格。

関連: #11（全国網羅追加計画）とは別の、ジオコーディング精度の未報告バグです。
