### PR TITLE
README を OSS 風に全面刷新（コントリビューション歓迎・コントリビューター一覧・構成整理）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Japan-facilities-api
 
+[![Contributors](https://img.shields.io/github/contributors/gl20percentclub/japan-facilities-address)](https://github.com/gl20percentclub/japan-facilities-address/graphs/contributors)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](#-コントリビューション)
+[![GitHub Issues](https://img.shields.io/github/issues/gl20percentclub/japan-facilities-address)](https://github.com/gl20percentclub/japan-facilities-address/issues)
+[![Last Commit](https://img.shields.io/github/last-commit/gl20percentclub/japan-facilities-address)](https://github.com/gl20percentclub/japan-facilities-address/commits/main)
+
 日本の自治体が公開しているオープンデータ（食品営業許可・届出）をクロールし、APIとして配信するシステムです。
 
 - **ソース**: 各自治体のオープンデータ（BODIK 等の CKAN、自治体ポータルの直リンク CSV/XLSX、フォーム配布など）。対象は `scripts/sources.js` で定義。
@@ -216,6 +221,37 @@ export const SOURCES = [
   都道府県・市区町村で自動補完されます。
 - 一部データはヘッダの「緯度」「経度」が入れ替わっている（例: 大阪市）ため、日本域の範囲で
   自動的にサニティ補正します。
+
+## 🤝 コントリビューション
+
+**コントリビューションは大歓迎です！** バグ報告・機能提案・プルリクエスト、どんな形の貢献でも歓迎します。
+
+たとえば次のような貢献ができます。
+
+- 🗾 **新しい自治体データソースの追加** — [データソースの追加](#データソースの追加) の手順どおり `scripts/sources.js` に1エントリ追加するだけです。未収録の自治体は [`docs/COVERAGE.md`](docs/COVERAGE.md) で確認できます
+- 🐛 **バグ報告・データ品質の問題報告** — [Issues](https://github.com/gl20percentclub/japan-facilities-address/issues) からお気軽にどうぞ（座標のずれ、重複、文字化けなど）
+- 💡 **機能提案・改善アイデア** — Issue で議論を始めてください
+- 📖 **ドキュメントの改善** — 誤字修正や説明の追加も立派な貢献です
+
+### プルリクエストの流れ
+
+1. このリポジトリを Fork する
+2. ブランチを作成する（`git checkout -b feature/add-your-city`）
+3. 変更をコミットする
+4. `npm test` でバリデーションが通ることを確認する
+5. プルリクエストを作成する
+
+小さな変更でも遠慮なくどうぞ。不明点があれば Issue で気軽に質問してください。
+
+## ✨ コントリビューター
+
+このプロジェクトに貢献してくださった皆さんです。ありがとうございます！
+
+<a href="https://github.com/gl20percentclub/japan-facilities-address/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=gl20percentclub/japan-facilities-address" alt="Contributors" />
+</a>
+
+*Made with [contrib.rocks](https://contrib.rocks).*
 
 ## 出典・ライセンス・免責事項
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,76 @@
-# Japan-facilities-api
+<div align="center">
+
+# 🍽️ Japan Facilities API
+
+**日本全国の飲食施設オープンデータ（食品営業許可・届出）を、無料で使える静的 API として配信**
 
 [![Contributors](https://img.shields.io/github/contributors/gl20percentclub/japan-facilities-address)](https://github.com/gl20percentclub/japan-facilities-address/graphs/contributors)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](#-コントリビューション)
 [![GitHub Issues](https://img.shields.io/github/issues/gl20percentclub/japan-facilities-address)](https://github.com/gl20percentclub/japan-facilities-address/issues)
 [![Last Commit](https://img.shields.io/github/last-commit/gl20percentclub/japan-facilities-address)](https://github.com/gl20percentclub/japan-facilities-address/commits/main)
+[![Weekly Crawl](https://img.shields.io/badge/更新-毎週自動-blue)](#️-自動更新の仕組み)
 
-日本の自治体が公開しているオープンデータ（食品営業許可・届出）をクロールし、APIとして配信するシステムです。
+[クイックスタート](#-クイックスタート) · [API リファレンス](#-api-リファレンス) · [収録状況](docs/COVERAGE.md) · [バグ報告](https://github.com/gl20percentclub/japan-facilities-address/issues/new) · [機能要望](https://github.com/gl20percentclub/japan-facilities-address/issues/new)
 
-- **ソース**: 各自治体のオープンデータ（BODIK 等の CKAN、自治体ポータルの直リンク CSV/XLSX、フォーム配布など）。対象は `scripts/sources.js` で定義。
-- **運用**: GitHub Actions で毎週自動クロール → GitHub Pages で配信
-- **ライセンス**: 元データのライセンスは自治体ごとに異なる（多くは CC BY 4.0 / CC BY 2.1 JP）。各データの出典・ライセンスは `index.json` の `meta.sources` を参照。
+</div>
 
-## 収録データ
+---
 
-> 📊 **どの自治体のデータをカバーしているか**は [`docs/COVERAGE.md`](docs/COVERAGE.md) を参照（全市区町村 × 管轄保健所設置主体の一覧・収集状況・出典・ライセンス）。
+各自治体が公開しているオープンデータ（食品営業許可・届出）を毎週自動クロールし、正規化・ジオコーディングした上で GitHub Pages から静的 API として配信しています。**登録不要・API キー不要**でそのまま利用できます。
+
+## ✨ 特徴
+
+- 🗾 **全国カバー** — 47都道府県・1,800以上の市区町村、70万件超の施設レコードを収録
+- 📍 **緯度経度つき** — 座標が無い元データも [normalize-japanese-addresses](https://github.com/geolonia/normalize-japanese-addresses) でジオコーディングして補完
+- 🔄 **毎週自動更新** — GitHub Actions が毎週クロールして最新データを配信
+- 📦 **好きな形式で** — 市区町村別 JSON、検索用インデックス、全国結合 CSV の3形式
+- 🆓 **静的配信** — GitHub Pages でホスティング。登録・認証・レート制限の心配なし
+
+<details>
+<summary><b>📖 目次</b></summary>
+
+- [クイックスタート](#-クイックスタート)
+- [収録データ](#-収録データ)
+- [全データ結合CSV（ダウンロード）](#-全データ結合csvダウンロード)
+- [API リファレンス](#-api-リファレンス)
+- [開発](#️-開発)
+  - [セットアップとビルド](#セットアップとビルド)
+  - [データソースの追加](#データソースの追加)
+- [自動更新の仕組み](#️-自動更新の仕組み)
+- [コントリビューション](#-コントリビューション)
+- [コントリビューター](#-コントリビューター)
+- [出典・ライセンス・免責事項](#-出典ライセンス免責事項)
+
+</details>
+
+## 🚀 クイックスタート
+
+ベース URL は `https://gl20percentclub.github.io/japan-facilities-address/api/` です。
+
+```bash
+# 都道府県一覧（都道府県名 → 市区町村名の配列）
+curl https://gl20percentclub.github.io/japan-facilities-address/api/facilities/index.json
+
+# 那覇市の全施設（パスは URL エンコードが必要な場合があります）
+curl "https://gl20percentclub.github.io/japan-facilities-address/api/facilities/%E6%B2%96%E7%B8%84%E7%9C%8C/%E9%82%A3%E8%A6%87%E5%B8%82/data.json"
+```
+
+JavaScript からはこう使えます。
+
+```js
+const BASE = 'https://gl20percentclub.github.io/japan-facilities-address/api';
+
+// 那覇市の全施設を取得（日本語パスは encodeURIComponent でエンコード）
+const res = await fetch(
+  `${BASE}/facilities/${encodeURIComponent('沖縄県')}/${encodeURIComponent('那覇市')}/data.json`
+);
+const { data } = await res.json();
+console.log(data[0].name, data[0].lat, data[0].lng);
+```
+
+## 📊 収録データ
+
+> 📋 **どの自治体のデータをカバーしているか**は [`docs/COVERAGE.md`](docs/COVERAGE.md) を参照（全市区町村 × 管轄保健所設置主体の一覧・収集状況・出典・ライセンス）。
 
 以下はクロール（`npm run build`）のたびに自動更新されます。ファイルサイズは目安です。
 
@@ -31,7 +88,7 @@
 > | `search-index.json` | 約 61.1 MB |
 <!-- STATS:END -->
 
-### 全データ結合CSV（ダウンロード）
+## 📥 全データ結合CSV（ダウンロード）
 
 都道府県別・市区町村別に分かれた JSON を、**全国 1 本にまとめた CSV** も配信しています。
 Excel / pandas / BI ツール等で扱いたい場合はこちらが便利です。
@@ -49,7 +106,7 @@ Excel / pandas / BI ツール等で扱いたい場合はこちらが便利です
 
 > ⚠️ **市区町村が「不明」の行について**: 元データに市区町村欄が無く住所も粗い個票は、都道府県／市区町村を機械的に確定できず `prefecture=不明` または `city=不明` のまま収録しています（欠損させるより残す方針）。これらは元データ側の品質に起因するもので、結合CSVの生成ロジックの問題ではありません。
 
-## API 構造
+## 🔍 API リファレンス
 
 **都道府県 > 市区町村 > `data.json`** の3階層構造です。
 
@@ -156,7 +213,7 @@ api/
 }
 ```
 
-#### 緯度経度（ジオコーディング）
+### 緯度経度（ジオコーディング）
 
 元データに緯度経度が無い施設は、住所をもとに
 [@geolonia/normalize-japanese-addresses](https://github.com/geolonia/normalize-japanese-addresses)
@@ -169,7 +226,9 @@ api/
 
 補完結果は `.cache/geocode-cache.json` にキャッシュされ、再クロール時に再利用されます。
 
-## 使い方
+## 🛠️ 開発
+
+### セットアップとビルド
 
 ```bash
 npm ci
@@ -190,7 +249,7 @@ node scripts/crawl.js --only=osaka-city,tokyo-minato
 npm test
 ```
 
-## データソースの追加
+### データソースの追加
 
 `scripts/sources.js` の `SOURCES` 配列に1エントリ追加するだけで、新しい自治体の
 オープンデータを取り込めます。取得方法（CKAN / 直リンクGET / フォームPOST）、
@@ -221,6 +280,13 @@ export const SOURCES = [
   都道府県・市区町村で自動補完されます。
 - 一部データはヘッダの「緯度」「経度」が入れ替わっている（例: 大阪市）ため、日本域の範囲で
   自動的にサニティ補正します。
+
+## ⚙️ 自動更新の仕組み
+
+`.github/workflows/crawl.yml` が毎週月曜 18:00 UTC（JST 火曜 AM 3:00）に実行され、
+`api/` を生成して `gh-pages` ブランチへ配信します。**生成物 `api/` は Git 管理せず**（`.gitignore`）、
+配信は gh-pages のみ（履歴肥大を避けるため）。README の「収録データ」統計だけを main に反映します。
+`workflow_dispatch` から手動実行も可能（`dry_run` / `fetch_i2fas` オプション付き）。
 
 ## 🤝 コントリビューション
 
@@ -253,7 +319,7 @@ export const SOURCES = [
 
 *Made with [contrib.rocks](https://contrib.rocks).*
 
-## 出典・ライセンス・免責事項
+## 📄 出典・ライセンス・免責事項
 
 本サービスは各自治体が公開するオープンデータを取得・加工・統合して提供しています。
 
@@ -293,10 +359,3 @@ export const SOURCES = [
 
 本サービスは各自治体が公開するオープンデータを独自に集約・加工したサービスです。
 **各自治体の公式サービスではありません。**
-
-## 自動更新
-
-`.github/workflows/crawl.yml` が毎週月曜 18:00 UTC（JST 火曜 AM 3:00）に実行され、
-`api/` を生成して `gh-pages` ブランチへ配信します。**生成物 `api/` は Git 管理せず**（`.gitignore`）、
-配信は gh-pages のみ（履歴肥大を避けるため）。README の「収録データ」統計だけを main に反映します。
-`workflow_dispatch` から手動実行も可能（`dry_run` / `fetch_i2fas` オプション付き）。


### PR DESCRIPTION
## 概要
- OSS としてコントリビューションを歓迎していることを README で明示し、貢献のハードルを下げる
- README 全体をモダンな OSS スタイルに再構成し、利用者が最初に知りたい情報（API の使い方）へ最短で辿り着けるようにする

## 変更内容
### コントリビューション関連
- 冒頭にバッジを5つ追加（Contributors 数 / PRs Welcome / Issues / Last Commit / 週次自動更新）
- 「🤝 コントリビューション」セクションを新設（データソース追加・バグ報告・機能提案・ドキュメント改善の案内、PR の流れ）
- 「✨ コントリビューター」セクションを新設（[contrib.rocks](https://contrib.rocks) による自動生成アイコン一覧）

### 構成の整理
- センタリングされたヘッダー（タイトル・タグライン・バッジ・クイックリンク）を追加
- 「✨ 特徴」セクションを新設（全国カバー・座標付き・週次更新・3形式配信・静的配信）
- 折りたたみ式の目次を追加
- 「🚀 クイックスタート」を新設 — curl / fetch での API 利用例を README の先頭近くに配置（従来は API の呼び出し例が無かった）
- 「API 構造」→「🔍 API リファレンス」に改名し、エンドポイント仕様を集約
- 「使い方」「データソースの追加」→「🛠️ 開発」配下に統合（開発者向け情報として分離）
- 「自動更新」→「⚙️ 自動更新の仕組み」に改名

### 変更していないもの
- `<!-- STATS:START/END -->` マーカーは維持（`gen-readme-stats.js` による自動更新が引き続き動作）
- 既存の説明文・免責事項・ライセンス記述の内容はすべて保持（配置のみ変更）

## テスト計画
- `node scripts/gen-readme-stats.test.js` 合格を確認済み（STATS マーカーも README に残存することを確認）
- 目次・バッジのアンカーリンクが GitHub のアンカー生成規則（絵文字除去・異体字セレクタ残存）に一致することを確認
- contrib.rocks の画像 URL が HTTP 200 を返すことを確認済み

## 破壊的変更
なし（ドキュメントのみ）

## 関連Issue
なし