### PR TITLE
出典表示（attribution）ページを追加

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -68,21 +68,26 @@ jobs:
           node scripts/build-merged-csv.js
           gzip -kf api/facilities-all.csv
 
+      # 出典表示ページ（attribution.html）を config/sources.yaml から再生成する。
+      # npm test で config との同期を検証するため、Validate より前に実行する。
+      - name: Build attribution page
+        run: npm run build:attribution
+
       - name: Validate
         run: npm test
 
-      # README の統計（件数・サイズ）だけを main に反映する。
+      # README の統計（件数・サイズ）と出典表示ページだけを main に反映する。
       # 生成物 api/ は Git 管理せず（.gitignore）、配信は gh-pages のみで行う（履歴肥大を避けるため）。
       # クロール中に他の push で main が進むことがあるため、rebase してリトライする。
       - name: Commit README stats
         run: |
-          if git diff --quiet README.md; then
-            echo "README 変更なし"; exit 0
+          if git diff --quiet README.md attribution.html; then
+            echo "README / attribution.html 変更なし"; exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add README.md
-          git commit -m "chore: update README data stats"
+          git add README.md attribution.html
+          git commit -m "chore: update README data stats and attribution page"
           for i in 1 2 3; do
             if git pull --rebase --autostash origin main && git push; then
               echo "pushed"; exit 0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Last Commit](https://img.shields.io/github/last-commit/gl20percentclub/japan-facilities-api)](https://github.com/gl20percentclub/japan-facilities-api/commits/main)
 [![Weekly Crawl](https://img.shields.io/badge/更新-毎週自動-blue)](#️-自動更新の仕組み)
 
-[クイックスタート](#-クイックスタート) · [API リファレンス](#-api-リファレンス) · [収録状況](docs/COVERAGE.md) · [バグ報告](https://github.com/gl20percentclub/japan-facilities-api/issues/new) · [機能要望](https://github.com/gl20percentclub/japan-facilities-api/issues/new)
+[クイックスタート](#-クイックスタート) · [API リファレンス](#-api-リファレンス) · [収録状況](docs/COVERAGE.md) · [出典・ライセンス](https://gl20percentclub.github.io/japan-facilities-api/attribution.html) · [バグ報告](https://github.com/gl20percentclub/japan-facilities-api/issues/new) · [機能要望](https://github.com/gl20percentclub/japan-facilities-api/issues/new)
 
 </div>
 
@@ -304,6 +304,9 @@ sources:
   自動的にサニティ補正します。
 - 取得 → パース → 正規化 → 出力 の各処理は `scripts/lib/`（`config` / `acquire` / `parse` /
   `normalize` / `geocode`）に分割されています。
+- ソースを追加・変更したら `npm run build:attribution` で
+  [出典表示ページ](https://gl20percentclub.github.io/japan-facilities-api/attribution.html)（`attribution.html`）を
+  再生成してください（`npm test` が config との同期を検証します）。
 
 ## ⚙️ 自動更新の仕組み
 
@@ -349,7 +352,13 @@ sources:
 
 ### 出典・データソース
 
-全国の自治体が公開する食品営業許可オープンデータを収録しています。対象ソースの完全な一覧（自治体・取得URL・出典ページ・ライセンス）は、機械可読な形で以下に定義されています。
+全国の自治体が公開する食品営業許可オープンデータを収録しています。
+
+> 📢 **利用時の出典表示は [出典・ライセンス表示ページ](https://gl20percentclub.github.io/japan-facilities-api/attribution.html) を参照してください。**
+> 全ソースの出典 URL・ライセンスと、各データのライセンスが求める形式に沿った出典表示文（コピーしてそのまま使えます）を一覧化しています。
+> このページは `config/sources.yaml` から `npm run build:attribution`（[`scripts/gen-attribution.js`](scripts/gen-attribution.js)）で自動生成しており、`npm test` で内容の同期を検証しています。
+
+対象ソースの完全な一覧（自治体・取得URL・出典ページ・ライセンス）は、機械可読な形で以下に定義されています。
 
 - [`config/sources.yaml`](config/sources.yaml) — 全データソースの単一定義（個別自治体・BODIK 掲載分・各自治体ポータル掲載分を統合）。各エントリに取得URL（`acquire`）と出典の掲載ページ（`sourceUrl`）、ライセンスを持ちます
 - `scripts/gen-bodik-sources.mjs` — BODIK（`data.bodik.jp`）掲載自治体のエントリを再生成（`config/sources.yaml` へマージ）

--- a/attribution.html
+++ b/attribution.html
@@ -1,0 +1,1588 @@
+<!DOCTYPE html>
+<!--
+  このファイルは scripts/gen-attribution.js が config/sources.yaml から自動生成しています。
+  直接編集せず、config/sources.yaml を更新して `npm run build:attribution` を実行してください。
+-->
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>出典・ライセンス表示 — Japan Facilities API</title>
+  <meta name="description" content="Japan Facilities API が収録する全データソースの出典URL・ライセンスと、各データの出典表示形式に沿った表示文の一覧です。">
+  <style>
+    :root {
+      --accent: #e8563f;
+      --ink: #1f2933;
+      --sub: #52606d;
+      --muted: #9aa5b1;
+      --border: rgba(31, 41, 51, 0.12);
+      --panel: #f7f8fa;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Noto Sans JP", sans-serif;
+      color: var(--ink);
+      line-height: 1.7;
+      background: #fff;
+    }
+    .wrap { max-width: 920px; margin: 0 auto; padding: 32px 20px 80px; }
+    a { color: var(--accent); }
+    h1 { font-size: 24px; margin: 0 0 8px; }
+    h2 {
+      font-size: 18px;
+      margin: 48px 0 4px;
+      padding-bottom: 6px;
+      border-bottom: 2px solid var(--accent);
+      scroll-margin-top: 16px;
+    }
+    h3 { font-size: 15px; margin: 0 0 6px; }
+    h3 .dataset { display: block; font-size: 13px; font-weight: 400; color: var(--sub); }
+    p { margin: 0 0 12px; }
+    .lead { color: var(--sub); font-size: 14px; }
+    .count { font-size: 12px; color: var(--muted); font-weight: 400; }
+    .muted { color: var(--muted); }
+    .requirement { font-size: 13px; color: var(--sub); margin: 10px 0 16px; }
+
+    /* まとめて1行で表示する場合の例 */
+    .callout {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-left: 4px solid var(--accent);
+      border-radius: 8px;
+      padding: 14px 16px;
+      font-size: 14px;
+    }
+
+    /* 目次 */
+    .toc { background: var(--panel); border-radius: 10px; padding: 12px 16px; font-size: 14px; }
+    .toc ul { margin: 6px 0 0; padding-left: 20px; }
+
+    /* ソース1件分のカード */
+    .src {
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 14px 16px;
+      margin-bottom: 12px;
+      scroll-margin-top: 16px;
+    }
+    .src dl {
+      display: grid;
+      grid-template-columns: 84px 1fr;
+      gap: 2px 12px;
+      margin: 8px 0;
+      font-size: 12.5px;
+    }
+    .src dt { color: var(--muted); }
+    .src dd { margin: 0; overflow-wrap: anywhere; }
+    .badge {
+      display: inline-block;
+      font-size: 11px;
+      color: var(--sub);
+      background: var(--panel);
+      border-radius: 999px;
+      padding: 1px 10px;
+      margin-bottom: 8px;
+    }
+
+    /* 出典表示文（コピー用） */
+    .attr {
+      display: flex;
+      gap: 10px;
+      align-items: flex-start;
+      background: var(--panel);
+      border-radius: 8px;
+      padding: 10px 12px;
+    }
+    .attr code {
+      flex: 1;
+      font-size: 12.5px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      overflow-wrap: anywhere;
+    }
+    .copy {
+      flex: none;
+      font: inherit;
+      font-size: 12px;
+      color: #fff;
+      background: var(--accent);
+      border: 0;
+      border-radius: 6px;
+      padding: 4px 12px;
+      cursor: pointer;
+    }
+    .copy:hover { opacity: 0.85; }
+
+    footer { margin-top: 56px; font-size: 12.5px; color: var(--sub); }
+    @media (max-width: 560px) {
+      .src dl { grid-template-columns: 1fr; }
+      .src dt { margin-top: 6px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>出典・ライセンス表示（Attribution）</h1>
+    <p class="lead">
+      <a href="https://gl20percentclub.github.io/japan-facilities-api/">Japan Facilities API</a> は、各自治体・省庁が公開する食品営業許可・届出のオープンデータを
+      取得し、全国共通フォーマットへの正規化と緯度経度の付与を行って配信しています。
+      本ページは収録している全 98 ソースの出典 URL とライセンス、および
+      各データが求める出典表示形式に沿った表示文の一覧です。
+    </p>
+
+    <h2 id="how-to">出典の表示方法</h2>
+    <p>
+      本 API のデータを利用・再配布する場合は、利用したデータのソースについて下記の表示文をそのまま掲載してください。
+      本 API は元データに加工（正規化・名寄せ・ジオコーディング）を加えているため、表示文には「加工して作成」の旨を含めています。
+    </p>
+    <p>全国データをまとめて利用する場合は、次の一括表記でも構いません（個別ソースの一覧として本ページを参照させてください）。</p>
+    <div class="callout">
+      <code>出典：Japan Facilities API（各自治体・厚生労働省が公開する食品営業許可オープンデータを加工して作成）<br>https://gl20percentclub.github.io/japan-facilities-api/attribution.html</code>
+    </div>
+    <p class="lead" style="margin-top:12px">
+      緯度経度は本サービスが住所からジオコーディングして独自に付与した参考情報であり、各自治体が提供しているものではありません。
+      加工したデータについて、提供元が本サービスを推奨・関与していると誤解させる表示は行わないでください。
+    </p>
+
+    <nav class="toc" aria-label="ライセンス別の目次">
+      <strong>ライセンス別の一覧</strong>
+      <ul>
+      <li><a href="#cc-by-4-0">CC BY 4.0</a> <span class="count">50</span></li>
+      <li><a href="#cc-by-3-0">CC BY 3.0</a> <span class="count">1</span></li>
+      <li><a href="#cc-by-2-1-jp">CC BY 2.1 JP</a> <span class="count">10</span></li>
+      <li><a href="#cc-by-2-0">CC BY 2.0</a> <span class="count">2</span></li>
+      <li><a href="#cc-by">CC BY（バージョン表記なし）</a> <span class="count">17</span></li>
+      <li><a href="#pdl-1-0">公共データ利用規約（第1.0版・PDL1.0）</a> <span class="count">2</span></li>
+      <li><a href="#local-terms">自治体独自の利用規約</a> <span class="count">7</span></li>
+      <li><a href="#unconfirmed">ライセンス表記が未確認</a> <span class="count">9</span></li>
+      </ul>
+    </nav>
+
+    <section class="license" id="cc-by-4-0">
+      <h2>CC BY 4.0 <span class="count">50 ソース</span></h2>
+      <p class="requirement">出典（提供者名・データセット名・出典 URL）の明示と、改変した旨の表示が必要です。本 API は正規化・緯度経度付与などの加工を行っているため、「加工して作成」の旨を必ず含めてください。 — <a href="https://creativecommons.org/licenses/by/4.0/deed.ja" target="_blank" rel="noopener">ライセンス本文</a></p>
+      <article class="src" id="src-iwaki">
+        <h3>いわき市<span class="dataset">食品営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.iwaki.lg.jp/www/contents/1652661537484/index.html" target="_blank" rel="noopener">https://www.city.iwaki.lg.jp/www/contents/1652661537484/index.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.iwaki.lg.jp/www/contents/1652661537484/simple/Shokuhin_itiran_R08.csv" target="_blank" rel="noopener">https://www.city.iwaki.lg.jp/www/contents/1652661537484/simple/Shokuhin…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：いわき市「食品営業許可施設一覧」（https://www.city.iwaki.lg.jp/www/contents/1652661537484/index.html）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：いわき市「食品営業許可施設一覧」（https://www.city.iwaki.lg.jp/www/contents/1652661537484/index.html）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-ichinomiya">
+        <h3>一宮市<span class="dataset">食品営業許可台帳</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.ichinomiya.aichi.jp/hokenjo/hoken-eisei/1044314/1039899/1040636.html" target="_blank" rel="noopener">https://www.city.ichinomiya.aichi.jp/hokenjo/hoken-eisei/1044314/1039899/1040636.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.ichinomiya.aichi.jp/_res/projects/default_project/_page_/001/040/636/232033_Food_Business_All_20260331.csv" target="_blank" rel="noopener">https://www.city.ichinomiya.aichi.jp/_res/projects/default_project/_pag…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：一宮市「食品営業許可台帳」（https://www.city.ichinomiya.aichi.jp/hokenjo/hoken-eisei/1044314/1039899/1040636.html）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：一宮市「食品営業許可台帳」（https://www.city.ichinomiya.aichi.jp/hokenjo/hoken-eisei/1044314/1039899/1040636.html）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-utsunomiya">
+        <h3>宇都宮市<span class="dataset">食品営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://catalog.city.utsunomiya.tochigi.jp/dataset/4b5cae93-4640-4b4e-87bb-a5e18042366c" target="_blank" rel="noopener">https://catalog.city.utsunomiya.tochigi.jp/dataset/4b5cae93-4640-4b4e-87bb-a5e18042366c</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://catalog.city.utsunomiya.tochigi.jp/dataset/4b5cae93-4640-4b4e-87bb-a5e18042366c/resource/a53500f2-7ba1-4e77-a906-e17dc5b60714/download/092011_seikatsueisei_shokuhin_shokuhin.csv" target="_blank" rel="noopener">https://catalog.city.utsunomiya.tochigi.jp/dataset/4b5cae93-4640-4b4e-8…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：宇都宮市「食品営業許可施設一覧」（https://catalog.city.utsunomiya.tochigi.jp/dataset/4b5cae93-4640-4b4e-87bb-a5e18042366c）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：宇都宮市「食品営業許可施設一覧」（https://catalog.city.utsunomiya.tochigi.jp/dataset/4b5cae93-4640-4b4e-87bb-a5e18042366c）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-bodik-3a1aaf46">
+        <h3>横須賀市<span class="dataset">【横須賀市】食品営業許可施設公開情報 （食品営業許可を取得している全施設）</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.bodik.jp/dataset/142018_00_18_syokuhin_all" target="_blank" rel="noopener">https://data.bodik.jp/dataset/142018_00_18_syokuhin_all</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=8d4bc9c9-b5b2-495c-a1fa-a34eeaa4fe23" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=8d4bc9c9-b5b2-495c-…</a></dd>
+        </dl>
+        <span class="badge">元の表記: Creative Commons Attribution 4.0 International</span>
+        <div class="attr">
+          <code>出典：横須賀市「【横須賀市】食品営業許可施設公開情報 （食品営業許可を取得している全施設）」（https://data.bodik.jp/dataset/142018_00_18_syokuhin_all）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：横須賀市「【横須賀市】食品営業許可施設公開情報 （食品営業許可を取得している全施設）」（https://data.bodik.jp/dataset/142018_00_18_syokuhin_all）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-bodik-aabced9d">
+        <h3>岡崎市<span class="dataset">食品等営業許可・届出一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.bodik.jp/dataset/aabced9d-d86e-422d-8ad0-2781d0f30671" target="_blank" rel="noopener">https://data.bodik.jp/dataset/aabced9d-d86e-422d-8ad0-2781d0f30671</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=a893c7d6-5c10-4fb4-b9fa-cb48edd81565" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=a893c7d6-5c10-4fb4-…</a></dd>
+        </dl>
+        <span class="badge">元の表記: Creative Commons Attribution 4.0 International</span>
+        <div class="attr">
+          <code>出典：岡崎市「食品等営業許可・届出一覧」（https://data.bodik.jp/dataset/aabced9d-d86e-422d-8ad0-2781d0f30671）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：岡崎市「食品等営業許可・届出一覧」（https://data.bodik.jp/dataset/aabced9d-d86e-422d-8ad0-2781d0f30671）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-okinawa-bodik">
+        <h3>沖縄県<span class="dataset">食品営業許可・届出</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.bodik.jp/dataset/90559956-0f04-42cf-9e96-91598a527d03" target="_blank" rel="noopener">https://data.bodik.jp/dataset/90559956-0f04-42cf-9e96-91598a527d03</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=c9bf82c1-0689-4354-aada-c422f052be5e" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=c9bf82c1-0689-4354-…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：沖縄県「食品営業許可・届出」（https://data.bodik.jp/dataset/90559956-0f04-42cf-9e96-91598a527d03）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：沖縄県「食品営業許可・届出」（https://data.bodik.jp/dataset/90559956-0f04-42cf-9e96-91598a527d03）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-chigasaki">
+        <h3>茅ヶ崎市<span class="dataset">食品営業許可台帳</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.chigasaki.kanagawa.jp/kenko/1022967/1041326.html" target="_blank" rel="noopener">https://www.city.chigasaki.kanagawa.jp/kenko/1022967/1041326.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.chigasaki.kanagawa.jp/_res/projects/default_project/_page_/001/041/779/syokuhinall2025.csv" target="_blank" rel="noopener">https://www.city.chigasaki.kanagawa.jp/_res/projects/default_project/_p…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：茅ヶ崎市「食品営業許可台帳」（https://www.city.chigasaki.kanagawa.jp/kenko/1022967/1041326.html）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：茅ヶ崎市「食品営業許可台帳」（https://www.city.chigasaki.kanagawa.jp/kenko/1022967/1041326.html）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-bodik-88d27dcd">
+        <h3>久万高原町<span class="dataset">食品等営業許可・届出一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.bodik.jp/dataset/88d27dcd-c645-4e36-84c8-e74b481f0cee" target="_blank" rel="noopener">https://data.bodik.jp/dataset/88d27dcd-c645-4e36-84c8-e74b481f0cee</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=6e598555-a1de-458b-a1c1-595aa6e4cbb4" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=6e598555-a1de-458b-…</a></dd>
+        </dl>
+        <span class="badge">元の表記: Creative Commons Attribution 4.0 International</span>
+        <div class="attr">
+          <code>出典：久万高原町「食品等営業許可・届出一覧」（https://data.bodik.jp/dataset/88d27dcd-c645-4e36-84c8-e74b481f0cee）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：久万高原町「食品等営業許可・届出一覧」（https://data.bodik.jp/dataset/88d27dcd-c645-4e36-84c8-e74b481f0cee）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-kyoto-city">
+        <h3>京都市<span class="dataset">食品営業許可施設一覧（令和3年3月末時点）</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.city.kyoto.lg.jp/dataset/00414" target="_blank" rel="noopener">https://data.city.kyoto.lg.jp/dataset/00414</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.city.kyoto.lg.jp/resource/?id=15447" target="_blank" rel="noopener">https://data.city.kyoto.lg.jp/resource/?id=15447</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：京都市「食品営業許可施設一覧（令和3年3月末時点）」（https://data.city.kyoto.lg.jp/dataset/00414）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：京都市「食品営業許可施設一覧（令和3年3月末時点）」（https://data.city.kyoto.lg.jp/dataset/00414）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-bodik-5a58e9d4">
+        <h3>熊本県<span class="dataset">食品営業許可施設、届出施設データ</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.bodik.jp/dataset/5a58e9d4-f3cc-4b21-9ec8-4896f7b42774" target="_blank" rel="noopener">https://data.bodik.jp/dataset/5a58e9d4-f3cc-4b21-9ec8-4896f7b42774</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=fe69c10f-a509-458d-b8e7-b424b5db45bb" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=fe69c10f-a509-458d-…</a></dd>
+        </dl>
+        <span class="badge">元の表記: Creative Commons Attribution 4.0 International</span>
+        <div class="attr">
+          <code>出典：熊本県「食品営業許可施設、届出施設データ」（https://data.bodik.jp/dataset/5a58e9d4-f3cc-4b21-9ec8-4896f7b42774）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：熊本県「食品営業許可施設、届出施設データ」（https://data.bodik.jp/dataset/5a58e9d4-f3cc-4b21-9ec8-4896f7b42774）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-koto-ku">
+        <h3>江東区<span class="dataset">東京都江東区食品等営業許可・届出一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://catalog.data.metro.tokyo.lg.jp/dataset/t131083d0000000028" target="_blank" rel="noopener">https://catalog.data.metro.tokyo.lg.jp/dataset/t131083d0000000028</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.opendata.metro.tokyo.lg.jp/koto/131083_015_food_business_all.csv" target="_blank" rel="noopener">https://www.opendata.metro.tokyo.lg.jp/koto/131083_015_food_business_al…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：江東区「東京都江東区食品等営業許可・届出一覧」（https://catalog.data.metro.tokyo.lg.jp/dataset/t131083d0000000028）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：江東区「東京都江東区食品等営業許可・届出一覧」（https://catalog.data.metro.tokyo.lg.jp/dataset/t131083d0000000028）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-tokyo-minato">
+        <h3>港区<span class="dataset">東京都港区食品営業許可一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://opendata.city.minato.tokyo.jp/dataset/54d8c582-00e2-4730-a23f-4a5befec9ae5" target="_blank" rel="noopener">https://opendata.city.minato.tokyo.jp/dataset/54d8c582-00e2-4730-a23f-4a5befec9ae5</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://opendata.city.minato.tokyo.jp/dataset/54d8c582-00e2-4730-a23f-4a5befec9ae5/resource/c9d0299e-8e05-4317-877f-83055709e41f/download/food_business_all.csv" target="_blank" rel="noopener">https://opendata.city.minato.tokyo.jp/dataset/54d8c582-00e2-4730-a23f-4…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：港区「東京都港区食品営業許可一覧」（https://opendata.city.minato.tokyo.jp/dataset/54d8c582-00e2-4730-a23f-4a5befec9ae5）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：港区「東京都港区食品営業許可一覧」（https://opendata.city.minato.tokyo.jp/dataset/54d8c582-00e2-4730-a23f-4a5befec9ae5）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-takasaki">
+        <h3>高崎市<span class="dataset">食品営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.takasaki.gunma.jp/page/4527.html" target="_blank" rel="noopener">https://www.city.takasaki.gunma.jp/page/4527.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.takasaki.gunma.jp/uploaded/attachment/40475.xlsx" target="_blank" rel="noopener">https://www.city.takasaki.gunma.jp/uploaded/attachment/40475.xlsx</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：高崎市「食品営業許可施設一覧」（https://www.city.takasaki.gunma.jp/page/4527.html）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：高崎市「食品営業許可施設一覧」（https://www.city.takasaki.gunma.jp/page/4527.html）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-bodik-571df2fc">
+        <h3>佐世保市<span class="dataset">［佐世保市］食品営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.bodik.jp/dataset/571df2fc-f781-4a2c-b9d7-09e1637b15fe" target="_blank" rel="noopener">https://data.bodik.jp/dataset/571df2fc-f781-4a2c-b9d7-09e1637b15fe</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=e91e20f8-8469-4c4d-a16c-8ad12b883d0e" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=e91e20f8-8469-4c4d-…</a></dd>
+        </dl>
+        <span class="badge">元の表記: Creative Commons Attribution 4.0 International</span>
+        <div class="attr">
+          <code>出典：佐世保市「［佐世保市］食品営業許可施設一覧」（https://data.bodik.jp/dataset/571df2fc-f781-4a2c-b9d7-09e1637b15fe）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：佐世保市「［佐世保市］食品営業許可施設一覧」（https://data.bodik.jp/dataset/571df2fc-f781-4a2c-b9d7-09e1637b15fe）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-bodik-f861e58c">
+        <h3>堺市<span class="dataset">堺市 食品営業許可施設一覧（令和8年4月1日現在）</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.bodik.jp/dataset/f861e58c-ee2b-4a8c-8bc7-db9f70431b4b" target="_blank" rel="noopener">https://data.bodik.jp/dataset/f861e58c-ee2b-4a8c-8bc7-db9f70431b4b</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=1714357c-0ded-41aa-bdc4-2f3b527067c7" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=1714357c-0ded-41aa-…</a></dd>
+        </dl>
+        <span class="badge">元の表記: Creative Commons Attribution 4.0 International</span>
+        <div class="attr">
+          <code>出典：堺市「堺市 食品営業許可施設一覧（令和8年4月1日現在）」（https://data.bodik.jp/dataset/f861e58c-ee2b-4a8c-8bc7-db9f70431b4b）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：堺市「堺市 食品営業許可施設一覧（令和8年4月1日現在）」（https://data.bodik.jp/dataset/f861e58c-ee2b-4a8c-8bc7-db9f70431b4b）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-sapporo">
+        <h3>札幌市<span class="dataset">食品営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://ckan.pf-sapporo.jp/dataset/be44af14-f135-41b9-acca-08e215d8a540" target="_blank" rel="noopener">https://ckan.pf-sapporo.jp/dataset/be44af14-f135-41b9-acca-08e215d8a540</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://ckan.pf-sapporo.jp/dataset/be44af14-f135-41b9-acca-08e215d8a540/resource/54618ac4-da90-493c-8a20-8df29be9d435/download/shokuhin260331.csv" target="_blank" rel="noopener">https://ckan.pf-sapporo.jp/dataset/be44af14-f135-41b9-acca-08e215d8a540…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：札幌市「食品営業許可施設一覧」（https://ckan.pf-sapporo.jp/dataset/be44af14-f135-41b9-acca-08e215d8a540）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：札幌市「食品営業許可施設一覧」（https://ckan.pf-sapporo.jp/dataset/be44af14-f135-41b9-acca-08e215d8a540）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-bodik-796b84b4">
+        <h3>三重県<span class="dataset">食品営業許可施設</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.bodik.jp/dataset/796b84b4-c197-44bd-b852-664a8a423676" target="_blank" rel="noopener">https://data.bodik.jp/dataset/796b84b4-c197-44bd-b852-664a8a423676</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=fc9fba2d-e6f7-4139-ba20-3e572ba99572" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=fc9fba2d-e6f7-4139-…</a></dd>
+        </dl>
+        <span class="badge">元の表記: Creative Commons Attribution 4.0 International</span>
+        <div class="attr">
+          <code>出典：三重県「食品営業許可施設」（https://data.bodik.jp/dataset/796b84b4-c197-44bd-b852-664a8a423676）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：三重県「食品営業許可施設」（https://data.bodik.jp/dataset/796b84b4-c197-44bd-b852-664a8a423676）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-yamagata-city">
+        <h3>山形市<span class="dataset">食品営業許可・届出施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.yamagata-yamagata.lg.jp/kenkofukushi/eisei/1006555/1006558/1012802.html" target="_blank" rel="noopener">https://www.city.yamagata-yamagata.lg.jp/kenkofukushi/eisei/1006555/1006558/1012802.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.yamagata-yamagata.lg.jp/kenkofukushi/eisei/1006555/1006558/1012802.html" target="_blank" rel="noopener">https://www.city.yamagata-yamagata.lg.jp/kenkofukushi/eisei/1006555/100…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：山形市「食品営業許可・届出施設一覧」（https://www.city.yamagata-yamagata.lg.jp/kenkofukushi/eisei/1006555/1006558/1012802.html）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：山形市「食品営業許可・届出施設一覧」（https://www.city.yamagata-yamagata.lg.jp/kenkofukushi/eisei/1006555/1006558/1012802.html）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-bodik-e5809d89">
+        <h3>四日市市<span class="dataset">【三重県四日市市】食品営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.bodik.jp/dataset/242021_00131" target="_blank" rel="noopener">https://data.bodik.jp/dataset/242021_00131</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=a0a4bc9b-d981-4499-b736-f6d9b7cf35ea" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=a0a4bc9b-d981-4499-…</a></dd>
+        </dl>
+        <span class="badge">元の表記: Creative Commons Attribution 4.0 International</span>
+        <div class="attr">
+          <code>出典：四日市市「【三重県四日市市】食品営業許可施設一覧」（https://data.bodik.jp/dataset/242021_00131）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：四日市市「【三重県四日市市】食品営業許可施設一覧」（https://data.bodik.jp/dataset/242021_00131）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-bodik-1bca2ed4">
+        <h3>鹿児島県<span class="dataset">鹿児島県食品営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.bodik.jp/dataset/1bca2ed4-7d8f-4330-b8e6-a05d27ace017" target="_blank" rel="noopener">https://data.bodik.jp/dataset/1bca2ed4-7d8f-4330-b8e6-a05d27ace017</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=e7c9bcaf-bf78-45f6-a4f6-61a157a00d37" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=e7c9bcaf-bf78-45f6-…</a></dd>
+        </dl>
+        <span class="badge">元の表記: Creative Commons Attribution 4.0 International</span>
+        <div class="attr">
+          <code>出典：鹿児島県「鹿児島県食品営業許可施設一覧」（https://data.bodik.jp/dataset/1bca2ed4-7d8f-4330-b8e6-a05d27ace017）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：鹿児島県「鹿児島県食品営業許可施設一覧」（https://data.bodik.jp/dataset/1bca2ed4-7d8f-4330-b8e6-a05d27ace017）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-bodik-f7485a92">
+        <h3>鹿児島市<span class="dataset">食品営業許可全施設一覧（2021年6月1日食品衛生法改正以前）</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.bodik.jp/dataset/f7485a92-6386-43f5-b65f-a6f32bbf0645" target="_blank" rel="noopener">https://data.bodik.jp/dataset/f7485a92-6386-43f5-b65f-a6f32bbf0645</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=6a78b822-6083-45b0-9d34-23ed6ebf0eee" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=6a78b822-6083-45b0-…</a></dd>
+        </dl>
+        <span class="badge">元の表記: Creative Commons Attribution 4.0 International</span>
+        <div class="attr">
+          <code>出典：鹿児島市「食品営業許可全施設一覧（2021年6月1日食品衛生法改正以前）」（https://data.bodik.jp/dataset/f7485a92-6386-43f5-b65f-a6f32bbf0645）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：鹿児島市「食品営業許可全施設一覧（2021年6月1日食品衛生法改正以前）」（https://data.bodik.jp/dataset/f7485a92-6386-43f5-b65f-a6f32bbf0645）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-akita-city">
+        <h3>秋田市<span class="dataset">食品営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.akita.lg.jp/kurashi/kenko/1005368/1010019/1017339.html" target="_blank" rel="noopener">https://www.city.akita.lg.jp/kurashi/kenko/1005368/1010019/1017339.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.akita.lg.jp/kurashi/kenko/1005368/1010019/1017339.html" target="_blank" rel="noopener">https://www.city.akita.lg.jp/kurashi/kenko/1005368/1010019/1017339.html</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：秋田市「食品営業許可施設一覧」（https://www.city.akita.lg.jp/kurashi/kenko/1005368/1010019/1017339.html）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：秋田市「食品営業許可施設一覧」（https://www.city.akita.lg.jp/kurashi/kenko/1005368/1010019/1017339.html）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-shibuya-ku">
+        <h3>渋谷区<span class="dataset">東京都渋谷区食品等営業許可・届出一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://city-shibuya-data.opendata.arcgis.com/items/e68f41ebfa5f4ea490ca9af701d44e02" target="_blank" rel="noopener">https://city-shibuya-data.opendata.arcgis.com/items/e68f41ebfa5f4ea490ca9af701d44e02</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://city-shibuya-data.opendata.arcgis.com/api/download/v1/items/e68f41ebfa5f4ea490ca9af701d44e02/csv?layers=0" target="_blank" rel="noopener">https://city-shibuya-data.opendata.arcgis.com/api/download/v1/items/e68…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：渋谷区「東京都渋谷区食品等営業許可・届出一覧」（https://city-shibuya-data.opendata.arcgis.com/items/e68f41ebfa5f4ea490ca9af701d44e02）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：渋谷区「東京都渋谷区食品等営業許可・届出一覧」（https://city-shibuya-data.opendata.arcgis.com/items/e68f41ebfa5f4ea490ca9af701d44e02）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-shinjuku-ku">
+        <h3>新宿区<span class="dataset">東京都新宿区食品等営業許可・届出一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://catalog.data.metro.tokyo.lg.jp/dataset/t131041d0000000124" target="_blank" rel="noopener">https://catalog.data.metro.tokyo.lg.jp/dataset/t131041d0000000124</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.shinjuku.lg.jp/content/000399975.csv" target="_blank" rel="noopener">https://www.city.shinjuku.lg.jp/content/000399975.csv</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：新宿区「東京都新宿区食品等営業許可・届出一覧」（https://catalog.data.metro.tokyo.lg.jp/dataset/t131041d0000000124）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：新宿区「東京都新宿区食品等営業許可・届出一覧」（https://catalog.data.metro.tokyo.lg.jp/dataset/t131041d0000000124）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-suita">
+        <h3>吹田市<span class="dataset">食品営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.suita.osaka.jp/home/soshiki/div-kenkoiryo/eiseikanri/opendata.html" target="_blank" rel="noopener">https://www.city.suita.osaka.jp/home/soshiki/div-kenkoiryo/eiseikanri/opendata.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.suita.osaka.jp/_res/projects/default_project/_page_/001/017/170/20260331new.xlsx" target="_blank" rel="noopener">https://www.city.suita.osaka.jp/_res/projects/default_project/_page_/00…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：吹田市「食品営業許可施設一覧」（https://www.city.suita.osaka.jp/home/soshiki/div-kenkoiryo/eiseikanri/opendata.html）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：吹田市「食品営業許可施設一覧」（https://www.city.suita.osaka.jp/home/soshiki/div-kenkoiryo/eiseikanri/opendata.html）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-setagaya-ku">
+        <h3>世田谷区<span class="dataset">東京都世田谷区食品衛生営業許可施設</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.setagaya.lg.jp/02245/online_tetsuzuki/3246.html" target="_blank" rel="noopener">https://www.city.setagaya.lg.jp/02245/online_tetsuzuki/3246.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.setagaya.lg.jp/documents/3246/zenkenr080331.csv" target="_blank" rel="noopener">https://www.city.setagaya.lg.jp/documents/3246/zenkenr080331.csv</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：世田谷区「東京都世田谷区食品衛生営業許可施設」（https://www.city.setagaya.lg.jp/02245/online_tetsuzuki/3246.html）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：世田谷区「東京都世田谷区食品衛生営業許可施設」（https://www.city.setagaya.lg.jp/02245/online_tetsuzuki/3246.html）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-morioka">
+        <h3>盛岡市<span class="dataset">食品営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.morioka.iwate.jp/kenkou/hokenjo/shokuhineisei/1017014/1006689.html" target="_blank" rel="noopener">https://www.city.morioka.iwate.jp/kenkou/hokenjo/shokuhineisei/1017014/1006689.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.morioka.iwate.jp/_res/projects/default_project/_page_/001/006/689/20260630.csv" target="_blank" rel="noopener">https://www.city.morioka.iwate.jp/_res/projects/default_project/_page_/…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：盛岡市「食品営業許可施設一覧」（https://www.city.morioka.iwate.jp/kenkou/hokenjo/shokuhineisei/1017014/1006689.html）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：盛岡市「食品営業許可施設一覧」（https://www.city.morioka.iwate.jp/kenkou/hokenjo/shokuhineisei/1017014/1006689.html）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-aomori-city">
+        <h3>青森市<span class="dataset">食品営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.aomori.aomori.jp/shisei/jouhokoukai/opendata/1006170/1006184.html" target="_blank" rel="noopener">https://www.city.aomori.aomori.jp/shisei/jouhokoukai/opendata/1006170/1006184.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.aomori.aomori.jp/shisei/jouhokoukai/opendata/1006170/1006184.html" target="_blank" rel="noopener">https://www.city.aomori.aomori.jp/shisei/jouhokoukai/opendata/1006170/1…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：青森市「食品営業許可施設一覧」（https://www.city.aomori.aomori.jp/shisei/jouhokoukai/opendata/1006170/1006184.html）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：青森市「食品営業許可施設一覧」（https://www.city.aomori.aomori.jp/shisei/jouhokoukai/opendata/1006170/1006184.html）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-kawasaki">
+        <h3>川崎市<span class="dataset">食品営業許可施設情報</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.kawasaki.jp/350/page/0000093741.html" target="_blank" rel="noopener">https://www.city.kawasaki.jp/350/page/0000093741.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.kawasaki.jp/350/page/0000093741.html" target="_blank" rel="noopener">https://www.city.kawasaki.jp/350/page/0000093741.html</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：川崎市「食品営業許可施設情報」（https://www.city.kawasaki.jp/350/page/0000093741.html）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：川崎市「食品営業許可施設情報」（https://www.city.kawasaki.jp/350/page/0000093741.html）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-bodik-be0e8464">
+        <h3>前橋市<span class="dataset">食品等営業許可・届出一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.bodik.jp/dataset/be0e8464-4b96-41f6-901d-1aa4bf11bcc0" target="_blank" rel="noopener">https://data.bodik.jp/dataset/be0e8464-4b96-41f6-901d-1aa4bf11bcc0</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=6808f251-ce78-4c09-a5d8-24a871a5d7e9" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=6808f251-ce78-4c09-…</a></dd>
+        </dl>
+        <span class="badge">元の表記: Creative Commons Attribution 4.0 International</span>
+        <div class="attr">
+          <code>出典：前橋市「食品等営業許可・届出一覧」（https://data.bodik.jp/dataset/be0e8464-4b96-41f6-901d-1aa4bf11bcc0）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：前橋市「食品等営業許可・届出一覧」（https://data.bodik.jp/dataset/be0e8464-4b96-41f6-901d-1aa4bf11bcc0）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-sagamihara">
+        <h3>相模原市<span class="dataset">食品衛生関係施設一覧（営業許可）</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://opendata.city.sagamihara.kanagawa.jp/dataset/eigyo_kyoka" target="_blank" rel="noopener">https://opendata.city.sagamihara.kanagawa.jp/dataset/eigyo_kyoka</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://opendata.city.sagamihara.kanagawa.jp/dataset/eigyo_kyoka/resource/1be0eb65-0348-4668-a440-0ce10cad1063/download/04.zip" target="_blank" rel="noopener">https://opendata.city.sagamihara.kanagawa.jp/dataset/eigyo_kyoka/resour…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：相模原市「食品衛生関係施設一覧（営業許可）」（https://opendata.city.sagamihara.kanagawa.jp/dataset/eigyo_kyoka）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：相模原市「食品衛生関係施設一覧（営業許可）」（https://opendata.city.sagamihara.kanagawa.jp/dataset/eigyo_kyoka）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-taito-ku">
+        <h3>台東区<span class="dataset">東京都台東区食品衛生営業施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.taito.lg.jp/kusei/online/opendata/kenko/shokuhineisei.html" target="_blank" rel="noopener">https://www.city.taito.lg.jp/kusei/online/opendata/kenko/shokuhineisei.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.taito.lg.jp/kenkohukusi/kenkokikikanrieisei/food/syokuhin-sisetu/index.files/2026ALL-IND-CSV.csv" target="_blank" rel="noopener">https://www.city.taito.lg.jp/kenkohukusi/kenkokikikanrieisei/food/syoku…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：台東区「東京都台東区食品衛生営業施設一覧」（https://www.city.taito.lg.jp/kusei/online/opendata/kenko/shokuhineisei.html）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：台東区「東京都台東区食品衛生営業施設一覧」（https://www.city.taito.lg.jp/kusei/online/opendata/kenko/shokuhineisei.html）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-osaka-city">
+        <h3>大阪市<span class="dataset">食品営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.osaka.lg.jp/kenko/page/0000575579.html" target="_blank" rel="noopener">https://www.city.osaka.lg.jp/kenko/page/0000575579.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.osaka.lg.jp/contents/wdu280/260331zenku.csv" target="_blank" rel="noopener">https://www.city.osaka.lg.jp/contents/wdu280/260331zenku.csv</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：大阪市「食品営業許可施設一覧」（https://www.city.osaka.lg.jp/kenko/page/0000575579.html）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：大阪市「食品営業許可施設一覧」（https://www.city.osaka.lg.jp/kenko/page/0000575579.html）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-otsu">
+        <h3>大津市<span class="dataset">食品営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.otsu.lg.jp/soshiki/021/1441/od/02594.html" target="_blank" rel="noopener">https://www.city.otsu.lg.jp/soshiki/021/1441/od/02594.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.otsu.lg.jp/material/files/group/4/od_2605.csv" target="_blank" rel="noopener">https://www.city.otsu.lg.jp/material/files/group/4/od_2605.csv</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：大津市「食品営業許可施設一覧」（https://www.city.otsu.lg.jp/soshiki/021/1441/od/02594.html）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：大津市「食品営業許可施設一覧」（https://www.city.otsu.lg.jp/soshiki/021/1441/od/02594.html）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-bodik-1b0a322a">
+        <h3>大分県<span class="dataset">食品営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.bodik.jp/dataset/1b0a322a-6355-4b47-8fe7-478ec1b7d5e9" target="_blank" rel="noopener">https://data.bodik.jp/dataset/1b0a322a-6355-4b47-8fe7-478ec1b7d5e9</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=b8d40e46-9b97-48cd-86a3-3183d78c629a" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=b8d40e46-9b97-48cd-…</a></dd>
+        </dl>
+        <span class="badge">元の表記: Creative Commons Attribution 4.0 International</span>
+        <div class="attr">
+          <code>出典：大分県「食品営業許可施設一覧」（https://data.bodik.jp/dataset/1b0a322a-6355-4b47-8fe7-478ec1b7d5e9）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：大分県「食品営業許可施設一覧」（https://data.bodik.jp/dataset/1b0a322a-6355-4b47-8fe7-478ec1b7d5e9）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-chuo-ku">
+        <h3>中央区<span class="dataset">東京都中央区食品等営業許可・届出一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.chuo.lg.jp/kusei/gaiyou/toukeidate/opendata.html" target="_blank" rel="noopener">https://www.city.chuo.lg.jp/kusei/gaiyou/toukeidate/opendata.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.chuo.lg.jp/documents/984/syokuhineigyoukyoka.csv" target="_blank" rel="noopener">https://www.city.chuo.lg.jp/documents/984/syokuhineigyoukyoka.csv</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：中央区「東京都中央区食品等営業許可・届出一覧」（https://www.city.chuo.lg.jp/kusei/gaiyou/toukeidate/opendata.html）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：中央区「東京都中央区食品等営業許可・届出一覧」（https://www.city.chuo.lg.jp/kusei/gaiyou/toukeidate/opendata.html）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-nakano-ku">
+        <h3>中野区<span class="dataset">東京都中野区食品等営業許可届出一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://catalog.data.metro.tokyo.lg.jp/dataset/t131148d0000000129" target="_blank" rel="noopener">https://catalog.data.metro.tokyo.lg.jp/dataset/t131148d0000000129</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www2.wagmap.jp/nakanodatamap/nakanodatamap/opendatafile/map_40/CSV/opendata_550150.csv" target="_blank" rel="noopener">https://www2.wagmap.jp/nakanodatamap/nakanodatamap/opendatafile/map_40/…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：中野区「東京都中野区食品等営業許可届出一覧」（https://catalog.data.metro.tokyo.lg.jp/dataset/t131148d0000000129）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：中野区「東京都中野区食品等営業許可届出一覧」（https://catalog.data.metro.tokyo.lg.jp/dataset/t131148d0000000129）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-bodik-22c74cf1">
+        <h3>長崎県<span class="dataset">食品営業許可一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.bodik.jp/dataset/22c74cf1-6e13-449a-a139-ee9fdc16130a" target="_blank" rel="noopener">https://data.bodik.jp/dataset/22c74cf1-6e13-449a-a139-ee9fdc16130a</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=000ad70b-7c0e-4193-84bc-c4470fc6a15a" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=000ad70b-7c0e-4193-…</a></dd>
+        </dl>
+        <span class="badge">元の表記: Creative Commons Attribution 4.0 International</span>
+        <div class="attr">
+          <code>出典：長崎県「食品営業許可一覧」（https://data.bodik.jp/dataset/22c74cf1-6e13-449a-a139-ee9fdc16130a）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：長崎県「食品営業許可一覧」（https://data.bodik.jp/dataset/22c74cf1-6e13-449a-a139-ee9fdc16130a）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-bodik-4d70b9d1">
+        <h3>長崎市<span class="dataset">食品等営業許可・届出一覧（全許可・届出一覧）（長崎市）</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.bodik.jp/dataset/4d70b9d1-9885-4045-9f59-9d1b99e02910" target="_blank" rel="noopener">https://data.bodik.jp/dataset/4d70b9d1-9885-4045-9f59-9d1b99e02910</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=1125a70b-ac9d-49f6-ba87-1011d0db4f1a" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=1125a70b-ac9d-49f6-…</a></dd>
+        </dl>
+        <span class="badge">元の表記: Creative Commons Attribution 4.0 International</span>
+        <div class="attr">
+          <code>出典：長崎市「食品等営業許可・届出一覧（全許可・届出一覧）（長崎市）」（https://data.bodik.jp/dataset/4d70b9d1-9885-4045-9f59-9d1b99e02910）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：長崎市「食品等営業許可・届出一覧（全許可・届出一覧）（長崎市）」（https://data.bodik.jp/dataset/4d70b9d1-9885-4045-9f59-9d1b99e02910）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-nagano-city">
+        <h3>長野市<span class="dataset">食品営業許可施設</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.nagano.nagano.jp/n023500/contents/p004876.html" target="_blank" rel="noopener">https://www.city.nagano.nagano.jp/n023500/contents/p004876.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.nagano.nagano.jp/documents/1948/202011_food_business_202605.csv" target="_blank" rel="noopener">https://www.city.nagano.nagano.jp/documents/1948/202011_food_business_2…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：長野市「食品営業許可施設」（https://www.city.nagano.nagano.jp/n023500/contents/p004876.html）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：長野市「食品営業許可施設」（https://www.city.nagano.nagano.jp/n023500/contents/p004876.html）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-tokyo-hokeniryo">
+        <h3>東京都<span class="dataset">東京都（保健医療局）食品関係営業許可台帳</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.hokeniryo.metro.tokyo.lg.jp/kenkou/hokenjo_daicho/shokuhineigyokyokadaicho" target="_blank" rel="noopener">https://www.hokeniryo.metro.tokyo.lg.jp/kenkou/hokenjo_daicho/shokuhineigyokyokadaicho</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.hokeniryo.metro.tokyo.lg.jp/documents/d/hokeniryo/shokuhin-kyoka-4" target="_blank" rel="noopener">https://www.hokeniryo.metro.tokyo.lg.jp/documents/d/hokeniryo/shokuhin-…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：東京都「東京都（保健医療局）食品関係営業許可台帳」（https://www.hokeniryo.metro.tokyo.lg.jp/kenkou/hokenjo_daicho/shokuhineigyokyokadaicho）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：東京都「東京都（保健医療局）食品関係営業許可台帳」（https://www.hokeniryo.metro.tokyo.lg.jp/kenkou/hokenjo_daicho/shokuhineigyokyokadaicho）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-higashimurayama">
+        <h3>東村山市<span class="dataset">東京都東村山市食品等営業許可・届出一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://catalog.data.metro.tokyo.lg.jp/dataset/t132136d3100000018" target="_blank" rel="noopener">https://catalog.data.metro.tokyo.lg.jp/dataset/t132136d3100000018</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.opendata.metro.tokyo.lg.jp/higashimurayama/20240619_food_business_all.csv" target="_blank" rel="noopener">https://www.opendata.metro.tokyo.lg.jp/higashimurayama/20240619_food_bu…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：東村山市「東京都東村山市食品等営業許可・届出一覧」（https://catalog.data.metro.tokyo.lg.jp/dataset/t132136d3100000018）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：東村山市「東京都東村山市食品等営業許可・届出一覧」（https://catalog.data.metro.tokyo.lg.jp/dataset/t132136d3100000018）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-bodik-b5eeed4c">
+        <h3>東大阪市<span class="dataset">食品等営業許可一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.bodik.jp/dataset/272272_15" target="_blank" rel="noopener">https://data.bodik.jp/dataset/272272_15</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=45bffc27-277f-4a7e-a965-768fe026626a" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=45bffc27-277f-4a7e-…</a></dd>
+        </dl>
+        <span class="badge">元の表記: Creative Commons Attribution 4.0 International</span>
+        <div class="attr">
+          <code>出典：東大阪市「食品等営業許可一覧」（https://data.bodik.jp/dataset/272272_15）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：東大阪市「食品等営業許可一覧」（https://data.bodik.jp/dataset/272272_15）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-bodik-cbd20a26">
+        <h3>那覇市<span class="dataset">（継続）食品営業許可施設</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.bodik.jp/dataset/cbd20a26-da5f-4c15-a472-37cb43345c86" target="_blank" rel="noopener">https://data.bodik.jp/dataset/cbd20a26-da5f-4c15-a472-37cb43345c86</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=86f2d2a8-363d-404f-97f4-1aa10a970f86" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=86f2d2a8-363d-404f-…</a></dd>
+        </dl>
+        <span class="badge">元の表記: Creative Commons Attribution 4.0 International</span>
+        <div class="attr">
+          <code>出典：那覇市「（継続）食品営業許可施設」（https://data.bodik.jp/dataset/cbd20a26-da5f-4c15-a472-37cb43345c86）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：那覇市「（継続）食品営業許可施設」（https://data.bodik.jp/dataset/cbd20a26-da5f-4c15-a472-37cb43345c86）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-amagasaki">
+        <h3>尼崎市<span class="dataset">食品営業許可施設</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.amagasaki.hyogo.jp/op_data/1000922/1001025.html" target="_blank" rel="noopener">https://www.city.amagasaki.hyogo.jp/op_data/1000922/1001025.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.amagasaki.hyogo.jp/_res/projects/default_project/_page_/001/001/025/kyoka202605.csv" target="_blank" rel="noopener">https://www.city.amagasaki.hyogo.jp/_res/projects/default_project/_page…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：尼崎市「食品営業許可施設」（https://www.city.amagasaki.hyogo.jp/op_data/1000922/1001025.html）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：尼崎市「食品営業許可施設」（https://www.city.amagasaki.hyogo.jp/op_data/1000922/1001025.html）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-shinagawa-ku">
+        <h3>品川区<span class="dataset">東京都品川区食品衛生許可施設</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.shinagawa.tokyo.jp/PC/kenkou/kenkou-eisei/kenkou-eisei-syokuhin/opendate.html" target="_blank" rel="noopener">https://www.city.shinagawa.tokyo.jp/PC/kenkou/kenkou-eisei/kenkou-eisei-syokuhin/opendate.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.shinagawa.tokyo.jp/contentshozon2026/R6-7.csv" target="_blank" rel="noopener">https://www.city.shinagawa.tokyo.jp/contentshozon2026/R6-7.csv</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：品川区「東京都品川区食品衛生許可施設」（https://www.city.shinagawa.tokyo.jp/PC/kenkou/kenkou-eisei/kenkou-eisei-syokuhin/opendate.html）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：品川区「東京都品川区食品衛生許可施設」（https://www.city.shinagawa.tokyo.jp/PC/kenkou/kenkou-eisei/kenkou-eisei-syokuhin/opendate.html）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-bodik-2d6870cc">
+        <h3>豊中市<span class="dataset">食品等営業許可一覧（豊中市）</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.bodik.jp/dataset/2d6870cc-3db8-4069-841e-2a6deeb173b4" target="_blank" rel="noopener">https://data.bodik.jp/dataset/2d6870cc-3db8-4069-841e-2a6deeb173b4</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=74c6e0d8-9fde-4503-8090-bada26639ae3" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=74c6e0d8-9fde-4503-…</a></dd>
+        </dl>
+        <span class="badge">元の表記: Creative Commons Attribution 4.0 International</span>
+        <div class="attr">
+          <code>出典：豊中市「食品等営業許可一覧（豊中市）」（https://data.bodik.jp/dataset/2d6870cc-3db8-4069-841e-2a6deeb173b4）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：豊中市「食品等営業許可一覧（豊中市）」（https://data.bodik.jp/dataset/2d6870cc-3db8-4069-841e-2a6deeb173b4）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-bodik-385d18b1">
+        <h3>豊田市<span class="dataset">食品営業許可施設一覧（2026年5月31日現在）</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.bodik.jp/dataset/385d18b1-7493-4a82-8b0d-b00d2996da69" target="_blank" rel="noopener">https://data.bodik.jp/dataset/385d18b1-7493-4a82-8b0d-b00d2996da69</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=91fe2bf3-0a1a-4daa-acf4-5737ca31ab83" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=91fe2bf3-0a1a-4daa-…</a></dd>
+        </dl>
+        <span class="badge">元の表記: Creative Commons Attribution 4.0 International</span>
+        <div class="attr">
+          <code>出典：豊田市「食品営業許可施設一覧（2026年5月31日現在）」（https://data.bodik.jp/dataset/385d18b1-7493-4a82-8b0d-b00d2996da69）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：豊田市「食品営業許可施設一覧（2026年5月31日現在）」（https://data.bodik.jp/dataset/385d18b1-7493-4a82-8b0d-b00d2996da69）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-bodik-979f325a">
+        <h3>名古屋市<span class="dataset">【名古屋市】食品営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.bodik.jp/dataset/231002_1304020000_01" target="_blank" rel="noopener">https://data.bodik.jp/dataset/231002_1304020000_01</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=55e4db0f-05e4-4863-a7d4-22954e3fec7d" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=55e4db0f-05e4-4863-…</a></dd>
+        </dl>
+        <span class="badge">元の表記: Creative Commons Attribution 4.0 International</span>
+        <div class="attr">
+          <code>出典：名古屋市「【名古屋市】食品営業許可施設一覧」（https://data.bodik.jp/dataset/231002_1304020000_01）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：名古屋市「【名古屋市】食品営業許可施設一覧」（https://data.bodik.jp/dataset/231002_1304020000_01）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-bodik-ec8a7389">
+        <h3>和水町<span class="dataset">和水町_食品等営業許可・届出一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.bodik.jp/dataset/ec8a7389-ec6d-4630-b7dd-942d41138715" target="_blank" rel="noopener">https://data.bodik.jp/dataset/ec8a7389-ec6d-4630-b7dd-942d41138715</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=2a0e0687-165a-4b4a-8344-dd8005bf3da9" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=2a0e0687-165a-4b4a-…</a></dd>
+        </dl>
+        <span class="badge">元の表記: Creative Commons Attribution 4.0 International</span>
+        <div class="attr">
+          <code>出典：和水町「和水町_食品等営業許可・届出一覧」（https://data.bodik.jp/dataset/ec8a7389-ec6d-4630-b7dd-942d41138715）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：和水町「和水町_食品等営業許可・届出一覧」（https://data.bodik.jp/dataset/ec8a7389-ec6d-4630-b7dd-942d41138715）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+    </section>
+    <section class="license" id="cc-by-3-0">
+      <h2>CC BY 3.0 <span class="count">1 ソース</span></h2>
+      <p class="requirement">出典の明示と、改変した旨の表示が必要です。 — <a href="https://creativecommons.org/licenses/by/3.0/deed.ja" target="_blank" rel="noopener">ライセンス本文</a></p>
+      <article class="src" id="src-matsumoto">
+        <h3>松本市<span class="dataset">食品営業許可台帳</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.matsumoto.nagano.jp/soshiki/5/4172.html" target="_blank" rel="noopener">https://www.city.matsumoto.nagano.jp/soshiki/5/4172.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="http://linkdata.org/download/rdf1s8748i/link/shokuhin_kyoka_eigyo_matsumoto.txt" target="_blank" rel="noopener">http://linkdata.org/download/rdf1s8748i/link/shokuhin_kyoka_eigyo_matsu…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：松本市「食品営業許可台帳」（https://www.city.matsumoto.nagano.jp/soshiki/5/4172.html）を加工して作成（CC BY 3.0）</code>
+          <button type="button" class="copy" data-copy="出典：松本市「食品営業許可台帳」（https://www.city.matsumoto.nagano.jp/soshiki/5/4172.html）を加工して作成（CC BY 3.0）">コピー</button>
+        </div>
+      </article>
+    </section>
+    <section class="license" id="cc-by-2-1-jp">
+      <h2>CC BY 2.1 JP <span class="count">10 ソース</span></h2>
+      <p class="requirement">出典の明示と、改変した旨の表示が必要です。 — <a href="https://creativecommons.org/licenses/by/2.1/jp/" target="_blank" rel="noopener">ライセンス本文</a></p>
+      <article class="src" id="src-aichi-pref">
+        <h3>愛知県<span class="dataset">食品営業者台帳（新規許可）</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.pref.aichi.jp/opendata/" target="_blank" rel="noopener">https://www.pref.aichi.jp/opendata/</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.pref.aichi.jp/uploaded/attachment/619853.csv" target="_blank" rel="noopener">https://www.pref.aichi.jp/uploaded/attachment/619853.csv</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：愛知県「食品営業者台帳（新規許可）」（https://www.pref.aichi.jp/opendata/）を加工して作成（CC BY 2.1 JP）</code>
+          <button type="button" class="copy" data-copy="出典：愛知県「食品営業者台帳（新規許可）」（https://www.pref.aichi.jp/opendata/）を加工して作成（CC BY 2.1 JP）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-yamanashi-pref">
+        <h3>山梨県<span class="dataset">営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.pref.yamanashi.jp/eisei-ykm/itiranhyou1.html" target="_blank" rel="noopener">https://www.pref.yamanashi.jp/eisei-ykm/itiranhyou1.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.pref.yamanashi.jp/documents/23776/190004_food_business_all.csv" target="_blank" rel="noopener">https://www.pref.yamanashi.jp/documents/23776/190004_food_business_all.…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：山梨県「営業許可施設一覧」（https://www.pref.yamanashi.jp/eisei-ykm/itiranhyou1.html）を加工して作成（CC BY 2.1 JP）</code>
+          <button type="button" class="copy" data-copy="出典：山梨県「営業許可施設一覧」（https://www.pref.yamanashi.jp/eisei-ykm/itiranhyou1.html）を加工して作成（CC BY 2.1 JP）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-kobe">
+        <h3>神戸市<span class="dataset">食品営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.kobe.lg.jp/a99427/kenko/health/hygiene/dataset.html" target="_blank" rel="noopener">https://www.city.kobe.lg.jp/a99427/kenko/health/hygiene/dataset.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.kobe.lg.jp/documents/6359/20260407150739.csv" target="_blank" rel="noopener">https://www.city.kobe.lg.jp/documents/6359/20260407150739.csv</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：神戸市「食品営業許可施設一覧」（https://www.city.kobe.lg.jp/a99427/kenko/health/hygiene/dataset.html）を加工して作成（CC BY 2.1 JP）</code>
+          <button type="button" class="copy" data-copy="出典：神戸市「食品営業許可施設一覧」（https://www.city.kobe.lg.jp/a99427/kenko/health/hygiene/dataset.html）を加工して作成（CC BY 2.1 JP）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-kawaguchi">
+        <h3>川口市<span class="dataset">食品衛生営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.kawaguchi.lg.jp/soshiki/01090/027/shokuhin/oshirasetop/shisetsuichiran/index.html" target="_blank" rel="noopener">https://www.city.kawaguchi.lg.jp/soshiki/01090/027/shokuhin/oshirasetop/shisetsuichiran/index.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.kawaguchi.lg.jp/material/files/group/232/R0803zenshisetsuichiran.xls" target="_blank" rel="noopener">https://www.city.kawaguchi.lg.jp/material/files/group/232/R0803zenshise…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：川口市「食品衛生営業許可施設一覧」（https://www.city.kawaguchi.lg.jp/soshiki/01090/027/shokuhin/oshirasetop/shisetsuichiran/index.html）を加工して作成（CC BY 2.1 JP）</code>
+          <button type="button" class="copy" data-copy="出典：川口市「食品衛生営業許可施設一覧」（https://www.city.kawaguchi.lg.jp/soshiki/01090/027/shokuhin/oshirasetop/shisetsuichiran/index.html）を加工して作成（CC BY 2.1 JP）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-oita-city">
+        <h3>大分市<span class="dataset">食品営業許可・届出施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.oita.oita.jp/o095/kenko/hoken/20220908.html" target="_blank" rel="noopener">https://www.city.oita.oita.jp/o095/kenko/hoken/20220908.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.oita.oita.jp/o095/kenko/hoken/documents/r080601allkyoka.csv" target="_blank" rel="noopener">https://www.city.oita.oita.jp/o095/kenko/hoken/documents/r080601allkyok…</a><br><a href="https://www.city.oita.oita.jp/o095/kenko/hoken/documents/r080601alltodoke.csv" target="_blank" rel="noopener">https://www.city.oita.oita.jp/o095/kenko/hoken/documents/r080601alltodo…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：大分市「食品営業許可・届出施設一覧」（https://www.city.oita.oita.jp/o095/kenko/hoken/20220908.html）を加工して作成（CC BY 2.1 JP）</code>
+          <button type="button" class="copy" data-copy="出典：大分市「食品営業許可・届出施設一覧」（https://www.city.oita.oita.jp/o095/kenko/hoken/20220908.html）を加工して作成（CC BY 2.1 JP）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-nara-city">
+        <h3>奈良市<span class="dataset">食品営業許可施設</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.nara.lg.jp/soshiki/97/10411.html" target="_blank" rel="noopener">https://www.city.nara.lg.jp/soshiki/97/10411.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.nara.lg.jp/uploaded/attachment/203480.csv" target="_blank" rel="noopener">https://www.city.nara.lg.jp/uploaded/attachment/203480.csv</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：奈良市「食品営業許可施設」（https://www.city.nara.lg.jp/soshiki/97/10411.html）を加工して作成（CC BY 2.1 JP）</code>
+          <button type="button" class="copy" data-copy="出典：奈良市「食品営業許可施設」（https://www.city.nara.lg.jp/soshiki/97/10411.html）を加工して作成（CC BY 2.1 JP）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-fukui-city">
+        <h3>福井市<span class="dataset">食品営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.fukui.lg.jp/sisei/tokei/opendata/opengov.html" target="_blank" rel="noopener">https://www.city.fukui.lg.jp/sisei/tokei/opendata/opengov.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.fukui.lg.jp/fukusi/eisei/syokuhin/p070519.html" target="_blank" rel="noopener">https://www.city.fukui.lg.jp/fukusi/eisei/syokuhin/p070519.html</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：福井市「食品営業許可施設一覧」（https://www.city.fukui.lg.jp/sisei/tokei/opendata/opengov.html）を加工して作成（CC BY 2.1 JP）</code>
+          <button type="button" class="copy" data-copy="出典：福井市「食品営業許可施設一覧」（https://www.city.fukui.lg.jp/sisei/tokei/opendata/opengov.html）を加工して作成（CC BY 2.1 JP）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-fukushima-pref">
+        <h3>福島県<span class="dataset">食品営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.pref.fukushima.lg.jp/sec/21045e/shisetujouhou.html" target="_blank" rel="noopener">https://www.pref.fukushima.lg.jp/sec/21045e/shisetujouhou.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.pref.fukushima.lg.jp/uploaded/attachment/743308.xlsx" target="_blank" rel="noopener">https://www.pref.fukushima.lg.jp/uploaded/attachment/743308.xlsx</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：福島県「食品営業許可施設一覧」（https://www.pref.fukushima.lg.jp/sec/21045e/shisetujouhou.html）を加工して作成（CC BY 2.1 JP）</code>
+          <button type="button" class="copy" data-copy="出典：福島県「食品営業許可施設一覧」（https://www.pref.fukushima.lg.jp/sec/21045e/shisetujouhou.html）を加工して作成（CC BY 2.1 JP）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-fukushima-city">
+        <h3>福島市<span class="dataset">食品営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.fukushima.fukushima.jp/soshiki/2/1005/1/1/5/1_1/index.html" target="_blank" rel="noopener">https://www.city.fukushima.fukushima.jp/soshiki/2/1005/1/1/5/1_1/index.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.fukushima.fukushima.jp/soshiki/2/1005/1/1/5/1_1/index.html" target="_blank" rel="noopener">https://www.city.fukushima.fukushima.jp/soshiki/2/1005/1/1/5/1_1/index.…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：福島市「食品営業許可施設一覧」（https://www.city.fukushima.fukushima.jp/soshiki/2/1005/1/1/5/1_1/index.html）を加工して作成（CC BY 2.1 JP）</code>
+          <button type="button" class="copy" data-copy="出典：福島市「食品営業許可施設一覧」（https://www.city.fukushima.fukushima.jp/soshiki/2/1005/1/1/5/1_1/index.html）を加工して作成（CC BY 2.1 JP）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-hirakata">
+        <h3>枚方市<span class="dataset">食品等営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.hirakata.osaka.jp/0000023479.html" target="_blank" rel="noopener">https://www.city.hirakata.osaka.jp/0000023479.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.hirakata.osaka.jp/cmsfiles/contents/0000023/23479/272108_food_business_all_202603_end.csv" target="_blank" rel="noopener">https://www.city.hirakata.osaka.jp/cmsfiles/contents/0000023/23479/2721…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：枚方市「食品等営業許可施設一覧」（https://www.city.hirakata.osaka.jp/0000023479.html）を加工して作成（CC BY 2.1 JP）</code>
+          <button type="button" class="copy" data-copy="出典：枚方市「食品等営業許可施設一覧」（https://www.city.hirakata.osaka.jp/0000023479.html）を加工して作成（CC BY 2.1 JP）">コピー</button>
+        </div>
+      </article>
+    </section>
+    <section class="license" id="cc-by-2-0">
+      <h2>CC BY 2.0 <span class="count">2 ソース</span></h2>
+      <p class="requirement">出典の明示と、改変した旨の表示が必要です。 — <a href="https://creativecommons.org/licenses/by/2.0/deed.ja" target="_blank" rel="noopener">ライセンス本文</a></p>
+      <article class="src" id="src-gifu-pref">
+        <h3>岐阜県<span class="dataset">食品営業許可施設情報</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://gifu-opendata.pref.gifu.lg.jp/dataset/f6bbdb66-1d55-4e55-82cb-15fe1bb24223" target="_blank" rel="noopener">https://gifu-opendata.pref.gifu.lg.jp/dataset/f6bbdb66-1d55-4e55-82cb-15fe1bb24223</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://gifu-opendata.pref.gifu.lg.jp/dataset/f6bbdb66-1d55-4e55-82cb-15fe1bb24223/resource/3c7d862d-a126-4441-a5b1-4839096b2591/download/20250331syokuhin.csv" target="_blank" rel="noopener">https://gifu-opendata.pref.gifu.lg.jp/dataset/f6bbdb66-1d55-4e55-82cb-1…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：岐阜県「食品営業許可施設情報」（https://gifu-opendata.pref.gifu.lg.jp/dataset/f6bbdb66-1d55-4e55-82cb-15fe1bb24223）を加工して作成（CC BY 2.0）</code>
+          <button type="button" class="copy" data-copy="出典：岐阜県「食品営業許可施設情報」（https://gifu-opendata.pref.gifu.lg.jp/dataset/f6bbdb66-1d55-4e55-82cb-15fe1bb24223）を加工して作成（CC BY 2.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-gifu-city">
+        <h3>岐阜市<span class="dataset">食品等営業許可一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://gifu-opendata.pref.gifu.lg.jp/dataset/2f9f1b1c-be25-4a27-96c6-47b597f1a0bd" target="_blank" rel="noopener">https://gifu-opendata.pref.gifu.lg.jp/dataset/2f9f1b1c-be25-4a27-96c6-47b597f1a0bd</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://gifu-opendata.pref.gifu.lg.jp/dataset/2f9f1b1c-be25-4a27-96c6-47b597f1a0bd/resource/16ef7794-d2b6-4d7d-8353-f55193432530/download/gifushisyokuhinkyokar7.6.1.csv" target="_blank" rel="noopener">https://gifu-opendata.pref.gifu.lg.jp/dataset/2f9f1b1c-be25-4a27-96c6-4…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：岐阜市「食品等営業許可一覧」（https://gifu-opendata.pref.gifu.lg.jp/dataset/2f9f1b1c-be25-4a27-96c6-47b597f1a0bd）を加工して作成（CC BY 2.0）</code>
+          <button type="button" class="copy" data-copy="出典：岐阜市「食品等営業許可一覧」（https://gifu-opendata.pref.gifu.lg.jp/dataset/2f9f1b1c-be25-4a27-96c6-47b597f1a0bd）を加工して作成（CC BY 2.0）">コピー</button>
+        </div>
+      </article>
+    </section>
+    <section class="license" id="cc-by">
+      <h2>CC BY（バージョン表記なし） <span class="count">17 ソース</span></h2>
+      <p class="requirement">掲載ページに「CC BY」とのみ記載されており、バージョンが特定できないソースです。CC BY 共通の要件である出典の明示と改変した旨の表示を行ってください（元の表記は各行に併記しています）。 — <a href="https://creativecommons.org/licenses/by/4.0/deed.ja" target="_blank" rel="noopener">ライセンス本文</a></p>
+      <article class="src" id="src-shimonoseki">
+        <h3>下関市<span class="dataset">食品営業許可施設一覧（マップ用）</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://yamaguchi-opendata.jp/ckan/dataset/50c21bfa-4ee1-4553-b166-8ed2e625a6f5" target="_blank" rel="noopener">https://yamaguchi-opendata.jp/ckan/dataset/50c21bfa-4ee1-4553-b166-8ed2e625a6f5</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://yamaguchi-opendata.jp/ckan/dataset/50c21bfa-4ee1-4553-b166-8ed2e625a6f5/resource/f61a61f9-a9ca-448f-8e48-38f647fd2539/download/352012_food_business_map.csv" target="_blank" rel="noopener">https://yamaguchi-opendata.jp/ckan/dataset/50c21bfa-4ee1-4553-b166-8ed2…</a></dd>
+        </dl>
+        <span class="badge">元の表記: CC BY</span>
+        <div class="attr">
+          <code>出典：下関市「食品営業許可施設一覧（マップ用）」（https://yamaguchi-opendata.jp/ckan/dataset/50c21bfa-4ee1-4553-b166-8ed2e625a6f5）を加工して作成（CC BY（バージョン表記なし））</code>
+          <button type="button" class="copy" data-copy="出典：下関市「食品営業許可施設一覧（マップ用）」（https://yamaguchi-opendata.jp/ckan/dataset/50c21bfa-4ee1-4553-b166-8ed2e625a6f5）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-bodik-f85dc2fb">
+        <h3>久留米市<span class="dataset">久留米市新規食品営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.bodik.jp/dataset/f85dc2fb-b148-4ed8-a00e-51a51e953793" target="_blank" rel="noopener">https://data.bodik.jp/dataset/f85dc2fb-b148-4ed8-a00e-51a51e953793</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=c1769ec0-e049-4256-a8c0-c0afd319843d" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=c1769ec0-e049-4256-…</a></dd>
+        </dl>
+        <span class="badge">元の表記: Creative Commons Attribution</span>
+        <div class="attr">
+          <code>出典：久留米市「久留米市新規食品営業許可施設一覧」（https://data.bodik.jp/dataset/f85dc2fb-b148-4ed8-a00e-51a51e953793）を加工して作成（CC BY（バージョン表記なし））</code>
+          <button type="button" class="copy" data-copy="出典：久留米市「久留米市新規食品営業許可施設一覧」（https://data.bodik.jp/dataset/f85dc2fb-b148-4ed8-a00e-51a51e953793）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-kanazawa">
+        <h3>金沢市<span class="dataset">食品衛生関係営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://catalog-data.city.kanazawa.ishikawa.jp/dataset/172014-syokuhineisei-kyokashisetsu" target="_blank" rel="noopener">https://catalog-data.city.kanazawa.ishikawa.jp/dataset/172014-syokuhineisei-kyokashisetsu</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://catalog-data.city.kanazawa.ishikawa.jp/datastore/dump/09a49521-cabf-40b4-978b-bd61ef02f650?bom=true" target="_blank" rel="noopener">https://catalog-data.city.kanazawa.ishikawa.jp/datastore/dump/09a49521-…</a></dd>
+        </dl>
+        <span class="badge">元の表記: CC BY</span>
+        <div class="attr">
+          <code>出典：金沢市「食品衛生関係営業許可施設一覧」（https://catalog-data.city.kanazawa.ishikawa.jp/dataset/172014-syokuhineisei-kyokashisetsu）を加工して作成（CC BY（バージョン表記なし））</code>
+          <button type="button" class="copy" data-copy="出典：金沢市「食品衛生関係営業許可施設一覧」（https://catalog-data.city.kanazawa.ishikawa.jp/dataset/172014-syokuhineisei-kyokashisetsu）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-takamatsu">
+        <h3>高松市<span class="dataset">食品等営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://opendata.smartcity-takamatsu.jp/ckan/dataset/licensed_food_business_facility_list" target="_blank" rel="noopener">https://opendata.smartcity-takamatsu.jp/ckan/dataset/licensed_food_business_facility_list</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://opendata.takamatsu-fact.com/licensed_food_business_facility_list/data.csv" target="_blank" rel="noopener">https://opendata.takamatsu-fact.com/licensed_food_business_facility_lis…</a></dd>
+        </dl>
+        <span class="badge">元の表記: CC BY</span>
+        <div class="attr">
+          <code>出典：高松市「食品等営業許可施設一覧」（https://opendata.smartcity-takamatsu.jp/ckan/dataset/licensed_food_business_facility_list）を加工して作成（CC BY（バージョン表記なし））</code>
+          <button type="button" class="copy" data-copy="出典：高松市「食品等営業許可施設一覧」（https://opendata.smartcity-takamatsu.jp/ckan/dataset/licensed_food_business_facility_list）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-yamaguchi-pref">
+        <h3>山口県<span class="dataset">食品営業許可施設情報一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://yamaguchi-opendata.jp/ckan/dataset/9d0d2325-62b4-447c-8817-a381c968a5cd" target="_blank" rel="noopener">https://yamaguchi-opendata.jp/ckan/dataset/9d0d2325-62b4-447c-8817-a381c968a5cd</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://yamaguchi-opendata.jp/ckan/dataset/9d0d2325-62b4-447c-8817-a381c968a5cd/resource/44efb857-48c7-4a2e-9e99-61bf38f6f125/download/350001_food_business_all.csv" target="_blank" rel="noopener">https://yamaguchi-opendata.jp/ckan/dataset/9d0d2325-62b4-447c-8817-a381…</a></dd>
+        </dl>
+        <span class="badge">元の表記: CC BY</span>
+        <div class="attr">
+          <code>出典：山口県「食品営業許可施設情報一覧」（https://yamaguchi-opendata.jp/ckan/dataset/9d0d2325-62b4-447c-8817-a381c968a5cd）を加工して作成（CC BY（バージョン表記なし））</code>
+          <button type="button" class="copy" data-copy="出典：山口県「食品営業許可施設情報一覧」（https://yamaguchi-opendata.jp/ckan/dataset/9d0d2325-62b4-447c-8817-a381c968a5cd）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-matsuyama">
+        <h3>松山市<span class="dataset">食品営業許可全施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.html" target="_blank" rel="noopener">https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.files/382019_food_business_all_2026031.csv" target="_blank" rel="noopener">https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.f…</a><br><a href="https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.files/382019_food_business_all_2026032.csv" target="_blank" rel="noopener">https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.f…</a></dd>
+        </dl>
+        <span class="badge">元の表記: CC BY</span>
+        <div class="attr">
+          <code>出典：松山市「食品営業許可全施設一覧」（https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.html）を加工して作成（CC BY（バージョン表記なし））</code>
+          <button type="button" class="copy" data-copy="出典：松山市「食品営業許可全施設一覧」（https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.html）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-nishinomiya">
+        <h3>西宮市<span class="dataset">食品営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="http://opendata.nishi.or.jp/opendata/ResultDetail.php?id=9" target="_blank" rel="noopener">http://opendata.nishi.or.jp/opendata/ResultDetail.php?id=9</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="http://opendata.nishi.or.jp/opendata/ResultDetail.php?id=9" target="_blank" rel="noopener">http://opendata.nishi.or.jp/opendata/ResultDetail.php?id=9</a></dd>
+        </dl>
+        <span class="badge">元の表記: CC BY相当</span>
+        <div class="attr">
+          <code>出典：西宮市「食品営業許可施設一覧」（http://opendata.nishi.or.jp/opendata/ResultDetail.php?id=9）を加工して作成（CC BY（バージョン表記なし））</code>
+          <button type="button" class="copy" data-copy="出典：西宮市「食品営業許可施設一覧」（http://opendata.nishi.or.jp/opendata/ResultDetail.php?id=9）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-bodik-86a8d652">
+        <h3>静岡市<span class="dataset">食品衛生関係営業許可台帳</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.bodik.jp/dataset/86a8d652-beb2-41b7-8da6-f9245e04217d" target="_blank" rel="noopener">https://data.bodik.jp/dataset/86a8d652-beb2-41b7-8da6-f9245e04217d</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=76e0c6d1-2332-4ca9-afd5-1ef442733eff" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=76e0c6d1-2332-4ca9-…</a></dd>
+        </dl>
+        <span class="badge">元の表記: Creative Commons Attribution</span>
+        <div class="attr">
+          <code>出典：静岡市「食品衛生関係営業許可台帳」（https://data.bodik.jp/dataset/86a8d652-beb2-41b7-8da6-f9245e04217d）を加工して作成（CC BY（バージョン表記なし））</code>
+          <button type="button" class="copy" data-copy="出典：静岡市「食品衛生関係営業許可台帳」（https://data.bodik.jp/dataset/86a8d652-beb2-41b7-8da6-f9245e04217d）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-tottori-city">
+        <h3>鳥取市<span class="dataset">食品等営業許可・届出一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://odp-pref-tottori.tori-info.co.jp/dataset/1858" target="_blank" rel="noopener">https://odp-pref-tottori.tori-info.co.jp/dataset/1858</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://odp-pref-tottori.tori-info.co.jp/dataset/1858/resource/9560/312011_food_business_all.csv" target="_blank" rel="noopener">https://odp-pref-tottori.tori-info.co.jp/dataset/1858/resource/9560/312…</a></dd>
+        </dl>
+        <span class="badge">元の表記: CC BY</span>
+        <div class="attr">
+          <code>出典：鳥取市「食品等営業許可・届出一覧」（https://odp-pref-tottori.tori-info.co.jp/dataset/1858）を加工して作成（CC BY（バージョン表記なし））</code>
+          <button type="button" class="copy" data-copy="出典：鳥取市「食品等営業許可・届出一覧」（https://odp-pref-tottori.tori-info.co.jp/dataset/1858）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-tokushima-pref">
+        <h3>徳島県<span class="dataset">食品等営業許可・届出一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://opendata.pref.tokushima.lg.jp/dataset/4615" target="_blank" rel="noopener">https://opendata.pref.tokushima.lg.jp/dataset/4615</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://opendata.pref.tokushima.lg.jp/dataset/4615/resource/14084/36000_food_business_all.csv" target="_blank" rel="noopener">https://opendata.pref.tokushima.lg.jp/dataset/4615/resource/14084/36000…</a></dd>
+        </dl>
+        <span class="badge">元の表記: CC BY</span>
+        <div class="attr">
+          <code>出典：徳島県「食品等営業許可・届出一覧」（https://opendata.pref.tokushima.lg.jp/dataset/4615）を加工して作成（CC BY（バージョン表記なし））</code>
+          <button type="button" class="copy" data-copy="出典：徳島県「食品等営業許可・届出一覧」（https://opendata.pref.tokushima.lg.jp/dataset/4615）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-hamamatsu">
+        <h3>浜松市<span class="dataset">食品衛生台帳（新規）</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://opendata.pref.shizuoka.jp/dataset/11921.html" target="_blank" rel="noopener">https://opendata.pref.shizuoka.jp/dataset/11921.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://static.hamamatsu.odpf.net/opendata/v01/syokuhineiseidaityou202401/syokuhineiseidaityou202401.csv" target="_blank" rel="noopener">https://static.hamamatsu.odpf.net/opendata/v01/syokuhineiseidaityou2024…</a></dd>
+        </dl>
+        <span class="badge">元の表記: CC BY</span>
+        <div class="attr">
+          <code>出典：浜松市「食品衛生台帳（新規）」（https://opendata.pref.shizuoka.jp/dataset/11921.html）を加工して作成（CC BY（バージョン表記なし））</code>
+          <button type="button" class="copy" data-copy="出典：浜松市「食品衛生台帳（新規）」（https://opendata.pref.shizuoka.jp/dataset/11921.html）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-toyama-pref">
+        <h3>富山県<span class="dataset">食品営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://opendata.pref.toyama.jp/dataset/syokuhin" target="_blank" rel="noopener">https://opendata.pref.toyama.jp/dataset/syokuhin</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://toyama-pref.box.com/shared/static/1t6074lluawpua1u5jhx1yeaynb48rle.csv" target="_blank" rel="noopener">https://toyama-pref.box.com/shared/static/1t6074lluawpua1u5jhx1yeaynb48…</a></dd>
+        </dl>
+        <span class="badge">元の表記: CC BY</span>
+        <div class="attr">
+          <code>出典：富山県「食品営業許可施設一覧」（https://opendata.pref.toyama.jp/dataset/syokuhin）を加工して作成（CC BY（バージョン表記なし））</code>
+          <button type="button" class="copy" data-copy="出典：富山県「食品営業許可施設一覧」（https://opendata.pref.toyama.jp/dataset/syokuhin）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-toyama-city">
+        <h3>富山市<span class="dataset">食品営業許可施設</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://opdt.city.toyama.lg.jp/dataset/fb1198c6-3ac2-42fc-ae99-81ea5ba09a2d" target="_blank" rel="noopener">https://opdt.city.toyama.lg.jp/dataset/fb1198c6-3ac2-42fc-ae99-81ea5ba09a2d</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://opdt.city.toyama.lg.jp/dataset/fb1198c6-3ac2-42fc-ae99-81ea5ba09a2d/resource/fa38003f-accd-4690-b71b-96b1d78e1c45/download/syokuhin.xlsx" target="_blank" rel="noopener">https://opdt.city.toyama.lg.jp/dataset/fb1198c6-3ac2-42fc-ae99-81ea5ba0…</a></dd>
+        </dl>
+        <span class="badge">元の表記: CC BY</span>
+        <div class="attr">
+          <code>出典：富山市「食品営業許可施設」（https://opdt.city.toyama.lg.jp/dataset/fb1198c6-3ac2-42fc-ae99-81ea5ba09a2d）を加工して作成（CC BY（バージョン表記なし））</code>
+          <button type="button" class="copy" data-copy="出典：富山市「食品営業許可施設」（https://opdt.city.toyama.lg.jp/dataset/fb1198c6-3ac2-42fc-ae99-81ea5ba09a2d）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-fukui-pref">
+        <h3>福井県<span class="dataset">食品営業許可取得施設</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://ckan.odp.jig.jp/dataset/jp-fukui-776-odp" target="_blank" rel="noopener">https://ckan.odp.jig.jp/dataset/jp-fukui-776-odp</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.odp.jig.jp/viewcsv/jp/fukui/776.csv" target="_blank" rel="noopener">https://data.odp.jig.jp/viewcsv/jp/fukui/776.csv</a><br><a href="https://data.odp.jig.jp/viewcsv/jp/fukui/777.csv" target="_blank" rel="noopener">https://data.odp.jig.jp/viewcsv/jp/fukui/777.csv</a></dd>
+        </dl>
+        <span class="badge">元の表記: CC BY</span>
+        <div class="attr">
+          <code>出典：福井県「食品営業許可取得施設」（https://ckan.odp.jig.jp/dataset/jp-fukui-776-odp）を加工して作成（CC BY（バージョン表記なし））</code>
+          <button type="button" class="copy" data-copy="出典：福井県「食品営業許可取得施設」（https://ckan.odp.jig.jp/dataset/jp-fukui-776-odp）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-bodik-5925a9fb">
+        <h3>福岡市<span class="dataset">福岡市　飲食店営業等営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.bodik.jp/dataset/5925a9fb-3326-4499-9acd-7b18c03d5e32" target="_blank" rel="noopener">https://data.bodik.jp/dataset/5925a9fb-3326-4499-9acd-7b18c03d5e32</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=70d22acf-2353-4bc1-b45d-f12d45da5216" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=70d22acf-2353-4bc1-…</a></dd>
+        </dl>
+        <span class="badge">元の表記: Creative Commons Attribution</span>
+        <div class="attr">
+          <code>出典：福岡市「福岡市　飲食店営業等営業許可施設一覧」（https://data.bodik.jp/dataset/5925a9fb-3326-4499-9acd-7b18c03d5e32）を加工して作成（CC BY（バージョン表記なし））</code>
+          <button type="button" class="copy" data-copy="出典：福岡市「福岡市　飲食店営業等営業許可施設一覧」（https://data.bodik.jp/dataset/5925a9fb-3326-4499-9acd-7b18c03d5e32）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-fukuyama">
+        <h3>福山市<span class="dataset">営業許認可等施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.city.fukuyama.hiroshima.jp/dataset/61f415c5-88f7-46d0-8ada-4bb8855685a0" target="_blank" rel="noopener">https://data.city.fukuyama.hiroshima.jp/dataset/61f415c5-88f7-46d0-8ada-4bb8855685a0</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.city.fukuyama.hiroshima.jp/dataset/61f415c5-88f7-46d0-8ada-4bb8855685a0/resource/21fec913-dc08-4344-94d1-ffb0068ab147/download/2026_3all.csv" target="_blank" rel="noopener">https://data.city.fukuyama.hiroshima.jp/dataset/61f415c5-88f7-46d0-8ada…</a></dd>
+        </dl>
+        <span class="badge">元の表記: CC BY</span>
+        <div class="attr">
+          <code>出典：福山市「営業許認可等施設一覧」（https://data.city.fukuyama.hiroshima.jp/dataset/61f415c5-88f7-46d0-8ada-4bb8855685a0）を加工して作成（CC BY（バージョン表記なし））</code>
+          <button type="button" class="copy" data-copy="出典：福山市「営業許認可等施設一覧」（https://data.city.fukuyama.hiroshima.jp/dataset/61f415c5-88f7-46d0-8ada-4bb8855685a0）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-bodik-822fb681">
+        <h3>北九州市<span class="dataset">北九州市　食品衛生法等許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.bodik.jp/dataset/822fb681-346a-444e-b482-33c67b50cac3" target="_blank" rel="noopener">https://data.bodik.jp/dataset/822fb681-346a-444e-b482-33c67b50cac3</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=dab2c5a1-393e-4bd2-9bab-7350296a05da" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=dab2c5a1-393e-4bd2-…</a></dd>
+        </dl>
+        <span class="badge">元の表記: Creative Commons Attribution</span>
+        <div class="attr">
+          <code>出典：北九州市「北九州市　食品衛生法等許可施設一覧」（https://data.bodik.jp/dataset/822fb681-346a-444e-b482-33c67b50cac3）を加工して作成（CC BY（バージョン表記なし））</code>
+          <button type="button" class="copy" data-copy="出典：北九州市「北九州市　食品衛生法等許可施設一覧」（https://data.bodik.jp/dataset/822fb681-346a-444e-b482-33c67b50cac3）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
+        </div>
+      </article>
+    </section>
+    <section class="license" id="pdl-1-0">
+      <h2>公共データ利用規約（第1.0版・PDL1.0） <span class="count">2 ソース</span></h2>
+      <p class="requirement">出典の明示が必要です（商用利用を含めて再利用可・CC BY 4.0 互換）。編集・加工した情報を提供する場合は、加工した旨も併記してください。 — <a href="https://www.digital.go.jp/resources/open_data/public_data_license_v1.0" target="_blank" rel="noopener">ライセンス本文</a></p>
+      <article class="src" id="src-kumamoto-city">
+        <h3>熊本市<span class="dataset">飲食店営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.kumamoto.jp/dynamic/opendata/pub/detail.aspx?c_id=38&amp;id=60" target="_blank" rel="noopener">https://www.city.kumamoto.jp/dynamic/opendata/pub/detail.aspx?c_id=38&amp;id=60</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.kumamoto.jp/dynamic/opendata/pub/Insyokutenneigyoukyoka.csv" target="_blank" rel="noopener">https://www.city.kumamoto.jp/dynamic/opendata/pub/Insyokutenneigyoukyok…</a></dd>
+        </dl>
+        <span class="badge">元の表記: 公共データ利用規約</span>
+        <div class="attr">
+          <code>出典：熊本市「飲食店営業許可施設一覧」（https://www.city.kumamoto.jp/dynamic/opendata/pub/detail.aspx?c_id=38&amp;id=60）を加工して作成（公共データ利用規約（第1.0版・PDL1.0））</code>
+          <button type="button" class="copy" data-copy="出典：熊本市「飲食店営業許可施設一覧」（https://www.city.kumamoto.jp/dynamic/opendata/pub/detail.aspx?c_id=38&amp;id=60）を加工して作成（公共データ利用規約（第1.0版・PDL1.0））">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-mhlw-i2fas">
+        <h3>厚生労働省<span class="dataset">食品衛生申請等システム（オープンデータ）</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://i2fas.mhlw.go.jp/faspub/IO_S010303.do" target="_blank" rel="noopener">https://i2fas.mhlw.go.jp/faspub/IO_S010303.do</a></dd>
+          <dt>取得URL</dt>
+          <dd><span class="muted">（キャッシュ経由・固定URLなし）</span></dd>
+        </dl>
+        <span class="badge">元の表記: 公共データ利用規約（第1.0版, PDL1.0）</span>
+        <div class="attr">
+          <code>出典：厚生労働省「食品衛生申請等システム（オープンデータ）」（https://i2fas.mhlw.go.jp/faspub/IO_S010303.do）を加工して作成（公共データ利用規約（第1.0版・PDL1.0））</code>
+          <button type="button" class="copy" data-copy="出典：厚生労働省「食品衛生申請等システム（オープンデータ）」（https://i2fas.mhlw.go.jp/faspub/IO_S010303.do）を加工して作成（公共データ利用規約（第1.0版・PDL1.0））">コピー</button>
+        </div>
+      </article>
+    </section>
+    <section class="license" id="local-terms">
+      <h2>自治体独自の利用規約 <span class="count">7 ソース</span></h2>
+      <p class="requirement">各自治体が定める独自の利用規約に従ってください（いずれも出典の明示が必要です）。規約の内容は各行の出典ページから確認できます。</p>
+      <article class="src" id="src-hiroshima-pref">
+        <h3>広島県<span class="dataset">食品営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.pref.hiroshima.lg.jp/soshiki/172/eigyoukyokaninnteisisetuitirann.html" target="_blank" rel="noopener">https://www.pref.hiroshima.lg.jp/soshiki/172/eigyoukyokaninnteisisetuitirann.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.pref.hiroshima.lg.jp/uploaded/attachment/664836.xlsx" target="_blank" rel="noopener">https://www.pref.hiroshima.lg.jp/uploaded/attachment/664836.xlsx</a></dd>
+        </dl>
+        <span class="badge">元の表記: 広島県利用規約</span>
+        <div class="attr">
+          <code>出典：広島県「食品営業許可施設一覧」（https://www.pref.hiroshima.lg.jp/soshiki/172/eigyoukyokaninnteisisetuitirann.html）を加工して作成</code>
+          <button type="button" class="copy" data-copy="出典：広島県「食品営業許可施設一覧」（https://www.pref.hiroshima.lg.jp/soshiki/172/eigyoukyokaninnteisisetuitirann.html）を加工して作成">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-shiga-pref">
+        <h3>滋賀県<span class="dataset">食品営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.pref.shiga.lg.jp/ippan/kurashi/syokunoanzen/300273.html" target="_blank" rel="noopener">https://www.pref.shiga.lg.jp/ippan/kurashi/syokunoanzen/300273.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.pref.shiga.lg.jp/ippan/kurashi/syokunoanzen/300273.html" target="_blank" rel="noopener">https://www.pref.shiga.lg.jp/ippan/kurashi/syokunoanzen/300273.html</a></dd>
+        </dl>
+        <span class="badge">元の表記: 滋賀県OD利用規約</span>
+        <div class="attr">
+          <code>出典：滋賀県「食品営業許可施設一覧」（https://www.pref.shiga.lg.jp/ippan/kurashi/syokunoanzen/300273.html）を加工して作成</code>
+          <button type="button" class="copy" data-copy="出典：滋賀県「食品営業許可施設一覧」（https://www.pref.shiga.lg.jp/ippan/kurashi/syokunoanzen/300273.html）を加工して作成">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-ishikawa-pref">
+        <h3>石川県<span class="dataset">営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.pref.ishikawa.lg.jp/yakuji/syokuhin/opendate.html" target="_blank" rel="noopener">https://www.pref.ishikawa.lg.jp/yakuji/syokuhin/opendate.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.pref.ishikawa.lg.jp/yakuji/syokuhin/documents/nendor7.xlsx" target="_blank" rel="noopener">https://www.pref.ishikawa.lg.jp/yakuji/syokuhin/documents/nendor7.xlsx</a></dd>
+        </dl>
+        <span class="badge">元の表記: 石川県利用規約</span>
+        <div class="attr">
+          <code>出典：石川県「営業許可施設一覧」（https://www.pref.ishikawa.lg.jp/yakuji/syokuhin/opendate.html）を加工して作成</code>
+          <button type="button" class="copy" data-copy="出典：石川県「営業許可施設一覧」（https://www.pref.ishikawa.lg.jp/yakuji/syokuhin/opendate.html）を加工して作成">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-nagano-pref">
+        <h3>長野県<span class="dataset">食品営業許可施設</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/opendata.html" target="_blank" rel="noopener">https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/opendata.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv" target="_blank" rel="noopener">https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/document…</a></dd>
+        </dl>
+        <span class="badge">元の表記: 長野県オープンデータ利用規約</span>
+        <div class="attr">
+          <code>出典：長野県「食品営業許可施設」（https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/opendata.html）を加工して作成</code>
+          <button type="button" class="copy" data-copy="出典：長野県「食品営業許可施設」（https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/opendata.html）を加工して作成">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-fujisawa">
+        <h3>藤沢市<span class="dataset">食品営業許可施設情報</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.fujisawa.kanagawa.jp/seiei/shokuhineisei/opendatabase.html" target="_blank" rel="noopener">https://www.city.fujisawa.kanagawa.jp/seiei/shokuhineisei/opendatabase.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.fujisawa.kanagawa.jp/seiei/shokuhineisei/opendatabase.html" target="_blank" rel="noopener">https://www.city.fujisawa.kanagawa.jp/seiei/shokuhineisei/opendatabase.…</a></dd>
+        </dl>
+        <span class="badge">元の表記: 藤沢市オープンデータ利用規約</span>
+        <div class="attr">
+          <code>出典：藤沢市「食品営業許可施設情報」（https://www.city.fujisawa.kanagawa.jp/seiei/shokuhineisei/opendatabase.html）を加工して作成</code>
+          <button type="button" class="copy" data-copy="出典：藤沢市「食品営業許可施設情報」（https://www.city.fujisawa.kanagawa.jp/seiei/shokuhineisei/opendatabase.html）を加工して作成">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-nara-pref">
+        <h3>奈良県<span class="dataset">食品営業許可施設一覧（奈良市を除く）</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.pref.nara.lg.jp/n086/52413.html" target="_blank" rel="noopener">https://www.pref.nara.lg.jp/n086/52413.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.pref.nara.lg.jp/n086/52413.html" target="_blank" rel="noopener">https://www.pref.nara.lg.jp/n086/52413.html</a></dd>
+        </dl>
+        <span class="badge">元の表記: 奈良県（出典明示・利用規約に従う）</span>
+        <div class="attr">
+          <code>出典：奈良県「食品営業許可施設一覧（奈良市を除く）」（https://www.pref.nara.lg.jp/n086/52413.html）を加工して作成</code>
+          <button type="button" class="copy" data-copy="出典：奈良県「食品営業許可施設一覧（奈良市を除く）」（https://www.pref.nara.lg.jp/n086/52413.html）を加工して作成">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-kashiwa">
+        <h3>柏市<span class="dataset">食品営業許可一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.kashiwa.lg.jp/databunseki/shiseijoho/jouhoukoukai/opendate/food.html" target="_blank" rel="noopener">https://www.city.kashiwa.lg.jp/databunseki/shiseijoho/jouhoukoukai/opendate/food.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.kashiwa.lg.jp/documents/24912/122173_food_business_all.csv" target="_blank" rel="noopener">https://www.city.kashiwa.lg.jp/documents/24912/122173_food_business_all…</a></dd>
+        </dl>
+        <span class="badge">元の表記: 柏市オープンデータ利用規約</span>
+        <div class="attr">
+          <code>出典：柏市「食品営業許可一覧」（https://www.city.kashiwa.lg.jp/databunseki/shiseijoho/jouhoukoukai/opendate/food.html）を加工して作成</code>
+          <button type="button" class="copy" data-copy="出典：柏市「食品営業許可一覧」（https://www.city.kashiwa.lg.jp/databunseki/shiseijoho/jouhoukoukai/opendate/food.html）を加工して作成">コピー</button>
+        </div>
+      </article>
+    </section>
+    <section class="license" id="unconfirmed">
+      <h2>ライセンス表記が未確認 <span class="count">9 ソース</span></h2>
+      <p class="requirement">掲載ページでライセンスの明示が確認できなかったソースです。本 API では出典を明示したうえで収録しています。再利用にあたっては、各自治体の利用条件を必ずご自身でご確認ください。</p>
+      <article class="src" id="src-koriyama">
+        <h3>郡山市<span class="dataset">食品営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.koriyama.lg.jp/soshiki/74/7244.html" target="_blank" rel="noopener">https://www.city.koriyama.lg.jp/soshiki/74/7244.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.koriyama.lg.jp/uploaded/attachment/120902.xls" target="_blank" rel="noopener">https://www.city.koriyama.lg.jp/uploaded/attachment/120902.xls</a></dd>
+        </dl>
+        <span class="badge">元の表記: 要確認</span>
+        <div class="attr">
+          <code>出典：郡山市「食品営業許可施設一覧」（https://www.city.koriyama.lg.jp/soshiki/74/7244.html）を加工して作成</code>
+          <button type="button" class="copy" data-copy="出典：郡山市「食品営業許可施設一覧」（https://www.city.koriyama.lg.jp/soshiki/74/7244.html）を加工して作成">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-kofu">
+        <h3>甲府市<span class="dataset">食品営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.kofu.yamanashi.jp/hokenjo/h31-shokuhin/2019-shokuhinkyokaitiran.html" target="_blank" rel="noopener">https://www.city.kofu.yamanashi.jp/hokenjo/h31-shokuhin/2019-shokuhinkyokaitiran.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.kofu.yamanashi.jp/hokenjo/h31-shokuhin/documents/download_20260430143717.zip" target="_blank" rel="noopener">https://www.city.kofu.yamanashi.jp/hokenjo/h31-shokuhin/documents/downl…</a></dd>
+        </dl>
+        <span class="badge">元の表記: 要確認</span>
+        <div class="attr">
+          <code>出典：甲府市「食品営業許可施設一覧」（https://www.city.kofu.yamanashi.jp/hokenjo/h31-shokuhin/2019-shokuhinkyokaitiran.html）を加工して作成</code>
+          <button type="button" class="copy" data-copy="出典：甲府市「食品営業許可施設一覧」（https://www.city.kofu.yamanashi.jp/hokenjo/h31-shokuhin/2019-shokuhinkyokaitiran.html）を加工して作成">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-matsue">
+        <h3>松江市<span class="dataset">食品営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.matsue.lg.jp/soshikikarasagasu/kenkofukushibu_hokeneiseika/hokeneisei/4/2226.html" target="_blank" rel="noopener">https://www.city.matsue.lg.jp/soshikikarasagasu/kenkofukushibu_hokeneiseika/hokeneisei/4/2226.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.matsue.lg.jp/material/files/group/50/202605_eigyoukyoka_zenken.xlsx" target="_blank" rel="noopener">https://www.city.matsue.lg.jp/material/files/group/50/202605_eigyoukyok…</a></dd>
+        </dl>
+        <span class="badge">元の表記: 要確認</span>
+        <div class="attr">
+          <code>出典：松江市「食品営業許可施設一覧」（https://www.city.matsue.lg.jp/soshikikarasagasu/kenkofukushibu_hokeneiseika/hokeneisei/4/2226.html）を加工して作成</code>
+          <button type="button" class="copy" data-copy="出典：松江市「食品営業許可施設一覧」（https://www.city.matsue.lg.jp/soshikikarasagasu/kenkofukushibu_hokeneiseika/hokeneisei/4/2226.html）を加工して作成">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-sendai">
+        <h3>仙台市<span class="dataset">営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.sendai.jp/sekatsuese-shokuhin/kyokalist/joho.html" target="_blank" rel="noopener">https://www.city.sendai.jp/sekatsuese-shokuhin/kyokalist/joho.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.sendai.jp/sekatsuese-shokuhin/kyokalist/documents/r7shokuhinichiran.zip" target="_blank" rel="noopener">https://www.city.sendai.jp/sekatsuese-shokuhin/kyokalist/documents/r7sh…</a></dd>
+        </dl>
+        <span class="badge">元の表記: 要確認</span>
+        <div class="attr">
+          <code>出典：仙台市「営業許可施設一覧」（https://www.city.sendai.jp/sekatsuese-shokuhin/kyokalist/joho.html）を加工して作成</code>
+          <button type="button" class="copy" data-copy="出典：仙台市「営業許可施設一覧」（https://www.city.sendai.jp/sekatsuese-shokuhin/kyokalist/joho.html）を加工して作成">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-chiba-city">
+        <h3>千葉市<span class="dataset">食品営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.chiba.jp/somu/somu/seisakuhomu/shisei/hokenjokankei.html" target="_blank" rel="noopener">https://www.city.chiba.jp/somu/somu/seisakuhomu/shisei/hokenjokankei.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.chiba.jp/somu/somu/seisakuhomu/shisei/documents/202605syokuhin.xlsx" target="_blank" rel="noopener">https://www.city.chiba.jp/somu/somu/seisakuhomu/shisei/documents/202605…</a></dd>
+        </dl>
+        <span class="badge">元の表記: 要確認</span>
+        <div class="attr">
+          <code>出典：千葉市「食品営業許可施設一覧」（https://www.city.chiba.jp/somu/somu/seisakuhomu/shisei/hokenjokankei.html）を加工して作成</code>
+          <button type="button" class="copy" data-copy="出典：千葉市「食品営業許可施設一覧」（https://www.city.chiba.jp/somu/somu/seisakuhomu/shisei/hokenjokankei.html）を加工して作成">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-shimane-pref">
+        <h3>島根県<span class="dataset">食品営業許可一覧（松江市を除く）</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.html" target="_blank" rel="noopener">https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.data/R8_05all_02unnnann.xlsx" target="_blank" rel="noopener">https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashiset…</a><br><a href="https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.data/R8_05all_03izumo.xlsx" target="_blank" rel="noopener">https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashiset…</a><br><a href="https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.data/R8_05all_04kenou.xlsx" target="_blank" rel="noopener">https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashiset…</a><br><a href="https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.data/R8_05all_05hamada.xlsx" target="_blank" rel="noopener">https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashiset…</a><br><a href="https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.data/R8_05all_06masuda.xlsx" target="_blank" rel="noopener">https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashiset…</a><br><a href="https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.data/R8_05all_07oki.xlsx" target="_blank" rel="noopener">https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashiset…</a></dd>
+        </dl>
+        <span class="badge">元の表記: 要確認</span>
+        <div class="attr">
+          <code>出典：島根県「食品営業許可一覧（松江市を除く）」（https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.html）を加工して作成</code>
+          <button type="button" class="copy" data-copy="出典：島根県「食品営業許可一覧（松江市を除く）」（https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.html）を加工して作成">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-itabashi-ku">
+        <h3>板橋区<span class="dataset">東京都板橋区食品営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.itabashi.tokyo.jp/kenko/eisei/shokuhin/1051220.html" target="_blank" rel="noopener">https://www.city.itabashi.tokyo.jp/kenko/eisei/shokuhin/1051220.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.itabashi.tokyo.jp/_res/projects/default_project/_page_/001/051/220/r8.5_shokuhinkyokashisetsu.xlsx" target="_blank" rel="noopener">https://www.city.itabashi.tokyo.jp/_res/projects/default_project/_page_…</a></dd>
+        </dl>
+        <span class="badge">元の表記: 要確認</span>
+        <div class="attr">
+          <code>出典：板橋区「東京都板橋区食品営業許可施設一覧」（https://www.city.itabashi.tokyo.jp/kenko/eisei/shokuhin/1051220.html）を加工して作成</code>
+          <button type="button" class="copy" data-copy="出典：板橋区「東京都板橋区食品営業許可施設一覧」（https://www.city.itabashi.tokyo.jp/kenko/eisei/shokuhin/1051220.html）を加工して作成">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-hyogo-pref">
+        <h3>兵庫県<span class="dataset">食品関係営業施設リスト（許可）</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://web.pref.hyogo.lg.jp/kf14/shokuhineigyoushisetsu_list.html" target="_blank" rel="noopener">https://web.pref.hyogo.lg.jp/kf14/shokuhineigyoushisetsu_list.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx" target="_blank" rel="noopener">https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisenc…</a></dd>
+        </dl>
+        <span class="badge">元の表記: 要確認</span>
+        <div class="attr">
+          <code>出典：兵庫県「食品関係営業施設リスト（許可）」（https://web.pref.hyogo.lg.jp/kf14/shokuhineigyoushisetsu_list.html）を加工して作成</code>
+          <button type="button" class="copy" data-copy="出典：兵庫県「食品関係営業施設リスト（許可）」（https://web.pref.hyogo.lg.jp/kf14/shokuhineigyoushisetsu_list.html）を加工して作成">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-toyohashi">
+        <h3>豊橋市<span class="dataset">食品営業許可施設情報（新規）</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.toyohashi.lg.jp/13766.htm" target="_blank" rel="noopener">https://www.city.toyohashi.lg.jp/13766.htm</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.toyohashi.lg.jp/secure/18290/shokuhinshinki202605EXCEL.xlsx" target="_blank" rel="noopener">https://www.city.toyohashi.lg.jp/secure/18290/shokuhinshinki202605EXCEL…</a></dd>
+        </dl>
+        <span class="badge">元の表記: 要確認</span>
+        <div class="attr">
+          <code>出典：豊橋市「食品営業許可施設情報（新規）」（https://www.city.toyohashi.lg.jp/13766.htm）を加工して作成</code>
+          <button type="button" class="copy" data-copy="出典：豊橋市「食品営業許可施設情報（新規）」（https://www.city.toyohashi.lg.jp/13766.htm）を加工して作成">コピー</button>
+        </div>
+      </article>
+    </section>
+
+    <footer>
+      <p>
+        このページは <a href="https://github.com/gl20percentclub/japan-facilities-api/blob/main/config/sources.yaml">config/sources.yaml</a> から
+        <a href="https://github.com/gl20percentclub/japan-facilities-api/blob/main/scripts/gen-attribution.js">scripts/gen-attribution.js</a> が自動生成しています。
+        誤りを見つけた場合は <a href="https://github.com/gl20percentclub/japan-facilities-api/issues">Issue</a> でお知らせください。
+      </p>
+      <p><a href="https://gl20percentclub.github.io/japan-facilities-api/">← プレビュー地図に戻る</a> · <a href="https://github.com/gl20percentclub/japan-facilities-api">GitHub リポジトリ</a></p>
+    </footer>
+  </div>
+
+  <script>
+    // 出典表示文をクリップボードへコピーする（コピー後は一時的にボタン表示を変える）。
+    document.addEventListener('click', (e) => {
+      const btn = e.target.closest('.copy');
+      if (!btn) return;
+      navigator.clipboard.writeText(btn.dataset.copy).then(() => {
+        btn.textContent = 'コピーしました';
+        setTimeout(() => { btn.textContent = 'コピー'; }, 1500);
+      }).catch(() => { btn.textContent = 'コピー失敗'; });
+    });
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -129,7 +129,8 @@
       <span class="legend-dot"></span>各点＝1施設
       <span id="updated"></span><br>
       <a href="https://github.com/gl20percentclub/japan-facilities-api">GitHub リポジトリ</a> ·
-      <a href="https://github.com/gl20percentclub/japan-facilities-api#-api-リファレンス">API リファレンス</a>
+      <a href="https://github.com/gl20percentclub/japan-facilities-api#-api-リファレンス">API リファレンス</a> ·
+      <a href="./attribution.html">出典・ライセンス</a>
     </p>
   </div>
 
@@ -168,7 +169,8 @@
             maxzoom: TILE_MAX_ZOOM,
             bounds: JAPAN_BOUNDS,
             attribution:
-              '施設データ: <a href="https://github.com/gl20percentclub/japan-facilities-api" target="_blank" rel="noopener">Japan Facilities API</a>（各自治体オープンデータ）',
+              '施設データ: <a href="https://github.com/gl20percentclub/japan-facilities-api" target="_blank" rel="noopener">Japan Facilities API</a>'
+              + '（<a href="./attribution.html">各自治体オープンデータの出典一覧</a>）',
           },
         },
         layers: [

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "build:search-index": "node scripts/gen-search-index.js",
     "build:tiles": "node scripts/gen-tiles.js",
     "build:readme-stats": "node scripts/gen-readme-stats.js",
+    "build:attribution": "node scripts/gen-attribution.js",
     "fetch:i2fas": "node scripts/fetch-i2fas.mjs",
-    "test": "node scripts/crawl.test.js && node scripts/lib/config.test.js && node scripts/gen-tiles.test.js && node scripts/preview-map.test.js && node scripts/test.js && node scripts/gen-readme-stats.test.js"
+    "test": "node scripts/crawl.test.js && node scripts/lib/config.test.js && node scripts/gen-tiles.test.js && node scripts/preview-map.test.js && node scripts/test.js && node scripts/gen-readme-stats.test.js && node scripts/gen-attribution.test.js"
   },
   "dependencies": {
     "@geolonia/normalize-japanese-addresses": "^3.1.3",

--- a/scripts/gen-attribution.js
+++ b/scripts/gen-attribution.js
@@ -1,0 +1,542 @@
+// ---------------------------------------------------------------------------
+// 出典表示（attribution）ページ attribution.html を config/sources.yaml から生成する。
+//
+// 収録している全データソースについて「提供者・データセット名・出典ページ URL・
+// 取得 URL・ライセンス」を一覧化し、各ライセンスが求める出典表示形式に沿った
+// 表示文（コピーしてそのまま使える文字列）を出力する。
+//
+// 生成物 attribution.html は Git 管理し、gh-pages にもそのまま配信される
+// （ワークフローの publish_dir が リポジトリルート のため）。config/sources.yaml を
+// 変更したら本スクリプトを実行して再生成すること（`npm test` で同期を検証する）。
+//
+// 使い方:
+//   node scripts/gen-attribution.js           attribution.html を再生成
+//   node scripts/gen-attribution.js --check   再生成せず、内容が最新かだけを検証
+// ---------------------------------------------------------------------------
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { loadConfig, ROOT } from './lib/config.js';
+
+/** 生成先。gh-pages のルートに配置され https://…/attribution.html で公開される。 */
+export const OUTPUT_PATH = path.join(ROOT, 'attribution.html');
+
+/** 公開サイトの URL（一括表記の例で使う）。 */
+const SITE_URL = 'https://gl20percentclub.github.io/japan-facilities-api/';
+/** リポジトリ URL（ページ内リンクで使う）。 */
+const REPO_URL = 'https://github.com/gl20percentclub/japan-facilities-api';
+
+/** 都道府県名（`source` の先頭から提供者を推定する際に使う）。 */
+const PREFECTURES = [
+  '北海道', '青森県', '岩手県', '宮城県', '秋田県', '山形県', '福島県',
+  '茨城県', '栃木県', '群馬県', '埼玉県', '千葉県', '東京都', '神奈川県',
+  '新潟県', '富山県', '石川県', '福井県', '山梨県', '長野県', '岐阜県',
+  '静岡県', '愛知県', '三重県', '滋賀県', '京都府', '大阪府', '兵庫県',
+  '奈良県', '和歌山県', '鳥取県', '島根県', '岡山県', '広島県', '山口県',
+  '徳島県', '香川県', '愛媛県', '高知県', '福岡県', '佐賀県', '長崎県',
+  '熊本県', '大分県', '宮崎県', '鹿児島県', '沖縄県',
+];
+
+/**
+ * ライセンス区分の定義。config/sources.yaml の `license` 表記は自治体ごとに
+ * 揺れる（例: 「CC BY 4.0」と「Creative Commons Attribution 4.0 International」）ため、
+ * ここで正規化したうえで「そのライセンスが求める出典表示形式」を対応づける。
+ *
+ *   id       区分の識別子（HTML の見出し id / セクション順に使う）
+ *   label    正規化後の表示名
+ *   url      ライセンス本文の URL（自治体独自規約・未確認は null）
+ *   match    config の license 表記のうちこの区分に含めるもの
+ *   requirement セクション見出し直下に出す「表示要件」の説明
+ *   noteModified 出典表示文に「加工して作成」を含めるか
+ */
+const LICENSE_GROUPS = [
+  {
+    id: 'cc-by-4-0',
+    label: 'CC BY 4.0',
+    url: 'https://creativecommons.org/licenses/by/4.0/deed.ja',
+    match: ['CC BY 4.0', 'Creative Commons Attribution 4.0 International'],
+    requirement:
+      '出典（提供者名・データセット名・出典 URL）の明示と、改変した旨の表示が必要です。'
+      + '本 API は正規化・緯度経度付与などの加工を行っているため、「加工して作成」の旨を必ず含めてください。',
+    noteModified: true,
+  },
+  {
+    id: 'cc-by-3-0',
+    label: 'CC BY 3.0',
+    url: 'https://creativecommons.org/licenses/by/3.0/deed.ja',
+    match: ['CC BY 3.0'],
+    requirement: '出典の明示と、改変した旨の表示が必要です。',
+    noteModified: true,
+  },
+  {
+    id: 'cc-by-2-1-jp',
+    label: 'CC BY 2.1 JP',
+    url: 'https://creativecommons.org/licenses/by/2.1/jp/',
+    match: ['CC BY 2.1 JP'],
+    requirement: '出典の明示と、改変した旨の表示が必要です。',
+    noteModified: true,
+  },
+  {
+    id: 'cc-by-2-0',
+    label: 'CC BY 2.0',
+    url: 'https://creativecommons.org/licenses/by/2.0/deed.ja',
+    match: ['CC BY 2.0'],
+    requirement: '出典の明示と、改変した旨の表示が必要です。',
+    noteModified: true,
+  },
+  {
+    id: 'cc-by',
+    label: 'CC BY（バージョン表記なし）',
+    url: 'https://creativecommons.org/licenses/by/4.0/deed.ja',
+    match: ['CC BY', 'Creative Commons Attribution', 'CC BY相当'],
+    requirement:
+      '掲載ページに「CC BY」とのみ記載されており、バージョンが特定できないソースです。'
+      + 'CC BY 共通の要件である出典の明示と改変した旨の表示を行ってください（元の表記は各行に併記しています）。',
+    noteModified: true,
+  },
+  {
+    id: 'pdl-1-0',
+    label: '公共データ利用規約（第1.0版・PDL1.0）',
+    url: 'https://www.digital.go.jp/resources/open_data/public_data_license_v1.0',
+    match: ['公共データ利用規約（第1.0版, PDL1.0）', '公共データ利用規約'],
+    requirement:
+      '出典の明示が必要です（商用利用を含めて再利用可・CC BY 4.0 互換）。'
+      + '編集・加工した情報を提供する場合は、加工した旨も併記してください。',
+    noteModified: true,
+  },
+  {
+    id: 'local-terms',
+    label: '自治体独自の利用規約',
+    url: null,
+    match: [], // 上記いずれにも当てはまらず「要確認」でもないものが入る
+    requirement:
+      '各自治体が定める独自の利用規約に従ってください（いずれも出典の明示が必要です）。'
+      + '規約の内容は各行の出典ページから確認できます。',
+    noteModified: true,
+  },
+  {
+    id: 'unconfirmed',
+    label: 'ライセンス表記が未確認',
+    url: null,
+    match: ['要確認'],
+    requirement:
+      '掲載ページでライセンスの明示が確認できなかったソースです。本 API では出典を明示したうえで収録しています。'
+      + '再利用にあたっては、各自治体の利用条件を必ずご自身でご確認ください。',
+    noteModified: true,
+  },
+];
+
+/**
+ * config の license 表記をライセンス区分に振り分ける。
+ * どの区分の match にも該当しない表記（「柏市オープンデータ利用規約」など）は
+ * 自治体独自の利用規約として扱う。
+ *
+ * @param {string} license config/sources.yaml の license の値
+ * @returns {{ id: string, label: string, url: string|null, requirement: string, noteModified: boolean }}
+ */
+export function classifyLicense(license) {
+  const raw = (license ?? '').trim();
+  const group =
+    LICENSE_GROUPS.find((g) => g.match.includes(raw))
+    ?? LICENSE_GROUPS.find((g) => g.id === 'local-terms');
+  return group;
+}
+
+/**
+ * `source`（出典表示名）と既定値から「提供者」と「データセット名」を切り出す。
+ *
+ * config の source は次の2形式が混在する。
+ *   - BODIK 由来 : "横須賀市 【横須賀市】食品営業許可施設公開情報" のように 提供者＋半角空白＋名称
+ *   - 個別追加分 : "大阪市食品営業許可施設一覧" のように 提供者名が先頭に連結
+ * 後者は defaultCity / defaultPref、それも無ければ都道府県名の前方一致で提供者を判定する。
+ *
+ * @param {object} src config/sources.yaml の1エントリ
+ * @returns {{ publisher: string, dataset: string }} 提供者とデータセット名
+ */
+export function derivePublisher(src) {
+  const source = (src.source ?? '').trim();
+
+  // BODIK 形式（提供者と名称が半角空白で区切られている）はそのまま分割する。
+  const spaceIdx = source.indexOf(' ');
+  if (spaceIdx > 0) {
+    return { publisher: source.slice(0, spaceIdx), dataset: source.slice(spaceIdx + 1).trim() };
+  }
+
+  // 既定値（defaultCity → defaultPref）→ 都道府県名の前方一致 の順で提供者を推定する。
+  const publisher =
+    src.defaultCity
+    ?? src.defaultPref
+    ?? PREFECTURES.find((p) => source.startsWith(p))
+    ?? source;
+
+  // 名称が提供者名で始まる場合（例: 大阪市 + 食品営業許可施設一覧）は重複を避けて切り落とす。
+  // ただし残りが括弧始まり（例: 東京都（保健医療局）…）だと名称として不自然なので元のまま使う。
+  const rest = source.startsWith(publisher) ? source.slice(publisher.length).trim() : '';
+  const dataset = rest && !rest.startsWith('（') ? rest : source;
+  return { publisher, dataset };
+}
+
+/**
+ * 実際にデータを取得している URL を求める（出典ページ sourceUrl とは別で、来歴として掲載する）。
+ * 取得方法が CKAN の場合は resource_show の API URL、複数ファイル取得の場合は全 URL を返す。
+ *
+ * @param {object} acquire config の acquire ブロック
+ * @returns {string[]} 取得 URL の配列（掲載ページ解決や i2fas など URL が定まらない場合は空配列）
+ */
+export function acquireUrls(acquire = {}) {
+  switch (acquire.type) {
+    case 'ckan':
+      return [`${acquire.ckanBase}/api/3/action/resource_show?id=${acquire.resourceId}`];
+    case 'get':
+      return acquire.urls ?? (acquire.url ? [acquire.url] : []);
+    case 'post':
+      return acquire.url ? [acquire.url] : [];
+    case 'resolve':
+      // 掲載ページ内のリンクを毎回解決するため、固定の取得 URL は掲載ページそのもの。
+      return acquire.pageUrl ? [acquire.pageUrl] : [];
+    default:
+      // i2fasglob など、ローカルキャッシュ経由で URL が1本に定まらないもの。
+      return [];
+  }
+}
+
+/**
+ * 1ソース分の出典表示文（コピーしてそのまま使える1行）を組み立てる。
+ * 形式は「出典：{提供者}「{データセット名}」（{出典URL}）を加工して作成（{ライセンス}）」。
+ * CC BY 系が求める "提供者・タイトル・出典元・改変の明示" をこの1行で満たす。
+ *
+ * @param {object} entry buildEntries() が返すエントリ
+ * @returns {string} 出典表示文
+ */
+export function buildAttribution(entry) {
+  const url = entry.sourceUrl ? `（${entry.sourceUrl}）` : '';
+  const modified = entry.license.noteModified ? 'を加工して作成' : '';
+  // 定型ライセンス（CC BY 系・PDL）はライセンス名まで併記する。自治体独自規約・未確認は
+  // 規約名を文中に入れても表示要件を満たさないため入れず、ページ側のセクションと
+  // 「元の表記」バッジで示す。
+  const suffix = entry.license.url ? `（${entry.license.label}）` : '';
+  return `出典：${entry.publisher}「${entry.dataset}」${url}${modified}${suffix}`;
+}
+
+/**
+ * config の sources を、ページ描画に必要な形へ整形する。
+ *
+ * @param {object[]} sources loadConfig().sources
+ * @returns {object[]} key / publisher / dataset / sourceUrl / acquire / license / attribution を持つ配列
+ */
+export function buildEntries(sources) {
+  return sources.map((src) => {
+    const { publisher, dataset } = derivePublisher(src);
+    const entry = {
+      key: src.key,
+      publisher,
+      dataset,
+      sourceName: src.source,
+      sourceUrl: src.sourceUrl ?? null,
+      acquireUrls: acquireUrls(src.acquire),
+      licenseRaw: (src.license ?? '').trim(),
+      license: classifyLicense(src.license),
+    };
+    entry.attribution = buildAttribution(entry);
+    return entry;
+  });
+}
+
+/**
+ * エントリをライセンス区分ごとにまとめる（LICENSE_GROUPS の並び順を維持し、0件の区分は落とす）。
+ *
+ * @param {object[]} entries buildEntries() の戻り値
+ * @returns {{ group: object, entries: object[] }[]} 区分ごとのセクション
+ */
+export function groupByLicense(entries) {
+  return LICENSE_GROUPS
+    .map((group) => ({
+      group,
+      // 表示順は提供者名の五十音（ロケール）順で安定させる。
+      entries: entries
+        .filter((e) => e.license.id === group.id)
+        .sort((a, b) => a.publisher.localeCompare(b.publisher, 'ja')),
+    }))
+    .filter((section) => section.entries.length > 0);
+}
+
+/** HTML に埋め込むテキストをエスケープする。 */
+function esc(s) {
+  return String(s ?? '').replace(/[&<>"']/g, (c) => (
+    { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+  ));
+}
+
+/** 表示用に URL を短く省略する（リンク先は元の URL のまま）。 */
+function shortenUrl(url, max = 72) {
+  return url.length <= max ? url : `${url.slice(0, max - 1)}…`;
+}
+
+/** 1ソース分のカード（提供者・出典リンク・取得URL・出典表示文）を描画する。 */
+function renderEntry(entry) {
+  // 取得 URL は複数のことがあるため、すべてリンクとして並べる。
+  const acquire = entry.acquireUrls.length
+    ? entry.acquireUrls
+      .map((u) => `<a href="${esc(u)}" target="_blank" rel="noopener">${esc(shortenUrl(u))}</a>`)
+      .join('<br>')
+    : '<span class="muted">（キャッシュ経由・固定URLなし）</span>';
+
+  // ライセンスの元表記が正規化後の表示名と違う場合だけ併記する（情報を失わせないため）。
+  const rawNote = entry.licenseRaw && entry.licenseRaw !== entry.license.label
+    ? `<span class="badge">元の表記: ${esc(entry.licenseRaw)}</span>`
+    : '';
+
+  return `      <article class="src" id="src-${esc(entry.key)}">
+        <h3>${esc(entry.publisher)}<span class="dataset">${esc(entry.dataset)}</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd>${entry.sourceUrl
+    ? `<a href="${esc(entry.sourceUrl)}" target="_blank" rel="noopener">${esc(entry.sourceUrl)}</a>`
+    : '<span class="muted">（なし）</span>'}</dd>
+          <dt>取得URL</dt>
+          <dd>${acquire}</dd>
+        </dl>
+        ${rawNote}
+        <div class="attr">
+          <code>${esc(entry.attribution)}</code>
+          <button type="button" class="copy" data-copy="${esc(entry.attribution)}">コピー</button>
+        </div>
+      </article>`;
+}
+
+/** ライセンス区分ごとのセクションを描画する。 */
+function renderSection({ group, entries }) {
+  const licenseLink = group.url
+    ? ` — <a href="${esc(group.url)}" target="_blank" rel="noopener">ライセンス本文</a>`
+    : '';
+  return `    <section class="license" id="${esc(group.id)}">
+      <h2>${esc(group.label)} <span class="count">${entries.length} ソース</span></h2>
+      <p class="requirement">${esc(group.requirement)}${licenseLink}</p>
+${entries.map(renderEntry).join('\n')}
+    </section>`;
+}
+
+/**
+ * 出典表示ページの HTML 全体を描画する（純粋関数：同じ入力なら常に同じ出力）。
+ * 生成日時などの変動値は埋め込まない。`npm test` で config との同期を検証するため。
+ *
+ * @param {object[]} entries buildEntries() の戻り値
+ * @returns {string} attribution.html の中身
+ */
+export function renderHtml(entries) {
+  const sections = groupByLicense(entries);
+  // 目次はセクション（ライセンス区分）単位。件数も出して全体像がすぐ分かるようにする。
+  const toc = sections
+    .map(({ group, entries: es }) =>
+      `      <li><a href="#${esc(group.id)}">${esc(group.label)}</a> <span class="count">${es.length}</span></li>`)
+    .join('\n');
+
+  return `<!DOCTYPE html>
+<!--
+  このファイルは scripts/gen-attribution.js が config/sources.yaml から自動生成しています。
+  直接編集せず、config/sources.yaml を更新して \`npm run build:attribution\` を実行してください。
+-->
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>出典・ライセンス表示 — Japan Facilities API</title>
+  <meta name="description" content="Japan Facilities API が収録する全データソースの出典URL・ライセンスと、各データの出典表示形式に沿った表示文の一覧です。">
+  <style>
+    :root {
+      --accent: #e8563f;
+      --ink: #1f2933;
+      --sub: #52606d;
+      --muted: #9aa5b1;
+      --border: rgba(31, 41, 51, 0.12);
+      --panel: #f7f8fa;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Noto Sans JP", sans-serif;
+      color: var(--ink);
+      line-height: 1.7;
+      background: #fff;
+    }
+    .wrap { max-width: 920px; margin: 0 auto; padding: 32px 20px 80px; }
+    a { color: var(--accent); }
+    h1 { font-size: 24px; margin: 0 0 8px; }
+    h2 {
+      font-size: 18px;
+      margin: 48px 0 4px;
+      padding-bottom: 6px;
+      border-bottom: 2px solid var(--accent);
+      scroll-margin-top: 16px;
+    }
+    h3 { font-size: 15px; margin: 0 0 6px; }
+    h3 .dataset { display: block; font-size: 13px; font-weight: 400; color: var(--sub); }
+    p { margin: 0 0 12px; }
+    .lead { color: var(--sub); font-size: 14px; }
+    .count { font-size: 12px; color: var(--muted); font-weight: 400; }
+    .muted { color: var(--muted); }
+    .requirement { font-size: 13px; color: var(--sub); margin: 10px 0 16px; }
+
+    /* まとめて1行で表示する場合の例 */
+    .callout {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-left: 4px solid var(--accent);
+      border-radius: 8px;
+      padding: 14px 16px;
+      font-size: 14px;
+    }
+
+    /* 目次 */
+    .toc { background: var(--panel); border-radius: 10px; padding: 12px 16px; font-size: 14px; }
+    .toc ul { margin: 6px 0 0; padding-left: 20px; }
+
+    /* ソース1件分のカード */
+    .src {
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 14px 16px;
+      margin-bottom: 12px;
+      scroll-margin-top: 16px;
+    }
+    .src dl {
+      display: grid;
+      grid-template-columns: 84px 1fr;
+      gap: 2px 12px;
+      margin: 8px 0;
+      font-size: 12.5px;
+    }
+    .src dt { color: var(--muted); }
+    .src dd { margin: 0; overflow-wrap: anywhere; }
+    .badge {
+      display: inline-block;
+      font-size: 11px;
+      color: var(--sub);
+      background: var(--panel);
+      border-radius: 999px;
+      padding: 1px 10px;
+      margin-bottom: 8px;
+    }
+
+    /* 出典表示文（コピー用） */
+    .attr {
+      display: flex;
+      gap: 10px;
+      align-items: flex-start;
+      background: var(--panel);
+      border-radius: 8px;
+      padding: 10px 12px;
+    }
+    .attr code {
+      flex: 1;
+      font-size: 12.5px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      overflow-wrap: anywhere;
+    }
+    .copy {
+      flex: none;
+      font: inherit;
+      font-size: 12px;
+      color: #fff;
+      background: var(--accent);
+      border: 0;
+      border-radius: 6px;
+      padding: 4px 12px;
+      cursor: pointer;
+    }
+    .copy:hover { opacity: 0.85; }
+
+    footer { margin-top: 56px; font-size: 12.5px; color: var(--sub); }
+    @media (max-width: 560px) {
+      .src dl { grid-template-columns: 1fr; }
+      .src dt { margin-top: 6px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>出典・ライセンス表示（Attribution）</h1>
+    <p class="lead">
+      <a href="${SITE_URL}">Japan Facilities API</a> は、各自治体・省庁が公開する食品営業許可・届出のオープンデータを
+      取得し、全国共通フォーマットへの正規化と緯度経度の付与を行って配信しています。
+      本ページは収録している全 ${entries.length} ソースの出典 URL とライセンス、および
+      各データが求める出典表示形式に沿った表示文の一覧です。
+    </p>
+
+    <h2 id="how-to">出典の表示方法</h2>
+    <p>
+      本 API のデータを利用・再配布する場合は、利用したデータのソースについて下記の表示文をそのまま掲載してください。
+      本 API は元データに加工（正規化・名寄せ・ジオコーディング）を加えているため、表示文には「加工して作成」の旨を含めています。
+    </p>
+    <p>全国データをまとめて利用する場合は、次の一括表記でも構いません（個別ソースの一覧として本ページを参照させてください）。</p>
+    <div class="callout">
+      <code>出典：Japan Facilities API（各自治体・厚生労働省が公開する食品営業許可オープンデータを加工して作成）<br>${SITE_URL}attribution.html</code>
+    </div>
+    <p class="lead" style="margin-top:12px">
+      緯度経度は本サービスが住所からジオコーディングして独自に付与した参考情報であり、各自治体が提供しているものではありません。
+      加工したデータについて、提供元が本サービスを推奨・関与していると誤解させる表示は行わないでください。
+    </p>
+
+    <nav class="toc" aria-label="ライセンス別の目次">
+      <strong>ライセンス別の一覧</strong>
+      <ul>
+${toc}
+      </ul>
+    </nav>
+
+${sections.map(renderSection).join('\n')}
+
+    <footer>
+      <p>
+        このページは <a href="${REPO_URL}/blob/main/config/sources.yaml">config/sources.yaml</a> から
+        <a href="${REPO_URL}/blob/main/scripts/gen-attribution.js">scripts/gen-attribution.js</a> が自動生成しています。
+        誤りを見つけた場合は <a href="${REPO_URL}/issues">Issue</a> でお知らせください。
+      </p>
+      <p><a href="${SITE_URL}">← プレビュー地図に戻る</a> · <a href="${REPO_URL}">GitHub リポジトリ</a></p>
+    </footer>
+  </div>
+
+  <script>
+    // 出典表示文をクリップボードへコピーする（コピー後は一時的にボタン表示を変える）。
+    document.addEventListener('click', (e) => {
+      const btn = e.target.closest('.copy');
+      if (!btn) return;
+      navigator.clipboard.writeText(btn.dataset.copy).then(() => {
+        btn.textContent = 'コピーしました';
+        setTimeout(() => { btn.textContent = 'コピー'; }, 1500);
+      }).catch(() => { btn.textContent = 'コピー失敗'; });
+    });
+  </script>
+</body>
+</html>
+`;
+}
+
+/**
+ * config/sources.yaml から attribution.html の内容を生成する。
+ *
+ * @returns {string} HTML 文字列
+ */
+export function generate() {
+  const { sources } = loadConfig();
+  return renderHtml(buildEntries(sources));
+}
+
+// CLI 実行時のみ書き出す（--check の場合は差分の有無だけを終了コードで返す）。
+// パスに記号（% 等）が含まれても比較できるよう pathToFileURL で URL 化して突き合わせる。
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const html = generate();
+  if (process.argv.includes('--check')) {
+    const current = fs.existsSync(OUTPUT_PATH) ? fs.readFileSync(OUTPUT_PATH, 'utf-8') : '';
+    if (current !== html) {
+      console.error('❌ attribution.html が config/sources.yaml と同期していません。'
+        + '`npm run build:attribution` を実行してください。');
+      process.exit(1);
+    }
+    console.log('✅ attribution.html は最新です');
+  } else {
+    fs.writeFileSync(OUTPUT_PATH, html);
+    console.log(`✅ ${path.relative(ROOT, OUTPUT_PATH)} を生成しました`);
+  }
+}

--- a/scripts/gen-attribution.test.js
+++ b/scripts/gen-attribution.test.js
@@ -1,0 +1,138 @@
+// gen-attribution.js の分類・整形ロジックと、生成物 attribution.html の同期を検証する。
+//
+//   node scripts/gen-attribution.test.js
+
+import fs from 'node:fs';
+import {
+  OUTPUT_PATH,
+  acquireUrls,
+  buildAttribution,
+  buildEntries,
+  classifyLicense,
+  derivePublisher,
+  generate,
+  groupByLicense,
+} from './gen-attribution.js';
+import { loadConfig } from './lib/config.js';
+
+let failures = 0;
+/** 条件を検証して結果を出力する（失敗数を数える）。 */
+function assert(cond, msg) {
+  if (cond) {
+    console.log(`  ✓ ${msg}`);
+  } else {
+    console.error(`  ✗ ${msg}`);
+    failures++;
+  }
+}
+
+console.log('gen-attribution テスト\n');
+
+// --- classifyLicense: 表記ゆれを同じ区分にまとめる ---
+assert(
+  classifyLicense('Creative Commons Attribution 4.0 International').id === 'cc-by-4-0',
+  'BODIK の英語表記が CC BY 4.0 に正規化される',
+);
+assert(classifyLicense('CC BY 4.0').id === 'cc-by-4-0', '「CC BY 4.0」が CC BY 4.0 区分になる');
+assert(classifyLicense('CC BY').id === 'cc-by', 'バージョン無しの「CC BY」は別区分になる');
+assert(classifyLicense('要確認').id === 'unconfirmed', '「要確認」は未確認区分になる');
+assert(
+  classifyLicense('柏市オープンデータ利用規約').id === 'local-terms',
+  '未知の規約名は自治体独自の利用規約になる',
+);
+assert(
+  classifyLicense('公共データ利用規約（第1.0版, PDL1.0）').id === 'pdl-1-0',
+  'PDL1.0 が公共データ利用規約の区分になる',
+);
+
+// --- derivePublisher: 提供者とデータセット名の切り出し ---
+assert(
+  derivePublisher({ source: '横須賀市 【横須賀市】食品営業許可施設公開情報' }).publisher === '横須賀市',
+  'BODIK 形式（空白区切り）から提供者を取り出す',
+);
+assert(
+  derivePublisher({ source: '大阪市食品営業許可施設一覧', defaultPref: '大阪府', defaultCity: '大阪市' }).dataset
+    === '食品営業許可施設一覧',
+  'defaultCity で提供者を判定し、名称から重複を取り除く',
+);
+assert(
+  derivePublisher({ source: '沖縄県食品営業許可・届出' }).publisher === '沖縄県',
+  '既定値が無い場合は都道府県名の前方一致で提供者を判定する',
+);
+assert(
+  derivePublisher({ source: '東京都（保健医療局）食品関係営業許可台帳', defaultPref: '東京都' }).dataset
+    === '東京都（保健医療局）食品関係営業許可台帳',
+  '括弧始まりになる場合は名称を切り詰めない',
+);
+
+// --- acquireUrls: 取得方法ごとに URL を求める ---
+assert(
+  acquireUrls({ type: 'ckan', ckanBase: 'https://data.bodik.jp', resourceId: 'abc' })[0]
+    === 'https://data.bodik.jp/api/3/action/resource_show?id=abc',
+  'CKAN は resource_show の URL になる',
+);
+assert(
+  acquireUrls({ type: 'get', urls: ['https://a/1.csv', 'https://a/2.csv'] }).length === 2,
+  '複数ファイル取得は全 URL を返す',
+);
+assert(acquireUrls({ type: 'i2fasglob' }).length === 0, '固定 URL を持たない取得方法は空配列');
+
+// --- buildAttribution: 出典表示文の形式 ---
+const ccEntry = buildEntries([{
+  key: 'x', source: '大阪市食品営業許可施設一覧', sourceUrl: 'https://example.jp/a',
+  license: 'CC BY 4.0', defaultCity: '大阪市', acquire: { type: 'get', url: 'https://example.jp/a.csv' },
+}])[0];
+assert(
+  ccEntry.attribution === '出典：大阪市「食品営業許可施設一覧」（https://example.jp/a）を加工して作成（CC BY 4.0）',
+  'CC BY は 提供者・名称・出典URL・改変の明示・ライセンス名 を含む',
+);
+const localEntry = buildEntries([{
+  key: 'y', source: '柏市食品営業許可一覧', sourceUrl: 'https://example.jp/b',
+  license: '柏市オープンデータ利用規約', defaultCity: '柏市', acquire: { type: 'get', url: 'https://example.jp/b.csv' },
+}])[0];
+assert(
+  localEntry.attribution === '出典：柏市「食品営業許可一覧」（https://example.jp/b）を加工して作成',
+  '独自規約は規約名を文中に含めず出典明示のみにする',
+);
+assert(
+  buildAttribution({ ...ccEntry, sourceUrl: null }) === '出典：大阪市「食品営業許可施設一覧」を加工して作成（CC BY 4.0）',
+  '出典URLが無い場合も文が壊れない',
+);
+
+// --- 実データ: 全ソースが漏れなくページに載る ---
+const { sources } = loadConfig();
+const entries = buildEntries(sources);
+assert(entries.length === sources.length, `全 ${sources.length} ソースがエントリ化される`);
+assert(
+  entries.every((e) => e.publisher && e.dataset && e.attribution.startsWith('出典：')),
+  '全エントリが提供者・名称・出典表示文を持つ',
+);
+assert(
+  entries.filter((e) => !e.sourceUrl).length === 0,
+  '全エントリが出典ページ URL を持つ',
+);
+const grouped = groupByLicense(entries).reduce((n, s) => n + s.entries.length, 0);
+assert(grouped === entries.length, 'ライセンス区分への振り分けで取りこぼしが無い');
+
+// --- 生成物が config と同期しているか ---
+const html = generate();
+const current = fs.existsSync(OUTPUT_PATH) ? fs.readFileSync(OUTPUT_PATH, 'utf-8') : '';
+assert(
+  current === html,
+  'attribution.html が config/sources.yaml と同期している（差分があれば npm run build:attribution）',
+);
+// HTML 側は & を実体参照にエスケープしているので、同じ変換をかけて突き合わせる。
+assert(
+  entries.every((e) => html.includes(e.sourceUrl.replaceAll('&', '&amp;'))),
+  '全ソースの出典 URL がページに載っている',
+);
+assert(
+  entries.every((e) => html.includes(`id="src-${e.key}"`)),
+  '全ソースのアンカー（key）がページに載っている',
+);
+
+if (failures > 0) {
+  console.error(`\n❌ ${failures}件のチェックに失敗`);
+  process.exit(1);
+}
+console.log('\n✅ gen-attribution テストに合格');


### PR DESCRIPTION
## 概要

収録している全 98 データソースの出典 URL・ライセンスと、**各データのライセンスが求める形式に沿った出典表示文**を一覧化した attribution ページ（`attribution.html`）を追加します。

これまで出典情報は `config/sources.yaml` と README の説明文にしか無く、利用者が「どう出典表示すればよいか」を自分で組み立てる必要がありました。本 PR で、コピーしてそのまま使える表示文を配信ページ上に用意します。

公開 URL（マージ後）: https://gl20percentclub.github.io/japan-facilities-api/attribution.html

## 変更内容

- `scripts/gen-attribution.js`（新規） — `config/sources.yaml` から `attribution.html` を生成
  - ライセンス表記のゆれを正規化（例: `Creative Commons Attribution 4.0 International` → CC BY 4.0）し、ライセンス区分ごとにセクション分け
  - 区分ごとに「表示要件」（出典明示・改変明示の要否など）とライセンス本文へのリンクを記載
  - `source` と `defaultPref` / `defaultCity` から提供者とデータセット名を切り出し、出典表示文を組み立て
  - 各ソースに 出典ページ URL / 取得 URL / 元のライセンス表記 / コピーボタン付き出典表示文
- `attribution.html`（新規・自動生成） — 生成物。gh-pages のルートに配信される
- `scripts/gen-attribution.test.js`（新規） — 分類・整形ロジックの検証に加え、**`attribution.html` が `config/sources.yaml` と同期しているか**を検証（ズレていれば `npm run build:attribution` を促して失敗）
- `package.json` — `npm run build:attribution` と、`npm test` へのテスト追加
- `.github/workflows/crawl.yml` — 週次クロール時にページを再生成し、README 統計と一緒に main へ反映
- `index.html` / `README.md` — 出典ページへの導線（地図の attribution・ヘッダー・README 冒頭・出典セクション）

## 出典表示文の形式

```
出典：大阪市「食品営業許可施設一覧」（https://www.city.osaka.lg.jp/kenko/page/0000575579.html）を加工して作成（CC BY 4.0）
```

- CC BY 系・PDL1.0 は「提供者・データセット名・出典 URL・改変した旨・ライセンス名」を含める（CC BY が求める要件を1行で満たす）
- 自治体独自の利用規約・ライセンス未確認のソースは、規約名を文中に入れず出典明示のみとし、規約名は「元の表記」バッジとセクション見出しで示す
- 全国データをまとめて使う場合の一括表記もページ冒頭に記載

## ライセンス区分ごとの内訳

| 区分 | ソース数 |
|---|---|
| CC BY 4.0 | 50 |
| CC BY 3.0 | 1 |
| CC BY 2.1 JP | 10 |
| CC BY 2.0 | 2 |
| CC BY（バージョン表記なし） | 17 |
| 公共データ利用規約（第1.0版・PDL1.0） | 2 |
| 自治体独自の利用規約 | 7 |
| ライセンス表記が未確認 | 9 |

## テスト

- `node scripts/gen-attribution.test.js` — 合格（22 チェック）
- `node scripts/preview-map.test.js` / `node scripts/lib/config.test.js` — 合格
- `npm test` はローカルに `api/` が無いため `scripts/test.js` で中断（既存の挙動。CI では生成済みの `api/` に対して実行されます）
- ローカルサーバーで表示確認済み（レイアウト・リンク・コピーボタン）
