### PR TITLE
データプレビュー地図を gh-pages のトップページに追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,257 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>🍽️ Japan Facilities API — データプレビュー地図</title>
+  <meta name="description" content="日本全国の飲食施設オープンデータ（食品営業許可・届出）を地図上でプレビューできます。">
+
+  <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css">
+  <style>
+    :root {
+      --accent: #e8563f;
+      --ink: #1f2933;
+      --panel-bg: rgba(255, 255, 255, 0.94);
+      --border: rgba(31, 41, 51, 0.12);
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; height: 100%; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Noto Sans JP", sans-serif;
+      color: var(--ink);
+    }
+    #map { position: absolute; inset: 0; }
+
+    /* ヘッダー（左上） */
+    .panel {
+      position: absolute;
+      top: 12px;
+      left: 12px;
+      z-index: 2;
+      max-width: min(340px, calc(100vw - 24px));
+      background: var(--panel-bg);
+      backdrop-filter: blur(8px);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      box-shadow: 0 4px 20px rgba(0, 0, 0, 0.12);
+      padding: 14px 16px;
+    }
+    .panel h1 {
+      margin: 0 0 4px;
+      font-size: 16px;
+      line-height: 1.35;
+      letter-spacing: 0.01em;
+    }
+    .panel .sub {
+      margin: 0 0 12px;
+      font-size: 12px;
+      color: #52606d;
+      line-height: 1.5;
+    }
+    .stats {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 8px;
+      margin-bottom: 10px;
+    }
+    .stat {
+      background: #f7f8fa;
+      border-radius: 8px;
+      padding: 8px 6px;
+      text-align: center;
+    }
+    .stat .num {
+      display: block;
+      font-size: 18px;
+      font-weight: 700;
+      color: var(--accent);
+      line-height: 1.1;
+    }
+    .stat .lbl { font-size: 10px; color: #616e7c; }
+    .meta-line { font-size: 11px; color: #7b8794; }
+    .meta-line a { color: var(--accent); text-decoration: none; }
+    .meta-line a:hover { text-decoration: underline; }
+
+    /* ズームヒント（下中央） */
+    .hint {
+      position: absolute;
+      left: 50%;
+      bottom: 28px;
+      transform: translateX(-50%);
+      z-index: 2;
+      background: rgba(31, 41, 51, 0.86);
+      color: #fff;
+      font-size: 12px;
+      padding: 8px 14px;
+      border-radius: 999px;
+      box-shadow: 0 2px 10px rgba(0, 0, 0, 0.25);
+      transition: opacity 0.3s;
+      pointer-events: none;
+      white-space: nowrap;
+    }
+    .hint.hidden { opacity: 0; }
+
+    /* ポップアップ */
+    .maplibregl-popup-content {
+      font-family: inherit;
+      padding: 12px 14px;
+      border-radius: 10px;
+      box-shadow: 0 4px 18px rgba(0, 0, 0, 0.18);
+    }
+    .fac-name { font-weight: 700; font-size: 14px; margin: 0 0 6px; }
+    .fac-row { font-size: 12px; color: #52606d; margin: 2px 0; }
+    .fac-row .k { color: #9aa5b1; margin-right: 6px; }
+
+    .legend-dot {
+      display: inline-block;
+      width: 10px; height: 10px;
+      border-radius: 50%;
+      background: var(--accent);
+      border: 1.5px solid #fff;
+      box-shadow: 0 0 0 1px rgba(0,0,0,0.15);
+      vertical-align: middle;
+      margin-right: 6px;
+    }
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+
+  <div class="panel">
+    <h1>🍽️ Japan Facilities API</h1>
+    <p class="sub">日本全国の飲食施設オープンデータ（食品営業許可・届出）のプレビュー地図です。</p>
+    <div class="stats">
+      <div class="stat"><span class="num" id="stat-pref">–</span><span class="lbl">都道府県</span></div>
+      <div class="stat"><span class="num" id="stat-city">–</span><span class="lbl">市区町村</span></div>
+      <div class="stat"><span class="num" id="stat-fac">70万+</span><span class="lbl">施設</span></div>
+    </div>
+    <p class="meta-line">
+      <span class="legend-dot"></span>各点＝1施設
+      <span id="updated"></span><br>
+      <a href="https://github.com/gl20percentclub/japan-facilities-api">GitHub リポジトリ</a> ·
+      <a href="https://github.com/gl20percentclub/japan-facilities-api#-api-リファレンス">API リファレンス</a>
+    </p>
+  </div>
+
+  <div class="hint" id="hint">🔍 ズームインすると施設ピンが表示されます</div>
+
+  <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
+  <script>
+    // データ配信ベース URL（このページと同じ gh-pages 上）。相対参照でローカルでも動く。
+    const API_BASE = './api';
+    // ベクトルタイルのズーム範囲（scripts/gen-tiles.js の設定と一致させる）
+    const TILE_MIN_ZOOM = 6;
+    const TILE_MAX_ZOOM = 12;
+    // 日本のおおよその範囲 [west, south, east, north]
+    const JAPAN_BOUNDS = [122, 20, 154, 46];
+
+    const map = new maplibregl.Map({
+      container: 'map',
+      // 国土地理院 淡色地図をベースにした最小構成スタイル（API キー不要）
+      style: {
+        version: 8,
+        glyphs: 'https://glyphs.geolonia.com/fonts/{fontstack}/{range}.pbf',
+        sources: {
+          gsi: {
+            type: 'raster',
+            tiles: ['https://cyberjapandata.gsi.go.jp/xyz/pale/{z}/{x}/{y}.png'],
+            tileSize: 256,
+            minzoom: 2,
+            maxzoom: 18,
+            attribution:
+              '<a href="https://maps.gsi.go.jp/development/ichiran.html" target="_blank" rel="noopener">地理院タイル</a>',
+          },
+          facilities: {
+            type: 'vector',
+            tiles: [`${location.href.replace(/[^/]*$/, '')}api/tiles/{z}/{x}/{y}.pbf`],
+            minzoom: TILE_MIN_ZOOM,
+            maxzoom: TILE_MAX_ZOOM,
+            bounds: JAPAN_BOUNDS,
+            attribution:
+              '施設データ: <a href="https://github.com/gl20percentclub/japan-facilities-api" target="_blank" rel="noopener">Japan Facilities API</a>（各自治体オープンデータ）',
+          },
+        },
+        layers: [
+          { id: 'gsi', type: 'raster', source: 'gsi' },
+          {
+            id: 'facilities-circle',
+            type: 'circle',
+            source: 'facilities',
+            'source-layer': 'facilities',
+            paint: {
+              'circle-color': '#e8563f',
+              'circle-opacity': 0.75,
+              'circle-stroke-color': '#ffffff',
+              'circle-stroke-width': 0.6,
+              // ズームに応じて点を大きくする
+              'circle-radius': [
+                'interpolate', ['linear'], ['zoom'],
+                6, 1.6,
+                9, 2.8,
+                12, 4.5,
+                16, 7,
+              ],
+            },
+          },
+        ],
+      },
+      bounds: JAPAN_BOUNDS,
+      fitBoundsOptions: { padding: 20 },
+      minZoom: 3,
+      maxZoom: 18,
+      attributionControl: false,
+    });
+
+    map.addControl(new maplibregl.NavigationControl({ showCompass: false }), 'top-right');
+    map.addControl(
+      new maplibregl.AttributionControl({ compact: true }),
+      'bottom-right',
+    );
+    map.addControl(new maplibregl.GeolocateControl({
+      positionOptions: { enableHighAccuracy: true },
+      trackUserLocation: true,
+    }), 'top-right');
+
+    // --- ヒントの表示制御（ズーム6未満では点が出ないため案内する）---
+    const hintEl = document.getElementById('hint');
+    function updateHint() {
+      hintEl.classList.toggle('hidden', map.getZoom() >= TILE_MIN_ZOOM);
+    }
+    map.on('zoom', updateHint);
+    map.on('load', updateHint);
+
+    // --- 施設クリックでポップアップ ---
+    map.on('click', 'facilities-circle', (e) => {
+      const p = e.features[0].properties || {};
+      const esc = (s) => String(s ?? '').replace(/[&<>"]/g, (c) =>
+        ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+      const rows = [];
+      if (p.business_type) rows.push(`<p class="fac-row"><span class="k">業種</span>${esc(p.business_type)}</p>`);
+      const loc = [p.pref, p.city].filter(Boolean).join(' ');
+      if (loc) rows.push(`<p class="fac-row"><span class="k">所在</span>${esc(loc)}</p>`);
+      new maplibregl.Popup({ offset: 8, maxWidth: '280px' })
+        .setLngLat(e.lngLat)
+        .setHTML(`<p class="fac-name">${esc(p.name) || '（名称なし）'}</p>${rows.join('')}`)
+        .addTo(map);
+    });
+    map.on('mouseenter', 'facilities-circle', () => { map.getCanvas().style.cursor = 'pointer'; });
+    map.on('mouseleave', 'facilities-circle', () => { map.getCanvas().style.cursor = ''; });
+
+    // --- 統計（index.json）を取得してヘッダーに反映 ---
+    fetch(`${API_BASE}/facilities/index.json`)
+      .then((r) => (r.ok ? r.json() : Promise.reject(r.status)))
+      .then((json) => {
+        const prefs = Object.keys(json.data || {});
+        const cities = prefs.reduce((n, p) => n + (json.data[p]?.length || 0), 0);
+        document.getElementById('stat-pref').textContent = prefs.length.toLocaleString('ja-JP');
+        document.getElementById('stat-city').textContent = cities.toLocaleString('ja-JP');
+        if (json.meta?.updated) {
+          const d = new Date(json.meta.updated * 1000);
+          const ymd = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+          document.getElementById('updated').textContent = `最終更新 ${ymd}`;
+        }
+      })
+      .catch(() => { /* 統計が取れなくても地図本体は動く */ });
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:tiles": "node scripts/gen-tiles.js",
     "build:readme-stats": "node scripts/gen-readme-stats.js",
     "fetch:i2fas": "node scripts/fetch-i2fas.mjs",
-    "test": "node scripts/crawl.test.js && node scripts/lib/config.test.js && node scripts/gen-tiles.test.js && node scripts/test.js && node scripts/gen-readme-stats.test.js"
+    "test": "node scripts/crawl.test.js && node scripts/lib/config.test.js && node scripts/gen-tiles.test.js && node scripts/preview-map.test.js && node scripts/test.js && node scripts/gen-readme-stats.test.js"
   },
   "dependencies": {
     "@geolonia/normalize-japanese-addresses": "^3.1.3",

--- a/scripts/preview-map.test.js
+++ b/scripts/preview-map.test.js
@@ -1,0 +1,110 @@
+// プレビュー地図(index.html)と gen-tiles.js の生成物との整合性テスト。
+//   node scripts/preview-map.test.js
+//
+// index.html はベクトルタイル(api/tiles)を直接読むため、レイヤ名・ズーム範囲・
+// タイルパス・利用する属性が gen-tiles.js の出力とズレると地図が黙って壊れる。
+// ここでは実際に generateTiles を走らせた生成物と index.html の記述を突き合わせ、
+// 両者が食い違ったら失敗させることで、その回帰を防ぐ。
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildFeatureCollection, generateTiles } from './gen-tiles.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const HTML = fs.readFileSync(path.join(ROOT, 'index.html'), 'utf-8');
+
+let passed = 0;
+function test(name, fn) {
+  fn();
+  passed++;
+  console.log(`  ✓ ${name}`);
+}
+
+// index.html から地図設定に使っている値を素朴に抽出する（フルパーサは不要）。
+function htmlValue(re, label) {
+  const m = HTML.match(re);
+  assert.ok(m, `index.html から ${label} を抽出できる`);
+  return m[1];
+}
+
+function makeFixture() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'preview-test-'));
+  const cityDir = path.join(dir, 'facilities', '東京都', '千代田区');
+  fs.mkdirSync(cityDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(cityDir, 'data.json'),
+    JSON.stringify({
+      meta: { updated: 1749600000 },
+      data: [
+        { name: '店A', business_type: '飲食店営業', address: '千代田区丸の内1-1', lat: 35.681, lng: 139.767, geocoding_level: 8 },
+      ],
+    }),
+  );
+  return dir;
+}
+
+test('source-layer が gen-tiles の出力レイヤ名(metadata.vector_layers[0].id)と一致する', () => {
+  const sourceLayer = htmlValue(/'source-layer':\s*'([^']+)'/, "source-layer");
+  const dir = makeFixture();
+  try {
+    const outDir = path.join(dir, 'tiles');
+    generateTiles({ minZoom: 6, maxZoom: 12, facilitiesDir: path.join(dir, 'facilities'), outDir });
+    const meta = JSON.parse(fs.readFileSync(path.join(outDir, 'metadata.json'), 'utf-8'));
+    assert.equal(sourceLayer, meta.vector_layers[0].id, `source-layer(${sourceLayer}) == 生成レイヤ(${meta.vector_layers[0].id})`);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('TILE_MIN_ZOOM / TILE_MAX_ZOOM が gen-tiles の既定ズーム範囲と一致する', () => {
+  const minZoom = Number(htmlValue(/TILE_MIN_ZOOM\s*=\s*(\d+)/, 'TILE_MIN_ZOOM'));
+  const maxZoom = Number(htmlValue(/TILE_MAX_ZOOM\s*=\s*(\d+)/, 'TILE_MAX_ZOOM'));
+  const dir = makeFixture();
+  try {
+    const outDir = path.join(dir, 'tiles');
+    // 既定のズーム範囲(scripts/gen-tiles.js の MIN_ZOOM/MAX_ZOOM)で生成する。
+    generateTiles({ facilitiesDir: path.join(dir, 'facilities'), outDir });
+    const meta = JSON.parse(fs.readFileSync(path.join(outDir, 'metadata.json'), 'utf-8'));
+    assert.equal(minZoom, meta.minzoom, `TILE_MIN_ZOOM(${minZoom}) == metadata.minzoom(${meta.minzoom})`);
+    assert.equal(maxZoom, meta.maxzoom, `TILE_MAX_ZOOM(${maxZoom}) == metadata.maxzoom(${meta.maxzoom})`);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('タイルURLテンプレートが「api/tiles/ + metadata.tiles[0]」の配置と一致する', () => {
+  const dir = makeFixture();
+  try {
+    const outDir = path.join(dir, 'tiles');
+    generateTiles({ minZoom: 6, maxZoom: 12, facilitiesDir: path.join(dir, 'facilities'), outDir });
+    const meta = JSON.parse(fs.readFileSync(path.join(outDir, 'metadata.json'), 'utf-8'));
+    const expectedPath = `api/tiles/${meta.tiles[0]}`; // = api/tiles/{z}/{x}/{y}.pbf
+    assert.ok(HTML.includes(expectedPath), `index.html がタイルパス ${expectedPath} を参照する`);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('ポップアップで参照する施設属性がすべて生成featureに存在する', () => {
+  const dir = makeFixture();
+  try {
+    const fc = buildFeatureCollection(path.join(dir, 'facilities'));
+    const props = fc.features[0].properties;
+    // index.html が p.<prop> として参照している属性を抽出する。
+    const referenced = new Set(
+      [...HTML.matchAll(/\bp\.([a-z_]+)\b/g)].map((m) => m[1]),
+    );
+    assert.ok(referenced.size >= 3, `index.html が施設属性を参照している (${[...referenced].join(',')})`);
+    for (const key of referenced) {
+      assert.ok(key in props, `属性 ${key} が生成feature.properties に存在する`);
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+console.log(`\n✅ preview-map 整合性テスト: ${passed}件すべて合格`);


### PR DESCRIPTION
## 背景・解決したい課題
- 配信中のデータ（施設オープンデータ）を、実際に地図上でどう見えるか手軽に確認する手段が無かった。
- GitHub Pages のトップ（`https://gl20percentclub.github.io/japan-facilities-api/`）は現状 index が無く 404。ここをプレビュー地図にすれば、配信物の入口も兼ねられる。

## 変更内容
- リポジトリ直下に `index.html` を追加。gh-pages は `publish_dir: .` で配信されるため、置くだけで Pages のトップページになる。
- 国土地理院・淡色地図をベースに、配信済みのベクトルタイル `api/tiles/{z}/{x}/{y}.pbf`（layer `facilities`）を重ねて全国の施設点を表示。
- 施設点クリックで名称・業種・所在地をポップアップ表示。ヘッダーに `api/facilities/index.json` から取得した都道府県数・市区町村数・最終更新日をライブ表示。
- タイルは z6〜12 のため、ズーム6未満では案内バナーを表示（ズームで自動的に消える）。
- `index.html` と `gen-tiles.js` の整合性テスト（`scripts/preview-map.test.js`）を追加し `npm test` に組み込み。

## 採用したアプローチと意図
- **ベクトルタイルを正面から利用**: 施設は70万件超で、GeoJSON 一括読み込みは非現実的。本リポジトリは既に地図配信用のベクトルタイルを生成しており、それをそのまま使うのが最も軽量かつ設計意図に沿う。
- **API キー不要構成**: 公開 gh-pages に秘密情報を置けないため、ベース地図は国土地理院タイル、地図ライブラリは MapLibre GL JS（CDN）で構成。Geolonia の embed は API キーが必要なため今回は不採用。
- **`index.html` を直下に追加するだけ**: 別途デプロイ用ワークフローを足すと `publish_dir: .`（生成物 `api/` を含む）と競合し得るため、既存のクロール deploy に相乗りする形にした。

## テスト
- ユニット/整合性テスト（`scripts/preview-map.test.js`, 4件）を追加。`gen-tiles.js` の生成物（metadata・feature）と `index.html` の記述（source-layer 名・ズーム範囲・タイルパス・参照する施設属性）が食い違ったら失敗する。将来 `gen-tiles.js` 側を変えて地図が黙って壊れる回帰を防ぐ。
- 手動確認: ローカルでサンプルタイルを生成し、Playwright で描画を検証。施設点5件が描画・属性正確・クリックでポップアップ表示・ヘッダー統計反映・ズームヒントの表示制御を確認。
- 既存の全テストスイート（crawl/config/gen-tiles/test.js/readme-stats）green を確認（`api/` を最小生成して `test.js` 含め全合格）。

## 確認してほしいポイント
- ⚠️ **本番反映のタイミング**: gh-pages への配信はクロール workflow（`schedule` / `workflow_dispatch`）でのみ行われる。本番にはまだ `api/tiles/` が無い（`gen-tiles.js` は最近追加）。マージ後の次回クロールで `index.html` とタイルが同時に配信され、その時点で地図が動く。今すぐ出す場合は Actions の "Crawl Facilities" を `dry_run=true` で手動実行すればよい。
- ℹ️ このリポジトリの CI（`crawl.yml`）は PR/push では起動しないため、本 PR には自動チェックが付かない（ローカルで全テスト green を確認済み）。