### PR TITLE
堺市の座標付与失敗を解消し、プレースホルダ住所をジオコーディング対象外にする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ node_modules/
 api/
 # gen-bodik-sources.mjs の生成中間物（手動マージ用）
 config/_bodik-generated.yaml
+# 分析用の出力（コミットしない）
+analysis/

--- a/config/sources.yaml
+++ b/config/sources.yaml
@@ -297,6 +297,10 @@ sources:
     source: 堺市 堺市 食品営業許可施設一覧（令和8年4月1日現在）
     sourceUrl: https://data.bodik.jp/dataset/f861e58c-ee2b-4a8c-8bc7-db9f70431b4b
     license: Creative Commons Attribution 4.0 International
+    # 住所が区名始まり（例「堺区戎島町…」）で市名を含まないため、既定値で「大阪府堺市」を
+    # 前置しないとジオコーダが政令区を解決できず座標付与に失敗する。
+    defaultPref: 大阪府
+    defaultCity: 堺市
   - key: bodik-796b84b4
     acquire:
       type: ckan

--- a/scripts/analyze-geocoding.mjs
+++ b/scripts/analyze-geocoding.mjs
@@ -1,0 +1,229 @@
+// ジオコーディング検証スクリプト（分析用・非コミット出力）
+//
+// config/sources.yaml の全ソースを取得・パースし、施設住所を
+// @geolonia/normalize-japanese-addresses(nja) で正規化＆ジオコーディングする。
+// 正規化後の住所でユニーク化（同一住所は1行に集約し件数を数える）し、結果を CSV に出力する。
+//
+// 出力（analysis/ 配下・Git管理外）:
+//   analysis/all.csv        全ユニーク住所（座標付与の成否 has_coord つき）
+//   analysis/no-coord.csv   座標を付与できなかった住所だけ（原因分析用・reason 付き）
+//
+// 使い方:
+//   node scripts/analyze-geocoding.mjs                全ソース
+//   node scripts/analyze-geocoding.mjs --only=osaka-city,okinawa-bodik   指定ソースのみ
+//   node scripts/analyze-geocoding.mjs --concurrency=8
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { normalize, config as njaConfig } from '@geolonia/normalize-japanese-addresses';
+import { loadConfig, ROOT } from './lib/config.js';
+import { acquire } from './lib/acquire.js';
+import { parseSource } from './lib/parse.js';
+import { mapRecord, toFacility, resolvePrefecture, resolveCity } from './lib/normalize.js';
+import { geocodeQuery } from './lib/geocode.js';
+
+const CACHE_DIR = path.join(ROOT, '.cache');
+const OUT_DIR = path.join(ROOT, 'analysis');
+
+const ONLY = (() => {
+  const a = process.argv.find((x) => x.startsWith('--only='));
+  return a ? new Set(a.slice(7).split(',').map((s) => s.trim()).filter(Boolean)) : null;
+})();
+const CONCURRENCY = (() => {
+  const a = process.argv.find((x) => x.startsWith('--concurrency='));
+  return a ? parseInt(a.split('=')[1], 10) : 8;
+})();
+
+const csvCell = (v) => {
+  if (v === null || v === undefined) return '';
+  const s = String(v);
+  return /[",\r\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+};
+const writeCsv = (file, columns, rows) => {
+  const out = fs.createWriteStream(file, { encoding: 'utf-8' });
+  out.write('﻿'); // Excel 互換 BOM
+  out.write(columns.join(',') + '\n');
+  for (const r of rows) out.write(columns.map((c) => csvCell(r[c])).join(',') + '\n');
+  return new Promise((res) => out.end(res));
+};
+
+// 並列ワーカープール
+async function runPool(items, concurrency, worker) {
+  let next = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+      while (next < items.length) {
+        const i = next++;
+        await worker(items[i], i);
+      }
+    }),
+  );
+}
+
+// nja 結果（座標なし）の失敗理由を分類する。
+function classifyFailure(r) {
+  if (!r) return '正規化結果なし';
+  if (!r.pref) return '都道府県も未特定';
+  if (!r.city) return '都道府県のみ（市区町村未特定）';
+  if (!r.town) return '市区町村まで（町字未特定）';
+  return '町字まで（座標なし）';
+}
+
+async function main() {
+  const { sources: allSources, columnMap } = loadConfig();
+  const sources = allSources.filter((s) => !ONLY || ONLY.has(s.key));
+  console.log(`ジオコーディング検証: 対象ソース ${sources.length}件${ONLY ? `（--only）` : ''}\n`);
+
+  // 1) 取得・パース・正規化(内部キー化) → 施設の住所クエリを収集
+  const facilities = []; // { name, rawAddress, pref, city, query, source, srcLat, srcLng }
+  const skipped = [];
+  for (const source of sources) {
+    try {
+      const files = await acquire(source, { cacheDir: CACHE_DIR, dryRun: false });
+      let kept = 0;
+      for (const { cachePath, format } of files) {
+        const rawRecords = await parseSource(source, cachePath, format, columnMap);
+        for (const raw of rawRecords) {
+          const rec = mapRecord(raw, columnMap);
+          const f = toFacility(rec);
+          if (!f) continue;
+          const pref = resolvePrefecture(rec, source);
+          const city = resolveCity(rec, source);
+          const query = geocodeQuery({ address: f.address, _pref: pref, _city: city });
+          if (!query) continue;
+          facilities.push({
+            name: f.name,
+            rawAddress: f.address,
+            pref,
+            city,
+            query,
+            source: source.source,
+            srcLat: f.lat,
+            srcLng: f.lng,
+          });
+          kept++;
+        }
+      }
+      console.log(`  ✓ ${source.key}: ${kept}件`);
+    } catch (err) {
+      skipped.push({ key: source.key, source: source.source, error: err.message });
+      console.log(`  ⚠ ${source.key} スキップ: ${err.message}`);
+    }
+  }
+  console.log(`\n収集: ${facilities.length}施設 / スキップ ${skipped.length}ソース`);
+
+  // 2) ユニークな住所クエリを nja で正規化＆ジオコーディング（クエリ単位でキャッシュ）
+  njaConfig.cacheSize = 100000;
+  const uniqueQueries = [...new Set(facilities.map((f) => f.query))];
+  console.log(`ユニーク住所クエリ: ${uniqueQueries.length}件 を正規化中...`);
+
+  const resultByQuery = new Map(); // query -> { ok, lat, lng, level, npref, ncity, ntown, naddr, normAddr, reason }
+  let done = 0;
+  await runPool(uniqueQueries, CONCURRENCY, async (q) => {
+    let entry;
+    try {
+      const r = await normalize(q);
+      const npref = r?.pref || '';
+      const ncity = r?.city || '';
+      const ntown = r?.town || '';
+      const naddr = r?.addr || '';
+      const normAddr = `${npref}${ncity}${ntown}${naddr}`;
+      if (r && r.point && Number.isFinite(r.point.lat) && Number.isFinite(r.point.lng)) {
+        entry = { ok: true, lat: r.point.lat, lng: r.point.lng, level: r.point.level ?? r.level ?? null, npref, ncity, ntown, naddr, normAddr };
+      } else {
+        entry = { ok: false, lat: null, lng: null, level: r?.level ?? null, npref, ncity, ntown, naddr, normAddr, reason: classifyFailure(r) };
+      }
+    } catch (e) {
+      entry = { ok: false, lat: null, lng: null, level: null, npref: '', ncity: '', ntown: '', naddr: '', normAddr: '', reason: `正規化エラー: ${e.message}` };
+    }
+    resultByQuery.set(q, entry);
+    if (++done % 20000 === 0) console.log(`    ...${done}/${uniqueQueries.length}`);
+  });
+
+  // 3) 正規化後の住所でユニーク化して集約
+  const byNorm = new Map(); // normKey -> aggregate
+  for (const f of facilities) {
+    const res = resultByQuery.get(f.query);
+    // 正規化に成功していれば正規化住所で、失敗していれば元クエリで束ねる
+    const key = res.normAddr || `【未正規化】${f.query}`;
+    let a = byNorm.get(key);
+    if (!a) {
+      a = {
+        normalized_address: res.normAddr,
+        pref: res.npref,
+        city: res.ncity,
+        town: res.ntown,
+        addr: res.naddr,
+        level: res.level,
+        has_coord: res.ok ? 1 : 0,
+        lat: res.lat,
+        lng: res.lng,
+        reason: res.ok ? '' : res.reason,
+        src_lat: null,
+        src_lng: null,
+        dup_count: 0,
+        _names: new Set(),
+        sample_name: f.name,
+        sample_raw_address: f.rawAddress,
+        _sources: new Set(),
+      };
+      byNorm.set(key, a);
+    }
+    a.dup_count++;
+    a._names.add(f.name);
+    a._sources.add(f.source);
+    if (a.src_lat == null && f.srcLat != null) {
+      a.src_lat = f.srcLat;
+      a.src_lng = f.srcLng;
+    }
+  }
+
+  const rows = [...byNorm.values()].map((a) => ({
+    ...a,
+    sources: [...a._sources].join('; '),
+    has_src_coord: a.src_lat != null ? 1 : 0,
+  }));
+  rows.sort((x, y) => y.dup_count - x.dup_count);
+
+  // 4) CSV 出力
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  const ALL_COLS = ['normalized_address', 'pref', 'city', 'town', 'addr', 'level', 'has_coord', 'lat', 'lng', 'src_lat', 'src_lng', 'dup_count', 'sample_name', 'sample_raw_address', 'sources'];
+  const NO_COORD_COLS = ['normalized_address', 'reason', 'level', 'has_src_coord', 'src_lat', 'src_lng', 'pref', 'city', 'dup_count', 'sample_name', 'sample_raw_address', 'sources'];
+
+  await writeCsv(path.join(OUT_DIR, 'all.csv'), ALL_COLS, rows);
+  const failures = rows.filter((r) => !r.has_coord);
+  await writeCsv(path.join(OUT_DIR, 'no-coord.csv'), NO_COORD_COLS, failures);
+
+  // 5) サマリ（原因分析の手がかり）
+  const uniqAddr = rows.length;
+  const failAddr = failures.length;
+  const failRecords = failures.reduce((n, r) => n + r.dup_count, 0);
+  const byReason = {};
+  const byPref = {};
+  let failButSrcCoord = 0;
+  for (const r of failures) {
+    byReason[r.reason] = (byReason[r.reason] || 0) + 1;
+    byPref[r.pref || '(都道府県不明)'] = (byPref[r.pref || '(都道府県不明)'] || 0) + 1;
+    if (r.has_src_coord) failButSrcCoord++;
+  }
+
+  console.log(`\n===== サマリ =====`);
+  console.log(`施設レコード: ${facilities.length}`);
+  console.log(`ユニーク住所: ${uniqAddr}（うち座標付与できた: ${uniqAddr - failAddr} / できなかった: ${failAddr}）`);
+  console.log(`座標付与できなかった住所に紐づく施設レコード数: ${failRecords}`);
+  console.log(`  └ うち元データには座標があった住所: ${failButSrcCoord}（nja辞書に無いだけの可能性が高い）`);
+  console.log(`\n失敗理由の内訳（ユニーク住所数）:`);
+  for (const [k, v] of Object.entries(byReason).sort((a, b) => b[1] - a[1])) console.log(`  ${String(v).padStart(7)}  ${k}`);
+  console.log(`\n失敗が多い都道府県 top15:`);
+  for (const [k, v] of Object.entries(byPref).sort((a, b) => b[1] - a[1]).slice(0, 15)) console.log(`  ${String(v).padStart(7)}  ${k}`);
+  if (skipped.length) {
+    console.log(`\nスキップしたソース ${skipped.length}件:`);
+    for (const s of skipped) console.log(`  ${s.key}: ${s.error}`);
+  }
+  console.log(`\n出力: analysis/all.csv (${uniqAddr}行) / analysis/no-coord.csv (${failAddr}行)`);
+}
+
+main().catch((err) => {
+  console.error('\n❌ エラー:', err.stack || err.message);
+  process.exit(1);
+});

--- a/scripts/crawl.js
+++ b/scripts/crawl.js
@@ -216,6 +216,6 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 }
 
 // テスト用に純粋関数を再エクスポートする（公開面は従来どおり）。
-export { normalizeDate, sanitizeLatLng, resolvePrefecture, resolveCity, mapRecord, toFacility, splitPrefCity } from './lib/normalize.js';
+export { normalizeDate, sanitizeLatLng, resolvePrefecture, resolveCity, mapRecord, toFacility, splitPrefCity, isPlaceholderAddress } from './lib/normalize.js';
 export { parseCSVText } from './lib/parse.js';
 export { fetchWithRetry, resolveLinkFromHtml } from './lib/acquire.js';

--- a/scripts/crawl.test.js
+++ b/scripts/crawl.test.js
@@ -16,6 +16,7 @@ import {
   findEmptySources,
   fetchWithRetry,
   resolveLinkFromHtml,
+  isPlaceholderAddress,
 } from './crawl.js';
 
 let passed = 0;
@@ -147,6 +148,20 @@ test('splitPrefCity: 市名が「市」で終わる市（二重の市）', () =>
 test('splitPrefCity: 都道府県で始まらなければ null', () => {
   assert.deepEqual(splitPrefCity('足寄町南三条'), [null, null]);
   assert.deepEqual(splitPrefCity(''), [null, null]);
+});
+
+// --- isPlaceholderAddress: 実体のない住所（一円・管内・空欄等）の判定 ---
+test('isPlaceholderAddress: プレースホルダを true と判定', () => {
+  for (const s of ['', '   ', '市内一円', '県内一円', '県下一円', '堺市内一円', '富山県内一円',
+    '県下一円（ただし、神戸市、姫路市を除く）', '北部保健所管内', '（露店営業）', '那覇市内']) {
+    assert.equal(isPlaceholderAddress(s), true, `placeholder: «${s}»`);
+  }
+});
+test('isPlaceholderAddress: 実住所は false と判定', () => {
+  for (const s of ['大阪府堺市中区深阪3丁10-59', '那覇市松山1-9-9', '港区赤坂一丁目1番',
+    '丸の内2-1-1', '足寄郡足寄町南三条']) {
+    assert.equal(isPlaceholderAddress(s), false, `real: «${s}»`);
+  }
 });
 
 // --- findEmptySources: 施設0件のソース検知 ---

--- a/scripts/lib/geocode.js
+++ b/scripts/lib/geocode.js
@@ -6,6 +6,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { normalize, config as njaConfig } from '@geolonia/normalize-japanese-addresses';
 import { ROOT } from './config.js';
+import { isPlaceholderAddress } from './normalize.js';
 
 const CACHE_DIR = path.join(ROOT, '.cache');
 const GEOCODE_CACHE_PATH = path.join(CACHE_DIR, 'geocode-cache.json');
@@ -56,7 +57,14 @@ async function runPool(items, concurrency, worker) {
 
 // 緯度経度の無い施設を住所からジオコーディングして補完する（facilities を破壊的に更新）。
 export async function enrichWithGeocoding(facilities, { concurrency = GEOCODE_CONCURRENCY } = {}) {
-  const targets = facilities.filter((f) => (f.lat == null || f.lng == null) && f.address);
+  // 座標が無く、かつ住所が実体を持つ施設だけをジオコーディング対象にする。
+  // 「市内一円」等のプレースホルダ住所は誤った代表点が付くのを避けて対象外にする（座標null）。
+  const needCoord = facilities.filter((f) => f.lat == null || f.lng == null);
+  const placeholders = needCoord.filter((f) => isPlaceholderAddress(f.address)).length;
+  const targets = needCoord.filter((f) => f.address && !isPlaceholderAddress(f.address));
+  if (placeholders > 0) {
+    console.log(`  プレースホルダ住所 ${placeholders}件 はジオコーディング対象外（座標null）`);
+  }
   if (targets.length === 0) {
     console.log('  座標補完が必要な施設はありません');
     return;

--- a/scripts/lib/normalize.js
+++ b/scripts/lib/normalize.js
@@ -192,6 +192,20 @@ export function sanitizeLatLng(lat, lng) {
   return [null, null]; // どちらでも日本域に収まらない → 無効
 }
 
+// 住所として実体を持たないプレースホルダを判定する。
+// 「市内一円」「県内一円」「県下一円」「○○保健所管内」「（露店営業）」空欄 などは、
+// 正規化しても都道府県の代表点(level 1)にしか落ちず施設位置として誤解を招くため、
+// ジオコーディング対象から除外する（座標は null のままにする）。
+export function isPlaceholderAddress(addr) {
+  const s = String(addr || '').trim();
+  if (!s) return true; // 空欄
+  if (/一円/.test(s)) return true; // 市内一円 / 県内一円 / 県下一円 / ○○内一円
+  if (/保健所管内/.test(s)) return true; // ○○保健所管内
+  if (/^[（(][^（(]*[)）]$/.test(s)) return true; // 「（露店営業）」等 括弧のみ
+  if (/(都|道|府|県|市|区|町|村)内$/.test(s)) return true; // 「那覇市内」等（住所続きなし）
+  return false;
+}
+
 // 安全なディレクトリ/ファイル名（スラッシュ等を除去）
 export function safeName(s) {
   return String(s).replace(/[\\/:*?"<>|]/g, '_').trim();


### PR DESCRIPTION
## 背景・解決したい課題

全ソース（83ソース・73万施設）を nja でジオコーディングして品質を調査したところ、**座標が全く付与できない住所 5,991件（施設9,653件）** が判明。原因は2つに切り分けられた。

- **堺市（失敗の96%＝5,762件）**: 住所が区名始まり（「堺区戎島町…」）で市名を含まず、`defaultPref`/`defaultCity` 未設定のため「大阪府堺市」を前置できず、ジオコーダが政令区を解決できていなかった。
- **プレースホルダ住所**: 「市内一円」「県下一円」「○○保健所管内」「（露店営業）」空欄 等は正規化しても都道府県の代表点(level 1)にしか落ちず、施設位置として誤解を招く座標が付いていた（level 1 は37,620施設）。

## 変更内容

1. **堺市に既定値を設定**（`config/sources.yaml`）: `defaultPref: 大阪府` / `defaultCity: 堺市`。
2. **プレースホルダ住所をジオコーディング対象外に**（`lib/normalize.js` の `isPlaceholderAddress` ＋ `lib/geocode.js`）。座標は付けず `null` のまま残す（検索索引・ベクトルタイルからも自然に除外される）。
3. **ジオコーディング検証スクリプトを追加**（`scripts/analyze-geocoding.mjs`）。今回の調査に使ったツールで、`analysis/all.csv`（座標付与できた住所）と `analysis/no-coord.csv`（できなかった住所・失敗理由つき）を出力する。

## 採用したアプローチと意図

- 全ソースを `.cache` から再パースして「都道府県が前置されないクエリ」を横断スキャンした結果、**市名始まりのソース（指宿市・桑名市・福岡市博多区…）は nja が市名から解決でき実際に失敗していない**。純粋に前置不足で失敗するのは**市名すら無い区名始まりの堺市のみ**だったため、既定値の追加は堺市に限定した（多ソースへの一律付与は誤った市名割り当てのリスクがあるため避けた）。
- プレースホルダは「除外（データから消す）」ではなく「座標 null で残す」方針。施設レコード自体は実在するため、位置情報だけを honest に空にする。

## テスト

- **ユニット追加**（`crawl.test.js`、計36件）: `isPlaceholderAddress` の判定（一円・管内・括弧のみ・空欄・「○○市内」を true、実住所を false）。
- **エンドツーエンド検証**: 堺市のみ実クロールし、修正後は**実住所9,228件すべてが座標付与成功（失敗0）**、プレースホルダ895件が対象外（座標null）になることを確認。
- `npm test`（全ユニット＋api/バリデーション＋stats）全緑。

## 確認してほしいポイント

- `isPlaceholderAddress` の判定パターン（誤検知しないか。特に `/(市|区|町|村|県|都|道|府)内$/` が実住所を弾かないか — 「丸の内」等は先頭文字が対象外なので false になることを確認済み）。
- プレースホルダを座標 null にすることで level 1 の施設が座標を失う（データの位置情報カバレッジは下がるが、誤った代表点を出さない方針でよいか）。

## 補足

- 静岡市の一部（「静岡県清水区…」と市名が抜けた表記）が level 1 に留まる別種の軽微な問題が残っている（1,071施設）。区が県直下に書かれるケースで、堺市とは別の対応が要るため本PRのスコープ外。
- 今回の調査で 15 ソースが取得失敗（うち9件は日付入りURLの陳腐化）していることも確認できた。これは既知の staleness 問題として別途対応予定。
