### PR TITLE
陳腐化した日付URLの9ソースを resolve 化で復旧し、resolve 取得を強化

### DIFF
--- a/config/sources.yaml
+++ b/config/sources.yaml
@@ -13,7 +13,13 @@
 #     { type: ckan, ckanBase, resourceId }        CKAN resource_show でURL解決
 #     { type: get,  url|urls, format?, encoding? } URLを直接GET（urls は複数結合）
 #     { type: post, url, body, format? }           フォームPOSTで取得（京都市 等）
-#     { type: resolve, pageUrl, linkPattern, format } 掲載ページのリンク文言から実URLを解決
+#     { type: resolve, pageUrl, linkPattern?, hrefPattern?, format } 掲載ページから最新の実URLを解決
+#         linkPattern <a> の表示テキストにマッチする正規表現 / hrefPattern href にマッチする正規表現
+#           （ファイル名で全件と新規・差分を区別する場合に使う）
+#         multi: true    一致した全リンクを取得（全件が複数ファイルに分割された自治体）
+#         hrefScan: true <a> に限らず生HTML中で hrefPattern に一致するURL/パスを拾う
+#                        （<button value="..."> 等 アンカー以外にURLが埋まっているページ向け）
+#         linkFormat     リンク抽出時の拡張子フィルタ（省略時は format。拡張子とパース形式が違う時に使う）
 #     { type: i2fasglob }                          .cache/i2fas/*.csv を一括取込（厚労省 i2fas）
 #     format:   csv | tsv | xlsx | xls（省略時はURL/CKAN情報から推定）
 #     encoding: utf-8 | shift_jis | utf-16 | auto（既定 auto）
@@ -446,10 +452,10 @@ sources:
     defaultCity: 札幌市
   - key: aomori-city
     acquire:
-      type: get
-      url: https://www.city.aomori.aomori.jp/_res/projects/default_project/_page_/001/006/184/r0805zendate.csv
+      type: resolve
+      pageUrl: https://www.city.aomori.aomori.jp/shisei/jouhokoukai/opendata/1006170/1006184.html
+      linkPattern: 全件
       format: csv
-      encoding: utf-8
     source: 青森市食品営業許可施設一覧
     sourceUrl: https://www.city.aomori.aomori.jp/shisei/jouhokoukai/opendata/1006170/1006184.html
     license: CC BY 4.0
@@ -468,8 +474,9 @@ sources:
     defaultCity: 盛岡市
   - key: akita-city
     acquire:
-      type: get
-      url: https://www.city.akita.lg.jp/_res/projects/default_project/_page_/001/017/339/r080601.xlsx
+      type: resolve
+      pageUrl: https://www.city.akita.lg.jp/kurashi/kenko/1005368/1010019/1017339.html
+      linkPattern: 食品営業許可施設一覧
       format: xlsx
     source: 秋田市食品営業許可施設一覧
     sourceUrl: https://www.city.akita.lg.jp/kurashi/kenko/1005368/1010019/1017339.html
@@ -478,10 +485,10 @@ sources:
     defaultCity: 秋田市
   - key: yamagata-city
     acquire:
-      type: get
-      url: https://www.city.yamagata-yamagata.lg.jp/_res/projects/default_project/_page_/001/012/802/062014_syokuhin_list_20260531.csv
+      type: resolve
+      pageUrl: https://www.city.yamagata-yamagata.lg.jp/kenkofukushi/eisei/1006555/1006558/1012802.html
+      linkPattern: 食品営業許可施設一覧（オープンデータ）
       format: csv
-      encoding: shift_jis
     source: 山形市食品営業許可・届出施設一覧
     sourceUrl: https://www.city.yamagata-yamagata.lg.jp/kenkofukushi/eisei/1006555/1006558/1012802.html
     license: CC BY 4.0
@@ -498,12 +505,12 @@ sources:
     defaultPref: 福島県
   - key: fukushima-city
     acquire:
-      type: get
-      url: https://www.city.fukushima.fukushima.jp/material/files/group/7/R7nendo_syokuhin.csv
+      type: resolve
+      pageUrl: https://www.city.fukushima.fukushima.jp/soshiki/2/1005/1/1/5/1_1/index.html
+      linkPattern: '^食品営業許可施設一覧（.+現在）'
       format: csv
-      encoding: utf-8
     source: 福島市食品営業許可施設一覧
-    sourceUrl: https://www.city.fukushima.fukushima.jp/soshiki/2/1005/1/1/5/7/2839.html
+    sourceUrl: https://www.city.fukushima.fukushima.jp/soshiki/2/1005/1/1/5/1_1/index.html
     license: CC BY 2.1 JP
     defaultPref: 福島県
     defaultCity: 福島市
@@ -691,10 +698,10 @@ sources:
     defaultCity: 東村山市
   - key: kawasaki
     acquire:
-      type: get
-      url: https://www.city.kawasaki.jp/350/cmsfiles/contents/0000093/93741/080503(UTF-8).csv
+      type: resolve
+      pageUrl: https://www.city.kawasaki.jp/350/page/0000093741.html
+      hrefPattern: '\d{4}03\(UTF-8\)\.csv$'
       format: csv
-      encoding: utf-8
     source: 川崎市食品営業許可施設情報
     sourceUrl: https://www.city.kawasaki.jp/350/page/0000093741.html
     license: CC BY 4.0
@@ -713,9 +720,11 @@ sources:
     defaultCity: 茅ヶ崎市
   - key: fujisawa
     acquire:
-      type: get
-      urls:
-        - https://www.city.fujisawa.kanagawa.jp/documents/28905/zende-ta2020603houjin.csv
+      type: resolve
+      pageUrl: https://www.city.fujisawa.kanagawa.jp/seiei/shokuhineisei/opendatabase.html
+      hrefPattern: 'zende-ta\d+(houjin|kojin)\.csv'
+      multi: true
+      linkFormat: csv
       format: tsv
       encoding: utf-16
     source: 藤沢市食品営業許可施設情報
@@ -777,8 +786,9 @@ sources:
     defaultPref: 福井県
   - key: fukui-city
     acquire:
-      type: get
-      url: https://www.city.fukui.lg.jp/fukusi/eisei/syokuhin/p070519_d/fil/11syokuhin_202605.xlsx
+      type: resolve
+      pageUrl: https://www.city.fukui.lg.jp/fukusi/eisei/syokuhin/p070519.html
+      hrefPattern: '11syokuhin_\d{6}\.xlsx$'
       format: xlsx
     source: 福井市食品営業許可施設一覧
     sourceUrl: https://www.city.fukui.lg.jp/sisei/tokei/opendata/opengov.html
@@ -816,6 +826,9 @@ sources:
     license: CC BY 4.0
     defaultPref: 長野県
     defaultCity: 長野市
+  # 注意: 配布元 linkdata.org が現在停止中（work/直リンクとも到達不可）。松本市サイト上に
+  # 代替の直接配布(CSV/XLSX)が無いため resolve 化できず、当面は取得失敗でスキップされる。
+  # linkdata.org 復活 or 市サイトでの直接配布開始を待って再設定する。
   - key: matsumoto
     acquire:
       type: get
@@ -892,10 +905,10 @@ sources:
     defaultCity: 一宮市
   - key: shiga-pref
     acquire:
-      type: get
-      urls:
-        - https://www.pref.shiga.lg.jp/file/attachment/5615791.csv
-        - https://www.pref.shiga.lg.jp/file/attachment/5615790.csv
+      type: resolve
+      pageUrl: https://www.pref.shiga.lg.jp/ippan/kurashi/syokunoanzen/300273.html
+      linkPattern: 食品営業許可施設一覧
+      multi: true
       format: csv
       encoding: shift_jis
     source: 滋賀県食品営業許可施設一覧
@@ -967,8 +980,10 @@ sources:
     defaultCity: 尼崎市
   - key: nishinomiya
     acquire:
-      type: get
-      url: http://opendata.nishi.or.jp/opendata/files/9/R8.5ichiran_syokuhin.xlsx
+      type: resolve
+      pageUrl: http://opendata.nishi.or.jp/opendata/ResultDetail.php?id=9
+      hrefScan: true
+      hrefPattern: 'files/9/R[0-9.]+ichiran_syokuhin\.xlsx'
       format: xlsx
     source: 西宮市食品営業許可施設一覧
     sourceUrl: http://opendata.nishi.or.jp/opendata/ResultDetail.php?id=9

--- a/scripts/crawl.test.js
+++ b/scripts/crawl.test.js
@@ -261,6 +261,28 @@ test('resolveLinkFromHtml: href の &amp; を復元', () => {
   assert.equal(hit.url, 'https://x/dl?id=1&t=x.csv');
 });
 
+// href でファイル名から全件/新規を区別する（表示テキストが同じでも href で絞れる）。
+const HREF_HTML = `
+  <a href="/d/11syokuhin_202606.xlsx">営業許可施設一覧（令和8年6月末現在）</a>
+  <a href="/d/12syokuhinhaigyo_202606.xlsx">廃業施設一覧（令和8年6月末現在）</a>`;
+test('resolveLinkFromHtml: hrefPattern で全件のみに絞る', () => {
+  const hit = resolveLinkFromHtml(HREF_HTML, { hrefPattern: '11syokuhin_\\d{6}\\.xlsx$', format: 'xlsx', baseUrl: 'https://x/' });
+  assert.equal(hit.count, 1);
+  assert.equal(hit.url, 'https://x/d/11syokuhin_202606.xlsx');
+});
+
+// multi 取得用に、一致した全リンクを all で返す。
+const MULTI_HTML = `
+  <a href="/f/5622702.csv">（～令和3年5月31日）食品営業許可施設一覧</a>
+  <a href="/f/5622703.csv">（令和3年6月1日～）食品営業許可施設一覧</a>
+  <a href="/f/9999.csv">理容所一覧</a>`;
+test('resolveLinkFromHtml: 複数一致を all で返す', () => {
+  const hit = resolveLinkFromHtml(MULTI_HTML, { pattern: '食品営業許可施設一覧', format: 'csv', baseUrl: 'https://x/' });
+  assert.equal(hit.count, 2);
+  assert.equal(hit.all.length, 2);
+  assert.deepEqual(hit.all.map((h) => h.url), ['https://x/f/5622702.csv', 'https://x/f/5622703.csv']);
+});
+
 const runAsync = async () => {
   for (const { name, fn } of asyncTests) {
     await fn();

--- a/scripts/lib/acquire.js
+++ b/scripts/lib/acquire.js
@@ -30,13 +30,23 @@ export async function fetchCkanResourceInfo(ckanBase, resourceId, attempt = 0) {
   return json.result; // { url, format, ... }
 }
 
-// キャッシュ済みファイルを拡張子から探す（dry-run で CKAN 問い合わせを避けるため）
-function findCachedFile(cacheDir, key) {
-  for (const ext of ['csv', 'tsv', 'xlsx', 'xls']) {
+// キャッシュ済みファイルを拡張子から探す（dry-run で CKAN 問い合わせ・リンク解決を避けるため）。
+// `key.ext` に加え、multi 取得の `key-0.ext` `key-1.ext` … も拾う。
+function findCachedFiles(cacheDir, key) {
+  const exts = ['csv', 'tsv', 'xlsx', 'xls'];
+  const found = [];
+  for (const ext of exts) {
     const p = path.join(cacheDir, `${key}.${ext}`);
-    if (fs.existsSync(p)) return { cachePath: p, format: ext };
+    if (fs.existsSync(p)) found.push({ cachePath: p, format: ext });
   }
-  return null;
+  for (let j = 0; ; j++) {
+    const hit = exts
+      .map((ext) => ({ cachePath: path.join(cacheDir, `${key}-${j}.${ext}`), format: ext }))
+      .find((c) => fs.existsSync(c.cachePath));
+    if (!hit) break;
+    found.push(hit);
+  }
+  return found;
 }
 
 // HTTP GET/POST をリトライ付きで実行し、本文を ArrayBuffer で返す。
@@ -77,10 +87,16 @@ function decodeHtmlEntities(s) {
     .replace(/&nbsp;/g, ' ');
 }
 
-// HTML から、リンク文言が pattern に一致する <a href> を1件解決する。
-// 返り値: { url, text, count }（一致0件なら null。複数時は先頭を採用）
-export function resolveLinkFromHtml(htmlText, { pattern, format, baseUrl } = {}) {
+// HTML から、条件に一致する <a href> を解決する。
+//   pattern      リンク表示テキストにマッチさせる正規表現文字列（任意）
+//   hrefPattern  href にマッチさせる正規表現文字列（任意。ファイル名で全件/差分を区別する場合に使う）
+//   format       href の拡張子で絞り込む（'xlsx' 等。任意）
+//   baseUrl      相対 href を絶対化する基準
+// 返り値: { url, text, count, all }（一致0件なら null）。
+//   url/text は先頭一致。all は全一致の [{url,text}]（multi 取得に使う）。
+export function resolveLinkFromHtml(htmlText, { pattern, hrefPattern, format, baseUrl } = {}) {
   const textRe = pattern ? new RegExp(pattern, 'i') : null;
+  const hrefRe = hrefPattern ? new RegExp(hrefPattern, 'i') : null;
   const extRe = format ? new RegExp(`\\.${format}(?:$|[?#])`, 'i') : null;
   const anchorRe = /<a\b[^>]*\shref="([^"]+)"[^>]*>([\s\S]*?)<\/a>/gi;
   const candidates = [];
@@ -90,12 +106,13 @@ export function resolveLinkFromHtml(htmlText, { pattern, format, baseUrl } = {})
     const text = decodeHtmlEntities(m[2].replace(/<[^>]+>/g, '')).replace(/\s+/g, ' ').trim();
     if (extRe && !extRe.test(href)) continue;
     if (textRe && !textRe.test(text)) continue;
+    if (hrefRe && !hrefRe.test(href)) continue;
     candidates.push({ href, text });
   }
   if (candidates.length === 0) return null;
-  const { href, text } = candidates[0];
-  const url = baseUrl ? new URL(href, baseUrl).toString() : href;
-  return { url, text, count: candidates.length };
+  const toUrl = (c) => ({ url: baseUrl ? new URL(c.href, baseUrl).toString() : c.href, text: c.text });
+  const all = candidates.map(toUrl);
+  return { ...all[0], count: candidates.length, all };
 }
 
 // ZIP バイト列から対象の csv/xlsx/xls を取り出す。
@@ -128,43 +145,10 @@ export async function acquire(source, { cacheDir, dryRun = false } = {}) {
   const urls = a.urls || (a.url ? [a.url] : [null]); // ckan は url なしで resourceId 解決
   const results = [];
 
-  for (let i = 0; i < urls.length; i++) {
-    const suffix = urls.length > 1 ? `-${i}` : '';
-    const key = `${source.key}${suffix}`;
-
-    // dry-run はキャッシュのみ使用。CKAN 問い合わせをせず拡張子からファイルを特定する。
-    if (dryRun) {
-      const hit = findCachedFile(cacheDir, key);
-      if (!hit) throw new Error(`--dry-run ですがキャッシュが存在しません: ${key}`);
-      console.log(`  [dry-run] キャッシュを使用: ${hit.cachePath}`);
-      results.push(hit);
-      continue;
-    }
-
-    let downloadUrl = urls[i];
-    let format = (a.format || '').toLowerCase();
-
-    if (a.type === 'ckan') {
-      const info = await fetchCkanResourceInfo(a.ckanBase, a.resourceId);
-      downloadUrl = info.url;
-      if (!format) format = (info.format || '').toLowerCase();
-    }
-    // resolve: 掲載ページ(pageUrl)を取得し、リンク文言が linkPattern に一致する
-    // <a href> を実ダウンロードURLとして解決する（ファイル名に日時が入る自治体向け）。
-    if (a.type === 'resolve') {
-      console.log(`  リンク解決中: ${a.pageUrl}`);
-      const html = Buffer.from(await fetchWithRetry(a.pageUrl, { headers: { ...DEFAULT_HEADERS } })).toString('utf-8');
-      const hit = resolveLinkFromHtml(html, { pattern: a.linkPattern, format, baseUrl: a.pageUrl });
-      if (!hit) {
-        throw new Error(
-          `リンク解決に失敗: ${a.pageUrl} に「${a.linkPattern || '(指定なし)'}」に一致する` +
-            `${format ? ` .${format}` : ''} リンクが見つかりません`,
-        );
-      }
-      if (hit.count > 1) console.log(`  ⚠ ${hit.count}件一致。先頭を採用: 「${hit.text}」`);
-      console.log(`  リンク解決: 「${hit.text}」 -> ${hit.url}`);
-      downloadUrl = hit.url;
-    }
+  // 1URLを取得して .cache に保存し {cachePath, format} を返す。
+  // 形式はヒント fmt を優先し、無ければ拡張子から推定。zip は中身を展開する。
+  async function downloadOne(downloadUrl, key, fmt) {
+    let format = (fmt || '').toLowerCase();
     if (!format) {
       const mm = String(downloadUrl).toLowerCase().match(/\.(csv|tsv|txt|xlsx|xls|zip)(?:$|\?)/);
       format = mm ? mm[1] : 'csv';
@@ -193,7 +177,82 @@ export async function acquire(source, { cacheDir, dryRun = false } = {}) {
     fs.mkdirSync(cacheDir, { recursive: true });
     fs.writeFileSync(cachePath, buf);
     console.log(`  キャッシュに保存: ${cachePath} (${buf.length} bytes)`);
-    results.push({ cachePath, format });
+    return { cachePath, format };
+  }
+
+  for (let i = 0; i < urls.length; i++) {
+    const suffix = urls.length > 1 ? `-${i}` : '';
+    const key = `${source.key}${suffix}`;
+
+    // dry-run はキャッシュのみ使用。CKAN 問い合わせをせず拡張子からファイルを特定する。
+    if (dryRun) {
+      const hits = findCachedFiles(cacheDir, key);
+      if (hits.length === 0) throw new Error(`--dry-run ですがキャッシュが存在しません: ${key}`);
+      for (const hit of hits) {
+        console.log(`  [dry-run] キャッシュを使用: ${hit.cachePath}`);
+        results.push(hit);
+      }
+      continue;
+    }
+
+    let downloadUrl = urls[i];
+    const format = (a.format || '').toLowerCase();
+
+    if (a.type === 'ckan') {
+      const info = await fetchCkanResourceInfo(a.ckanBase, a.resourceId);
+      downloadUrl = info.url;
+      results.push(await downloadOne(downloadUrl, key, format || (info.format || '').toLowerCase()));
+      continue;
+    }
+
+    // resolve: 掲載ページ(pageUrl)を取得し、最新のダウンロードURLを解決する（日付でURLが変わる自治体向け）。
+    //   linkPattern  <a> の表示テキストにマッチ / hrefPattern  href にマッチ（ファイル名で全件/差分を区別）
+    //   multi:true   一致した全リンクを取得（全件が複数ファイルに分割された自治体）
+    //   hrefScan:true <a> に限らず生HTML中で hrefPattern に一致するURL/パスを拾う
+    //                 （<button value="..."> 等 アンカー以外にURLが埋まっているページ向け）
+    if (a.type === 'resolve') {
+      console.log(`  リンク解決中: ${a.pageUrl}`);
+      const html = Buffer.from(await fetchWithRetry(a.pageUrl, { headers: { ...DEFAULT_HEADERS } })).toString('utf-8');
+      const linkFmt = (a.linkFormat || format || '').toLowerCase();
+      let resolvedUrls;
+
+      if (a.hrefScan) {
+        if (!a.hrefPattern) throw new Error(`resolve hrefScan には hrefPattern が必要です: ${source.key}`);
+        const re = new RegExp(a.hrefPattern, 'ig');
+        const seen = new Set();
+        let mm;
+        while ((mm = re.exec(html))) seen.add(new URL(mm[0], a.pageUrl).toString());
+        resolvedUrls = [...seen];
+        if (resolvedUrls.length === 0) {
+          throw new Error(`リンク解決に失敗: ${a.pageUrl} に hrefPattern「${a.hrefPattern}」に一致するURLがありません`);
+        }
+        console.log(`  リンク解決(hrefScan): ${resolvedUrls.length}件`);
+      } else {
+        const hit = resolveLinkFromHtml(html, { pattern: a.linkPattern, hrefPattern: a.hrefPattern, format: linkFmt, baseUrl: a.pageUrl });
+        if (!hit) {
+          throw new Error(
+            `リンク解決に失敗: ${a.pageUrl} に「${a.linkPattern || a.hrefPattern || '(指定なし)'}」に一致する` +
+              `${linkFmt ? ` .${linkFmt}` : ''} リンクが見つかりません`,
+          );
+        }
+        resolvedUrls = a.multi ? hit.all.map((h) => h.url) : [hit.url];
+        if (a.multi) console.log(`  リンク解決: ${hit.count}件を取得`);
+        else {
+          if (hit.count > 1) console.log(`  ⚠ ${hit.count}件一致。先頭を採用: 「${hit.text}」`);
+          console.log(`  リンク解決: 「${hit.text}」 -> ${hit.url}`);
+        }
+      }
+
+      if (a.multi || a.hrefScan) {
+        for (let j = 0; j < resolvedUrls.length; j++) {
+          results.push(await downloadOne(resolvedUrls[j], `${key}-${j}`, format));
+        }
+        continue;
+      }
+      downloadUrl = resolvedUrls[0];
+    }
+
+    results.push(await downloadOne(downloadUrl, key, format));
   }
   return results;
 }


### PR DESCRIPTION
## 背景・解決したい課題

ファイル名に日付/年月が入る直リンク（例: `r0805zendate.csv`、`11syokuhin_202605.xlsx`）は、自治体が翌月のファイルを**別URL**で公開すると旧URLが 404 になり取得できなくなる。全ソースのジオコーディング調査で、この陳腐化により **9ソースが実際に 404 で取得失敗**していることが判明した（青森・秋田・山形・福島市・川崎・藤沢・福井市・滋賀・西宮）。

## 変更内容

日付URLを直接ピン留めするのをやめ、**掲載ページから毎回最新リンクを解決する `resolve` 型**へ9ソースを移行。あわせて `resolve` を強化した。

**resolve 取得の強化（`lib/acquire.js`）**
- `hrefPattern`: href（ファイル名）にマッチする正規表現。表示テキストが同じでも全件/新規・差分・廃業をファイル名で区別できる。
- `multi`: 一致した全リンクを取得（全件が複数ファイルに分割された自治体向け）。
- `hrefScan`: `<a>` に限らず生HTML中で `hrefPattern` に一致するURLを拾う（`<button value="…">` 等 アンカー以外にURLが埋まっているページ向け）。
- `linkFormat`: リンク抽出の拡張子フィルタをパース形式と分離（拡張子は `.csv` だが中身は TSV、等）。
- 取得処理を `downloadOne` に切り出し、`resolveLinkFromHtml` は全一致を `all` で返すよう変更。`findCachedFiles` で multi の `key-0/key-1…` を dry-run でも拾えるように。

**9ソースの移行（`config/sources.yaml`）**
- 青森市/秋田市/山形市: 掲載ページの「全件/一覧」リンクを解決。
- 福島市: 掲載ページが移設されていたため `pageUrl`/`sourceUrl` も更新。
- 川崎市/福井市: ファイル名で全件を識別（`hrefPattern`）。
- 藤沢市: 全件が法人+個人の2ファイル（`multi` + `linkFormat`: 拡張子 csv・中身 tsv）。
- 滋賀県: 全件が許可時期で2ファイル（`multi`）。
- 西宮市: リンクが `<button value>` でアンカーでないため `hrefScan`。
- 松本市: 配布元 linkdata.org が停止中・市サイトに代替配布が無く**復旧不可**（注記のみ、別対応）。

## 採用したアプローチと意図

- **検知より復旧を優先**: 9ソースは既に 404 で死んでいるため、鮮度監視では復活しない。既知の掲載ページ（前PRで調査済みの `sourceUrl`）を使い `resolve` へ移行することで、復活と将来の自動追従を同時に実現する。
- **今 404 の9件に限定**: 日付URLは他にもあるが、現に生きているものは nja/取得が成功しており、一律移行は working なソースを壊すリスクがある。掲載ページの構造確認が必要なため、壊れている9件に絞った。
- 掲載ページごとに「全件」と「新規/差分/廃業」の区別方法が異なる（表示テキスト or ファイル名）ため、text マッチと href マッチの両対応にした。

## テスト

- **ユニット追加**（`crawl.test.js`、計36件）: `resolveLinkFromHtml` の `hrefPattern`（ファイル名で全件のみに絞る）、`all`（複数一致を返す）。
- **エンドツーエンド検証**: 移行した9ソース全てで、掲載ページからの最新リンク解決 → ダウンロード → パースを実地確認。全て**旧URLから最新ファイルへ自動追従**して取得成功（例: 青森 r0805→r0806、秋田→r080701、藤沢/滋賀は2ファイル取得、西宮は hrefScan で解決）。計 約58,700施設が復活。
- `npm test`（全ユニット＋api/バリデーション＋stats）全緑。

## 確認してほしいポイント

- `resolve` の `linkPattern`/`hrefPattern` の使い分け（各ソースで全件を確実に選べているか。特に川崎の suffix `03`、福井の `11syokuhin_` プレフィックスでの識別）。
- 松本市を復旧不可として残す判断（linkdata.org 復活待ち）。

## 補足

- 「長期未更新・古いデータの鮮度監視（ハッシュ/Last-Modified/データ内最新日）」は本PRのスコープ外で、別PRを予定。今回はあくまで壊れたURLの復旧と追従化。
