### PR TITLE
クロールに allow_empty_sources 手動実行オプションを追加（配信回復用）

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -14,6 +14,10 @@ on:
         description: '厚労省 i2fas オープンデータを再取得する（ブラウザ自動化・時間がかかる）'
         type: boolean
         default: false
+      allow_empty_sources:
+        description: '取得0のソースがあっても中断せず続行する（既知の配信停止ソースを許容してデプロイ）'
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -56,7 +60,7 @@ jobs:
         # Node のヒープ上限を引き上げる（GitHub Linux ランナーは 16GB RAM）。
         env:
           NODE_OPTIONS: --max-old-space-size=12288
-        run: node scripts/crawl.js ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run) && '--dry-run' || '' }}
+        run: node scripts/crawl.js ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run) && '--dry-run' || '' }} ${{ (github.event_name == 'workflow_dispatch' && inputs.allow_empty_sources) && '--allow-empty-sources' || '' }}
 
       # 全市区町村を結合した1本の配布用CSV（api/facilities-all.csv[.gz]）を生成する。
       # 市区町村名は normalize-japanese-addresses で名寄せ済み。gh-pages でそのまま配信される。


### PR DESCRIPTION
## 背景・解決したい課題
- クロールは「取得0のソースが1件でもあると中断」する安全弁（`--allow-empty-sources` で解除可）を持つ。
- 現在、上流オープンデータ14ソースが 404/503 で配信停止しており、この安全弁で毎回クロールが失敗 → gh-pages への配信が 2026-07-13 以降止まっている。
- 死んだソースの修復（別対応）を待たず、現行データ＋ベクトルタイル＋プレビュー地図を配信できるようにしたい。

## 変更内容
- `crawl.yml` の `workflow_dispatch` に `allow_empty_sources`（boolean, 既定 false）を追加。
- true のとき Crawl ステップに `--allow-empty-sources` を渡し、取得0ソースがあっても中断せず続行する。

## 採用したアプローチと意図
- crawl.js には既に `--allow-empty-sources` フラグが実装済み。それを手動実行から渡せるようにするだけの最小変更で、既定 false のため定期実行の挙動は不変（欠落データの誤配信は引き続き防止）。
- 恒久策はソース URL の修復だが、それとは独立に「既知の配信停止を許容して配信を回復する」運用手段を用意する意図。

## テスト
- 設定(YAML)のみの変更のため自動テストは追加なし。`python -c "yaml.safe_load(...)"` で構文の妥当性を確認済み。

## 確認してほしいポイント
- ⚠️ **既知の運用上の注意（本PRとは別の既存の脆さ）**: 「Commit README stats」ステップが `git pull --rebase origin main` を行うため、**この workflow を feature ブランチから dispatch すると rebase がコンフリクトし、生成物 `api/` が配信されず本番が壊れる**。クロールの手動実行は必ず `main` から行うこと。将来的にはこのステップを main 実行時のみに限定するハードニングが望ましい（別PR）。