### PR TITLE
リポジトリ名を japan-food-facilities-api に変更する参照更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 <div align="center">
 
-# 🍽️ Japan Facilities API
+# 🍽️ Japan Food Facilities API
 
-**日本全国の飲食施設オープンデータ（食品営業許可・届出）を、無料で使える静的 API として配信**
+**日本全国の食品営業施設オープンデータ（食品営業許可・届出）を、無料で使える静的 API として配信**
 
-[![Contributors](https://img.shields.io/github/contributors/gl20percentclub/japan-facilities-api)](https://github.com/gl20percentclub/japan-facilities-api/graphs/contributors)
+[![Contributors](https://img.shields.io/github/contributors/gl20percentclub/japan-food-facilities-api)](https://github.com/gl20percentclub/japan-food-facilities-api/graphs/contributors)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](#-コントリビューション)
-[![GitHub Issues](https://img.shields.io/github/issues/gl20percentclub/japan-facilities-api)](https://github.com/gl20percentclub/japan-facilities-api/issues)
-[![Last Commit](https://img.shields.io/github/last-commit/gl20percentclub/japan-facilities-api)](https://github.com/gl20percentclub/japan-facilities-api/commits/main)
+[![GitHub Issues](https://img.shields.io/github/issues/gl20percentclub/japan-food-facilities-api)](https://github.com/gl20percentclub/japan-food-facilities-api/issues)
+[![Last Commit](https://img.shields.io/github/last-commit/gl20percentclub/japan-food-facilities-api)](https://github.com/gl20percentclub/japan-food-facilities-api/commits/main)
 [![Weekly Crawl](https://img.shields.io/badge/更新-毎週自動-blue)](#️-自動更新の仕組み)
 
-[クイックスタート](#-クイックスタート) · [API リファレンス](#-api-リファレンス) · [収録状況](docs/COVERAGE.md) · [バグ報告](https://github.com/gl20percentclub/japan-facilities-api/issues/new) · [機能要望](https://github.com/gl20percentclub/japan-facilities-api/issues/new)
+[クイックスタート](#-クイックスタート) · [API リファレンス](#-api-リファレンス) · [収録状況](docs/COVERAGE.md) · [バグ報告](https://github.com/gl20percentclub/japan-food-facilities-api/issues/new) · [機能要望](https://github.com/gl20percentclub/japan-food-facilities-api/issues/new)
 
 </div>
 
@@ -21,6 +21,7 @@
 ## ✨ 特徴
 
 - 🗾 **全国カバー** — 47都道府県・1,800以上の市区町村、70万件超の施設レコードを収録
+- 🍱 **飲食店だけじゃない** — レコードの8割強は飲食店営業ですが、菓子製造業・そうざい製造業・食肉/魚介類販売業・食肉処理業・食品の冷凍又は冷蔵業など、食品衛生法上の許可・届出業種を幅広く収録（業種は `business_type` で判別）
 - 📍 **緯度経度つき** — 座標が無い元データも [normalize-japanese-addresses](https://github.com/geolonia/normalize-japanese-addresses) でジオコーディングして補完
 - 🔄 **毎週自動更新** — GitHub Actions が毎週クロールして最新データを配信
 - 📦 **好きな形式で** — 市区町村別 JSON、検索用インデックス、全国結合 CSV、地図用ベクトルタイル
@@ -45,20 +46,20 @@
 
 ## 🚀 クイックスタート
 
-ベース URL は `https://gl20percentclub.github.io/japan-facilities-api/api/` です。
+ベース URL は `https://gl20percentclub.github.io/japan-food-facilities-api/api/` です。
 
 ```bash
 # 都道府県一覧（都道府県名 → 市区町村名の配列）
-curl https://gl20percentclub.github.io/japan-facilities-api/api/facilities/index.json
+curl https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities/index.json
 
 # 那覇市の全施設（パスは URL エンコードが必要な場合があります）
-curl "https://gl20percentclub.github.io/japan-facilities-api/api/facilities/%E6%B2%96%E7%B8%84%E7%9C%8C/%E9%82%A3%E8%A6%87%E5%B8%82/data.json"
+curl "https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities/%E6%B2%96%E7%B8%84%E7%9C%8C/%E9%82%A3%E8%A6%87%E5%B8%82/data.json"
 ```
 
 JavaScript からはこう使えます。
 
 ```js
-const BASE = 'https://gl20percentclub.github.io/japan-facilities-api/api';
+const BASE = 'https://gl20percentclub.github.io/japan-food-facilities-api/api';
 
 // 那覇市の全施設を取得（日本語パスは encodeURIComponent でエンコード）
 const res = await fetch(
@@ -95,8 +96,8 @@ Excel / pandas / BI ツール等で扱いたい場合はこちらが便利です
 
 | ファイル | 配布URL |
 |---|---|
-| 結合CSV（gzip 圧縮・約60MB） | https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv.gz |
-| 結合CSV（非圧縮・約540MB） | https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv |
+| 結合CSV（gzip 圧縮・約60MB） | https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv.gz |
+| 結合CSV（非圧縮・約540MB） | https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv |
 
 - **文字コード**: UTF-8（BOM 付き。Excel でそのまま開けます）
 - **列**: `prefecture, city, city_raw, name, name_kana, business_type, address, lat, lng, geocoding_level, phone, license_no, license_date, expire_date, sources, licenses`
@@ -135,14 +136,14 @@ api/
 ```js
 map.addSource('facilities', {
   type: 'vector',
-  tiles: ['https://gl20percentclub.github.io/japan-facilities-api/api/tiles/{z}/{x}/{y}.pbf'],
+  tiles: ['https://gl20percentclub.github.io/japan-food-facilities-api/api/tiles/{z}/{x}/{y}.pbf'],
   minzoom: 6, maxzoom: 12,
 });
 // レイヤ名は "facilities"、各点の属性は name / business_type / pref / city
 ```
 
 - タイルは非圧縮 pbf で配信するため、追加のヘッダ設定は不要です。
-- メタデータ（レイヤ定義・ズーム範囲・bounds）は [`tiles/metadata.json`](https://gl20percentclub.github.io/japan-facilities-api/api/tiles/metadata.json) を参照。
+- メタデータ（レイヤ定義・ズーム範囲・bounds）は [`tiles/metadata.json`](https://gl20percentclub.github.io/japan-food-facilities-api/api/tiles/metadata.json) を参照。
 - 生成は `npm run build:tiles`（クロール時 `npm run build` にも自動生成、pure JS の geojson-vt + vt-pbf）。
 
 ### `search-index.json`（施設名検索用・都道府県別分割）
@@ -319,7 +320,7 @@ sources:
 たとえば次のような貢献ができます。
 
 - 🗾 **新しい自治体データソースの追加** — [データソースの追加](#データソースの追加) の手順どおり [`config/sources.yaml`](config/sources.yaml) に1エントリ追加するだけです。未収録の自治体は [`docs/COVERAGE.md`](docs/COVERAGE.md) で確認できます
-- 🐛 **バグ報告・データ品質の問題報告** — [Issues](https://github.com/gl20percentclub/japan-facilities-api/issues) からお気軽にどうぞ（座標のずれ、重複、文字化けなど）
+- 🐛 **バグ報告・データ品質の問題報告** — [Issues](https://github.com/gl20percentclub/japan-food-facilities-api/issues) からお気軽にどうぞ（座標のずれ、重複、文字化けなど）
 - 💡 **機能提案・改善アイデア** — Issue で議論を始めてください
 - 📖 **ドキュメントの改善** — 誤字修正や説明の追加も立派な貢献です
 
@@ -337,8 +338,8 @@ sources:
 
 このプロジェクトに貢献してくださった皆さんです。ありがとうございます！
 
-<a href="https://github.com/gl20percentclub/japan-facilities-api/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=gl20percentclub/japan-facilities-api" alt="Contributors" />
+<a href="https://github.com/gl20percentclub/japan-food-facilities-api/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=gl20percentclub/japan-food-facilities-api" alt="Contributors" />
 </a>
 
 *Made with [contrib.rocks](https://contrib.rocks).*

--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>🍽️ Japan Facilities API — データプレビュー地図</title>
-  <meta name="description" content="日本全国の飲食施設オープンデータ（食品営業許可・届出）を地図上でプレビューできます。">
+  <title>🍽️ Japan Food Facilities API — データプレビュー地図</title>
+  <meta name="description" content="日本全国の食品営業施設オープンデータ（食品営業許可・届出）を地図上でプレビューできます。">
 
   <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css">
   <style>
@@ -118,8 +118,8 @@
   <div id="map"></div>
 
   <div class="panel">
-    <h1>🍽️ Japan Facilities API</h1>
-    <p class="sub">日本全国の飲食施設オープンデータ（食品営業許可・届出）のプレビュー地図です。</p>
+    <h1>🍽️ Japan Food Facilities API</h1>
+    <p class="sub">日本全国の食品営業施設オープンデータ（食品営業許可・届出）のプレビュー地図です。</p>
     <div class="stats">
       <div class="stat"><span class="num" id="stat-pref">–</span><span class="lbl">都道府県</span></div>
       <div class="stat"><span class="num" id="stat-city">–</span><span class="lbl">市区町村</span></div>
@@ -128,8 +128,8 @@
     <p class="meta-line">
       <span class="legend-dot"></span>各点＝1施設
       <span id="updated"></span><br>
-      <a href="https://github.com/gl20percentclub/japan-facilities-api">GitHub リポジトリ</a> ·
-      <a href="https://github.com/gl20percentclub/japan-facilities-api#-api-リファレンス">API リファレンス</a>
+      <a href="https://github.com/gl20percentclub/japan-food-facilities-api">GitHub リポジトリ</a> ·
+      <a href="https://github.com/gl20percentclub/japan-food-facilities-api#-api-リファレンス">API リファレンス</a>
     </p>
   </div>
 
@@ -168,7 +168,7 @@
             maxzoom: TILE_MAX_ZOOM,
             bounds: JAPAN_BOUNDS,
             attribution:
-              '施設データ: <a href="https://github.com/gl20percentclub/japan-facilities-api" target="_blank" rel="noopener">Japan Facilities API</a>（各自治体オープンデータ）',
+              '施設データ: <a href="https://github.com/gl20percentclub/japan-food-facilities-api" target="_blank" rel="noopener">Japan Food Facilities API</a>（各自治体オープンデータ）',
           },
         },
         layers: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "okinawa-facilities-api",
+  "name": "japan-food-facilities-api",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "okinawa-facilities-api",
+      "name": "japan-food-facilities-api",
       "dependencies": {
         "@geolonia/normalize-japanese-addresses": "^3.1.3",
         "fflate": "^0.8.3",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "okinawa-facilities-api",
+  "name": "japan-food-facilities-api",
   "type": "module",
   "scripts": {
     "build": "node scripts/crawl.js",

--- a/scripts/lib/acquire.js
+++ b/scripts/lib/acquire.js
@@ -9,7 +9,7 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 // bot 対策で User-Agent 等を求めるサーバがあるため、常識的なヘッダを付ける。
 const DEFAULT_HEADERS = {
-  'User-Agent': 'Mozilla/5.0 (compatible; japan-facilities-api/1.0; +https://github.com/gl20percentclub/japan-facilities-api)',
+  'User-Agent': 'Mozilla/5.0 (compatible; japan-food-facilities-api/1.0; +https://github.com/gl20percentclub/japan-food-facilities-api)',
   'Accept-Language': 'ja,en;q=0.8',
   Accept: '*/*',
 };


### PR DESCRIPTION
## 概要

リポジトリ名を `japan-facilities-api` → **`japan-food-facilities-api`** に変更するのに先立ち、コード・ドキュメント内の参照を新名称に更新します。

「施設」だけでは何のデータかわからないため、食品営業許可・届出データであることが名前から伝わるようにするのが目的です。

## 変更内容

| ファイル | 内容 |
|---|---|
| `package.json` / `package-lock.json` | `name` を `okinawa-facilities-api` → `japan-food-facilities-api`（沖縄県のみ対応だった頃の名前が残っていた） |
| `README.md` | H1 タイトル・バッジ URL・Pages ベース URL・curl / JS サンプル・タイル URL・Issues リンク・contrib.rocks を新名称に |
| `index.html` | `<title>` / `<h1>` / `meta description` / 出典表示リンクを新名称に |
| `scripts/lib/acquire.js` | クロール時の User-Agent 文字列を新名称に |

あわせて説明文も実データに合わせて修正しました。

- 「日本全国の**飲食**施設オープンデータ」→「日本全国の**食品営業**施設オープンデータ」
- README の特徴に収録業種の内訳を追記

## 収録業種について（説明文修正の根拠）

元データ（大阪市 65,517件 / 港区 5,579件）の業種別内訳を集計した結果、飲食店営業は8割強で、残りは製造業・販売業・処理業でした。

| 業種 | 大阪市 | 港区 |
|---|---|---|
| 飲食店営業 | 84.6% | 83.3% |
| 菓子製造業 | 5.6% | 5.6% |
| 食肉販売業 | 2.9% | 1.9% |
| 魚介類販売業 | 2.4% | 0.8% |
| そうざい製造業 | 1.9% | 4.6% |
| その他（食肉処理業・麺類製造業・食品の冷凍又は冷蔵業・酒類製造業など30業種前後） | 残り | 残り |

「飲食施設」だと製造業・販売業（全国で数万件規模）が名前・説明から漏れるため、`food` を含む名称と「食品営業施設」という表現にしています。

## ⚠️ リポジトリ名変更の影響（別途対応が必要）

このPRはコード内の参照更新のみです。GitHub 上の実リネーム（`gh repo rename` / Settings）は含みません。

リネームすると **GitHub Pages の URL が変わり、既存の API 利用者に影響します**。

- 旧: `https://gl20percentclub.github.io/japan-facilities-api/api/`
- 新: `https://gl20percentclub.github.io/japan-food-facilities-api/api/`

このPRをマージした時点では README の URL が実在しない状態になるため、**マージとリネームは近いタイミングで実施**してください。推奨順序は「リネーム → 本PRマージ → crawl ワークフロー実行で Pages 再デプロイ」です。

## テスト

ユニットテストはすべて合格（crawl 38件 / config 5件 / gen-tiles 6件 / preview-map 4件 / gen-readme-stats）。

`scripts/test.js` は生成済みの `api/` を検証するスクリプトのため、ローカル（未ビルド）では実行不可。CI ではクロール後に実行されるため影響ありません。