### PR TITLE
ランディングページを追加（プレビュー地図は map.html へ移動）

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Last Commit](https://img.shields.io/github/last-commit/gl20percentclub/japan-facilities-api)](https://github.com/gl20percentclub/japan-facilities-api/commits/main)
 [![Weekly Crawl](https://img.shields.io/badge/更新-毎週自動-blue)](#️-自動更新の仕組み)
 
-[クイックスタート](#-クイックスタート) · [API リファレンス](#-api-リファレンス) · [収録状況](docs/COVERAGE.md) · [出典・ライセンス](https://gl20percentclub.github.io/japan-facilities-api/attribution.html) · [バグ報告](https://github.com/gl20percentclub/japan-facilities-api/issues/new) · [機能要望](https://github.com/gl20percentclub/japan-facilities-api/issues/new)
+[公式サイト](https://gl20percentclub.github.io/japan-facilities-api/) · [クイックスタート](#-クイックスタート) · [API リファレンス](#-api-リファレンス) · [プレビュー地図](https://gl20percentclub.github.io/japan-facilities-api/map.html) · [収録状況](docs/COVERAGE.md) · [出典・ライセンス](https://gl20percentclub.github.io/japan-facilities-api/attribution.html) · [バグ報告](https://github.com/gl20percentclub/japan-facilities-api/issues/new) · [機能要望](https://github.com/gl20percentclub/japan-facilities-api/issues/new)
 
 </div>
 
@@ -314,6 +314,14 @@ sources:
 `api/` を生成して `gh-pages` ブランチへ配信します。**生成物 `api/` は Git 管理せず**（`.gitignore`）、
 配信は gh-pages のみ（履歴肥大を避けるため）。README の「収録データ」統計だけを main に反映します。
 `workflow_dispatch` から手動実行も可能（`dry_run` / `fetch_i2fas` オプション付き）。
+
+配信サイト（gh-pages）のページ構成は次のとおりです。いずれもリポジトリルートの静的 HTML で、ビルド不要です。
+
+| URL | ファイル | 内容 |
+|---|---|---|
+| [`/`](https://gl20percentclub.github.io/japan-facilities-api/) | `index.html` | ランディングページ（概要・特徴・クイックスタート・配信形式） |
+| [`/map.html`](https://gl20percentclub.github.io/japan-facilities-api/map.html) | `map.html` | プレビュー地図（ベクトルタイルを MapLibre で表示） |
+| [`/attribution.html`](https://gl20percentclub.github.io/japan-facilities-api/attribution.html) | `attribution.html` | 出典・ライセンス表示（`config/sources.yaml` から自動生成） |
 
 ## 🤝 コントリビューション
 

--- a/attribution.html
+++ b/attribution.html
@@ -17,6 +17,18 @@
       --muted: #9aa5b1;
       --border: rgba(31, 41, 51, 0.12);
       --panel: #f7f8fa;
+      --bg: #ffffff;
+    }
+    /* 端末のダークモード設定に追随する（LP・地図と配色をそろえる） */
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --ink: #e4e7eb;
+        --sub: #b0b8c0;
+        --muted: #7b8794;
+        --border: rgba(228, 231, 235, 0.16);
+        --panel: #1c2229;
+        --bg: #14181d;
+      }
     }
     * { box-sizing: border-box; }
     body {
@@ -24,7 +36,7 @@
       font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Noto Sans JP", sans-serif;
       color: var(--ink);
       line-height: 1.7;
-      background: #fff;
+      background: var(--bg);
     }
     .wrap { max-width: 920px; margin: 0 auto; padding: 32px 20px 80px; }
     a { color: var(--accent); }
@@ -1569,7 +1581,10 @@
         <a href="https://github.com/gl20percentclub/japan-facilities-api/blob/main/scripts/gen-attribution.js">scripts/gen-attribution.js</a> が自動生成しています。
         誤りを見つけた場合は <a href="https://github.com/gl20percentclub/japan-facilities-api/issues">Issue</a> でお知らせください。
       </p>
-      <p><a href="https://gl20percentclub.github.io/japan-facilities-api/">← プレビュー地図に戻る</a> · <a href="https://github.com/gl20percentclub/japan-facilities-api">GitHub リポジトリ</a></p>
+      <p>
+        <a href="./">← トップへ戻る</a> · <a href="./map.html">プレビュー地図</a> ·
+        <a href="https://github.com/gl20percentclub/japan-facilities-api">GitHub リポジトリ</a>
+      </p>
     </footer>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -3,243 +3,384 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>🍽️ Japan Facilities API — データプレビュー地図</title>
-  <meta name="description" content="日本全国の飲食施設オープンデータ（食品営業許可・届出）を地図上でプレビューできます。">
+  <title>Japan Facilities API — 日本全国の飲食施設オープンデータを無料の静的 API で</title>
+  <meta name="description" content="全国の自治体が公開する食品営業許可・届出のオープンデータを、正規化・ジオコーディングして無料の静的 API として配信。登録不要・API キー不要で、JSON / CSV / ベクトルタイルをそのまま利用できます。">
 
-  <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css">
+  <!-- SNS シェア時のカード表示（画像は用意していないためテキストのみ） -->
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Japan Facilities API">
+  <meta property="og:description" content="日本全国の飲食施設オープンデータ（食品営業許可・届出）を、登録不要・無料の静的 API として配信。">
+  <meta property="og:url" content="https://gl20percentclub.github.io/japan-facilities-api/">
+  <meta name="twitter:card" content="summary">
+
   <style>
     :root {
       --accent: #e8563f;
+      --accent-dark: #c9412c;
       --ink: #1f2933;
-      --panel-bg: rgba(255, 255, 255, 0.94);
+      --sub: #52606d;
+      --muted: #9aa5b1;
       --border: rgba(31, 41, 51, 0.12);
+      --panel: #f7f8fa;
+      --bg: #ffffff;
+      --code-bg: #1f2933;
+      --code-ink: #e4e7eb;
+    }
+    /* 端末のダークモード設定に追随する（配色だけを差し替える） */
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --ink: #e4e7eb;
+        --sub: #b0b8c0;
+        --muted: #7b8794;
+        --border: rgba(228, 231, 235, 0.16);
+        --panel: #1c2229;
+        --bg: #14181d;
+        --code-bg: #0f1317;
+      }
     }
     * { box-sizing: border-box; }
-    html, body { margin: 0; height: 100%; }
     body {
+      margin: 0;
       font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Noto Sans JP", sans-serif;
       color: var(--ink);
+      background: var(--bg);
+      line-height: 1.75;
+      -webkit-font-smoothing: antialiased;
     }
-    #map { position: absolute; inset: 0; }
+    a { color: var(--accent); }
+    code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    .wrap { max-width: 960px; margin: 0 auto; padding: 0 20px; }
+    section { padding: 56px 0; border-top: 1px solid var(--border); }
+    section h2 { font-size: 22px; margin: 0 0 6px; }
+    section .lead { color: var(--sub); font-size: 14.5px; margin: 0 0 28px; }
 
-    /* ヘッダー（左上） */
-    .panel {
-      position: absolute;
-      top: 12px;
-      left: 12px;
-      z-index: 2;
-      max-width: min(340px, calc(100vw - 24px));
-      background: var(--panel-bg);
-      backdrop-filter: blur(8px);
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      box-shadow: 0 4px 20px rgba(0, 0, 0, 0.12);
-      padding: 14px 16px;
-    }
-    .panel h1 {
-      margin: 0 0 4px;
-      font-size: 16px;
-      line-height: 1.35;
-      letter-spacing: 0.01em;
-    }
-    .panel .sub {
-      margin: 0 0 12px;
+    /* --- ヒーロー --- */
+    .hero { padding: 72px 0 56px; text-align: center; }
+    .hero .eyebrow {
+      display: inline-block;
       font-size: 12px;
-      color: #52606d;
-      line-height: 1.5;
+      letter-spacing: 0.08em;
+      color: var(--accent);
+      background: rgba(232, 86, 63, 0.1);
+      border-radius: 999px;
+      padding: 4px 14px;
+      margin-bottom: 18px;
     }
+    .hero h1 { font-size: 38px; line-height: 1.3; margin: 0 0 16px; letter-spacing: -0.01em; }
+    .hero h1 .accent { color: var(--accent); }
+    .hero p { font-size: 16px; color: var(--sub); margin: 0 auto 28px; max-width: 640px; }
+
+    /* CTA ボタン */
+    .cta { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
+    .btn {
+      display: inline-block;
+      font-size: 14px;
+      font-weight: 600;
+      text-decoration: none;
+      border-radius: 8px;
+      padding: 11px 22px;
+      border: 1px solid var(--accent);
+      transition: opacity 0.15s;
+    }
+    .btn:hover { opacity: 0.85; }
+    .btn.primary { background: var(--accent); color: #fff; }
+    .btn.ghost { color: var(--accent); background: transparent; }
+
+    /* --- 統計 --- */
     .stats {
       display: grid;
-      grid-template-columns: repeat(3, 1fr);
-      gap: 8px;
-      margin-bottom: 10px;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 12px;
+      margin-top: 44px;
     }
     .stat {
-      background: #f7f8fa;
-      border-radius: 8px;
-      padding: 8px 6px;
-      text-align: center;
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 16px 10px;
     }
-    .stat .num {
-      display: block;
-      font-size: 18px;
-      font-weight: 700;
-      color: var(--accent);
-      line-height: 1.1;
-    }
-    .stat .lbl { font-size: 10px; color: #616e7c; }
-    .meta-line { font-size: 11px; color: #7b8794; }
-    .meta-line a { color: var(--accent); text-decoration: none; }
-    .meta-line a:hover { text-decoration: underline; }
+    .stat .num { display: block; font-size: 26px; font-weight: 700; color: var(--accent); line-height: 1.2; }
+    .stat .lbl { font-size: 12px; color: var(--sub); }
+    .stats-note { font-size: 11.5px; color: var(--muted); text-align: center; margin: 10px 0 0; }
 
-    /* ズームヒント（下中央） */
-    .hint {
-      position: absolute;
-      left: 50%;
-      bottom: 28px;
-      transform: translateX(-50%);
-      z-index: 2;
-      background: rgba(31, 41, 51, 0.86);
-      color: #fff;
-      font-size: 12px;
-      padding: 8px 14px;
-      border-radius: 999px;
-      box-shadow: 0 2px 10px rgba(0, 0, 0, 0.25);
-      transition: opacity 0.3s;
-      pointer-events: none;
-      white-space: nowrap;
+    /* --- 特徴カード --- */
+    .cards { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+    .card {
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 18px 20px;
+      background: var(--bg);
     }
-    .hint.hidden { opacity: 0; }
+    .card h3 { font-size: 15px; margin: 0 0 6px; }
+    .card p { font-size: 13.5px; color: var(--sub); margin: 0; }
+    .card .ico { font-size: 22px; line-height: 1; display: block; margin-bottom: 8px; }
 
-    /* ポップアップ */
-    .maplibregl-popup-content {
-      font-family: inherit;
-      padding: 12px 14px;
+    /* --- コード --- */
+    pre {
+      background: var(--code-bg);
+      color: var(--code-ink);
       border-radius: 10px;
-      box-shadow: 0 4px 18px rgba(0, 0, 0, 0.18);
+      padding: 16px 18px;
+      overflow-x: auto;
+      font-size: 12.5px;
+      line-height: 1.7;
+      margin: 0 0 16px;
     }
-    .fac-name { font-weight: 700; font-size: 14px; margin: 0 0 6px; }
-    .fac-row { font-size: 12px; color: #52606d; margin: 2px 0; }
-    .fac-row .k { color: #9aa5b1; margin-right: 6px; }
+    pre .c { color: #9aa5b1; } /* コメント */
+    .step { font-size: 14px; color: var(--sub); margin: 0 0 8px; }
 
-    .legend-dot {
-      display: inline-block;
-      width: 10px; height: 10px;
-      border-radius: 50%;
-      background: var(--accent);
-      border: 1.5px solid #fff;
-      box-shadow: 0 0 0 1px rgba(0,0,0,0.15);
-      vertical-align: middle;
-      margin-right: 6px;
+    /* --- 配信形式テーブル --- */
+    .formats { width: 100%; border-collapse: collapse; font-size: 13.5px; }
+    .formats th, .formats td { text-align: left; padding: 10px 12px; border-bottom: 1px solid var(--border); vertical-align: top; }
+    .formats th { color: var(--muted); font-weight: 600; font-size: 12px; white-space: nowrap; }
+    .formats td:first-child { white-space: nowrap; font-weight: 600; }
+    .table-scroll { overflow-x: auto; }
+
+    /* --- 出典・注意書き --- */
+    .notice {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-left: 4px solid var(--accent);
+      border-radius: 8px;
+      padding: 14px 18px;
+      font-size: 13.5px;
+      color: var(--sub);
+    }
+    .notice + .notice { margin-top: 12px; }
+    .notice strong { color: var(--ink); }
+
+    footer { padding: 40px 0 64px; font-size: 13px; color: var(--sub); text-align: center; }
+    footer a { margin: 0 6px; }
+
+    @media (max-width: 720px) {
+      .hero { padding: 48px 0 40px; }
+      .hero h1 { font-size: 27px; }
+      .cards { grid-template-columns: 1fr; }
+      .stats { grid-template-columns: repeat(2, 1fr); }
     }
   </style>
 </head>
 <body>
-  <div id="map"></div>
+  <!-- ================= ヒーロー ================= -->
+  <header class="hero">
+    <div class="wrap">
+      <span class="eyebrow">登録不要 · API キー不要 · 無料</span>
+      <h1>日本全国の飲食施設オープンデータを<br><span class="accent">そのまま使える API</span> に</h1>
+      <p>
+        全国の自治体が公開する食品営業許可・届出のオープンデータを毎週自動でクロールし、
+        全国共通フォーマットへの正規化と緯度経度の付与を行って、静的 API として配信しています。
+      </p>
+      <div class="cta">
+        <a class="btn primary" href="#quickstart">クイックスタート</a>
+        <a class="btn ghost" href="./map.html">地図で見てみる</a>
+        <a class="btn ghost" href="https://github.com/gl20percentclub/japan-facilities-api">GitHub</a>
+      </div>
 
-  <div class="panel">
-    <h1>🍽️ Japan Facilities API</h1>
-    <p class="sub">日本全国の飲食施設オープンデータ（食品営業許可・届出）のプレビュー地図です。</p>
-    <div class="stats">
-      <div class="stat"><span class="num" id="stat-pref">–</span><span class="lbl">都道府県</span></div>
-      <div class="stat"><span class="num" id="stat-city">–</span><span class="lbl">市区町村</span></div>
-      <div class="stat"><span class="num" id="stat-fac">70万+</span><span class="lbl">施設</span></div>
+      <!-- 統計は配信中の api/ から読み込んで更新する（取得できなければ下の既定値のまま） -->
+      <div class="stats">
+        <div class="stat"><span class="num" id="stat-facility">110万</span><span class="lbl">ユニーク施設</span></div>
+        <div class="stat"><span class="num" id="stat-pref">52</span><span class="lbl">都道府県</span></div>
+        <div class="stat"><span class="num" id="stat-city">1,958</span><span class="lbl">市区町村</span></div>
+        <div class="stat"><span class="num" data-source-count>98</span><span class="lbl">データソース</span></div>
+      </div>
+      <p class="stats-note" id="stats-note">毎週月曜に自動更新</p>
+      <p class="stats-note">ユニーク施設数は「名前＋座標」で重複除外した件数です（業種違いを含む全レコードは約 149 万件）。</p>
     </div>
-    <p class="meta-line">
-      <span class="legend-dot"></span>各点＝1施設
-      <span id="updated"></span><br>
-      <a href="https://github.com/gl20percentclub/japan-facilities-api">GitHub リポジトリ</a> ·
-      <a href="https://github.com/gl20percentclub/japan-facilities-api#-api-リファレンス">API リファレンス</a> ·
-      <a href="./attribution.html">出典・ライセンス</a>
-    </p>
-  </div>
+  </header>
 
-  <div class="hint" id="hint">🔍 ズームインすると施設ピンが表示されます</div>
+  <!-- ================= 特徴 ================= -->
+  <section id="features">
+    <div class="wrap">
+      <h2>特徴</h2>
+      <p class="lead">バラバラの形式で公開されている自治体データを、1つの使いやすい形にまとめています。</p>
+      <div class="cards">
+        <div class="card">
+          <span class="ico">🗾</span>
+          <h3>全国をカバー</h3>
+          <p>47 都道府県・1,900 以上の市区町村。都道府県 > 市区町村 の階層で、必要な地域だけを取得できます。</p>
+        </div>
+        <div class="card">
+          <span class="ico">📍</span>
+          <h3>緯度経度つき</h3>
+          <p>座標が無い元データも normalize-japanese-addresses でジオコーディングして補完。精度レベルも一緒に返します。</p>
+        </div>
+        <div class="card">
+          <span class="ico">🧹</span>
+          <h3>形式を正規化</h3>
+          <p>自治体ごとに違う列名・文字コード・市区町村表記を統一し、同じスキーマの JSON にそろえています。</p>
+        </div>
+        <div class="card">
+          <span class="ico">🔄</span>
+          <h3>毎週自動更新</h3>
+          <p>GitHub Actions が毎週クロールして再配信。元データの差し替えにも追従します。</p>
+        </div>
+        <div class="card">
+          <span class="ico">📦</span>
+          <h3>好きな形式で</h3>
+          <p>市区町村別 JSON、施設名検索用インデックス、全国結合 CSV、地図用ベクトルタイルを用意。</p>
+        </div>
+        <div class="card">
+          <span class="ico">🆓</span>
+          <h3>静的配信で無料</h3>
+          <p>GitHub Pages でホスティング。登録・認証・レート制限はありません。CORS も開放済みです。</p>
+        </div>
+      </div>
+    </div>
+  </section>
 
-  <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
+  <!-- ================= クイックスタート ================= -->
+  <section id="quickstart">
+    <div class="wrap">
+      <h2>クイックスタート</h2>
+      <p class="lead">
+        ベース URL は <code>https://gl20percentclub.github.io/japan-facilities-api/api/</code>。
+        取得したい市区町村の <code>data.json</code> を叩くだけです。
+      </p>
+
+      <p class="step">1. 収録されている都道府県・市区町村の一覧を取る</p>
+<pre><code>curl https://gl20percentclub.github.io/japan-facilities-api/api/facilities/index.json</code></pre>
+
+      <p class="step">2. 市区町村の全施設を取る（日本語パスは URL エンコードする）</p>
+<pre><code>curl "https://gl20percentclub.github.io/japan-facilities-api/api/facilities/%E6%B2%96%E7%B8%84%E7%9C%8C/%E9%82%A3%E8%A6%87%E5%B8%82/data.json"</code></pre>
+
+      <p class="step">3. JavaScript から使う</p>
+<pre><code>const BASE = 'https://gl20percentclub.github.io/japan-facilities-api/api';
+
+<span class="c">// 那覇市の全施設を取得</span>
+const res = await fetch(
+  `${BASE}/facilities/${encodeURIComponent('沖縄県')}/${encodeURIComponent('那覇市')}/data.json`
+);
+const { data } = await res.json();
+console.log(data[0].name, data[0].lat, data[0].lng);</code></pre>
+
+      <p class="step">4. 地図に出す（MapLibre GL JS・タイルサーバー不要）</p>
+<pre><code>map.addSource('facilities', {
+  type: 'vector',
+  tiles: ['https://gl20percentclub.github.io/japan-facilities-api/api/tiles/{z}/{x}/{y}.pbf'],
+  minzoom: 6, maxzoom: 12,
+});
+<span class="c">// レイヤ名は "facilities"、属性は name / business_type / pref / city</span></code></pre>
+
+      <p class="step">返ってくる施設データ</p>
+<pre><code>{
+  "name": "ステーキハウス○○",
+  "name_kana": "ステーキハウスマルマル",
+  "business_type": "飲食店営業",
+  "address": "那覇市松山1-9-9",
+  "lat": 26.216965935,
+  "lng": 127.678060421,
+  "geocoding_level": 8,        <span class="c">// 8=街区・地番 / 3=町丁目 / 2=市区町村 / 1=都道府県</span>
+  "phone": "098-XXX-XXXX",
+  "license_no": "第01202300556号",
+  "license_date": "2023-12-07",
+  "expire_date": "2030-01-31"
+}</code></pre>
+    </div>
+  </section>
+
+  <!-- ================= 配信形式 ================= -->
+  <section id="formats">
+    <div class="wrap">
+      <h2>配信している形式</h2>
+      <p class="lead">用途に合わせて選べます。すべて同じベース URL 配下の静的ファイルです。</p>
+      <div class="table-scroll">
+        <table class="formats">
+          <thead>
+            <tr><th>形式</th><th>パス</th><th>用途</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>市区町村別 JSON</td>
+              <td><code>api/facilities/{都道府県}/{市区町村}/data.json</code></td>
+              <td>ある地域の全施設を、全項目つきで取得する。もっとも基本的な形式です。</td>
+            </tr>
+            <tr>
+              <td>検索インデックス</td>
+              <td><code>api/search-index.json</code>（都道府県別に分割）</td>
+              <td>施設名の横断検索向けの軽量な索引。名前・住所・座標だけを配列で持ちます。</td>
+            </tr>
+            <tr>
+              <td>全国結合 CSV</td>
+              <td><code>api/facilities-all.csv.gz</code>（約 60MB / 非圧縮 約 540MB）</td>
+              <td>Excel・pandas・BI ツールでまとめて分析する。UTF-8 BOM 付きです。</td>
+            </tr>
+            <tr>
+              <td>ベクトルタイル</td>
+              <td><code>api/tiles/{z}/{x}/{y}.pbf</code>（z6–12）</td>
+              <td>地図にそのまま重ねる。MapLibre GL JS から直接読めます。</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="lead" style="margin:20px 0 0">
+        各項目の詳細は <a href="https://github.com/gl20percentclub/japan-facilities-api#-api-リファレンス">API リファレンス</a>、
+        自治体ごとの収録状況は <a href="https://github.com/gl20percentclub/japan-facilities-api/blob/main/docs/COVERAGE.md">収録状況一覧</a> を参照してください。
+      </p>
+    </div>
+  </section>
+
+  <!-- ================= 出典・注意点 ================= -->
+  <section id="attribution">
+    <div class="wrap">
+      <h2>出典・ライセンス</h2>
+      <p class="lead">
+        本サービスは各自治体・厚生労働省が公開するオープンデータを加工・統合したものです。
+        利用時の出典表示は、ライセンスごとに求められる形式が異なります。
+      </p>
+      <div class="notice">
+        <strong>📢 出典表示文は <a href="./attribution.html">出典・ライセンス表示ページ</a> にまとめています。</strong><br>
+        全 <span data-source-count>98</span> ソースの出典 URL とライセンス、およびそのまま貼れる出典表示文を一覧化しています。
+      </div>
+      <div class="notice">
+        <strong>緯度経度は本サービスが独自に付与した参考情報です。</strong>
+        自治体が提供しているものではなく、住所からのジオコーディング結果のため、実際の所在地と異なる場合があります。
+      </div>
+      <div class="notice">
+        <strong>本サービスは各自治体の公式サービスではありません。</strong>
+        内容の正確性・完全性・最新性を保証するものではないため、正式な情報は各自治体の公開情報をご確認ください。
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= コントリビュート ================= -->
+  <section id="contribute">
+    <div class="wrap">
+      <h2>データソースの追加も歓迎です</h2>
+      <p class="lead">
+        未収録の自治体は <code>config/sources.yaml</code> に 1 エントリ追加するだけで取り込めます。
+        バグ報告・データ品質の問題報告・ドキュメント改善も歓迎です。
+      </p>
+      <div class="cta" style="justify-content:flex-start">
+        <a class="btn primary" href="https://github.com/gl20percentclub/japan-facilities-api#-コントリビューション">コントリビュート方法</a>
+        <a class="btn ghost" href="https://github.com/gl20percentclub/japan-facilities-api/issues/new">Issue を立てる</a>
+      </div>
+    </div>
+  </section>
+
+  <footer>
+    <div class="wrap">
+      <p>
+        <a href="./map.html">プレビュー地図</a> ·
+        <a href="./attribution.html">出典・ライセンス</a> ·
+        <a href="https://github.com/gl20percentclub/japan-facilities-api">GitHub</a> ·
+        <a href="https://github.com/gl20percentclub/japan-facilities-api/issues">Issues</a>
+      </p>
+      <p>各自治体が公開するオープンデータを加工して作成 — Japan Facilities API</p>
+    </div>
+  </footer>
+
   <script>
-    // データ配信ベース URL（このページと同じ gh-pages 上）。相対参照でローカルでも動く。
+    // 配信中の api/ から件数を読み、ヒーローの統計を最新の値に差し替える。
+    // 取得できない場合は HTML に書かれた既定値をそのまま残す（表示は壊さない）。
     const API_BASE = './api';
-    // ベクトルタイルのズーム範囲（scripts/gen-tiles.js の設定と一致させる）
-    const TILE_MIN_ZOOM = 6;
-    const TILE_MAX_ZOOM = 12;
-    // 日本のおおよその範囲 [west, south, east, north]
-    const JAPAN_BOUNDS = [122, 20, 154, 46];
 
-    const map = new maplibregl.Map({
-      container: 'map',
-      // 国土地理院 淡色地図をベースにした最小構成スタイル（API キー不要）
-      style: {
-        version: 8,
-        glyphs: 'https://glyphs.geolonia.com/fonts/{fontstack}/{range}.pbf',
-        sources: {
-          gsi: {
-            type: 'raster',
-            tiles: ['https://cyberjapandata.gsi.go.jp/xyz/pale/{z}/{x}/{y}.png'],
-            tileSize: 256,
-            minzoom: 2,
-            maxzoom: 18,
-            attribution:
-              '<a href="https://maps.gsi.go.jp/development/ichiran.html" target="_blank" rel="noopener">地理院タイル</a>',
-          },
-          facilities: {
-            type: 'vector',
-            tiles: [`${location.href.replace(/[^/]*$/, '')}api/tiles/{z}/{x}/{y}.pbf`],
-            minzoom: TILE_MIN_ZOOM,
-            maxzoom: TILE_MAX_ZOOM,
-            bounds: JAPAN_BOUNDS,
-            attribution:
-              '施設データ: <a href="https://github.com/gl20percentclub/japan-facilities-api" target="_blank" rel="noopener">Japan Facilities API</a>'
-              + '（<a href="./attribution.html">各自治体オープンデータの出典一覧</a>）',
-          },
-        },
-        layers: [
-          { id: 'gsi', type: 'raster', source: 'gsi' },
-          {
-            id: 'facilities-circle',
-            type: 'circle',
-            source: 'facilities',
-            'source-layer': 'facilities',
-            paint: {
-              'circle-color': '#e8563f',
-              'circle-opacity': 0.75,
-              'circle-stroke-color': '#ffffff',
-              'circle-stroke-width': 0.6,
-              // ズームに応じて点を大きくする
-              'circle-radius': [
-                'interpolate', ['linear'], ['zoom'],
-                6, 1.6,
-                9, 2.8,
-                12, 4.5,
-                16, 7,
-              ],
-            },
-          },
-        ],
-      },
-      bounds: JAPAN_BOUNDS,
-      fitBoundsOptions: { padding: 20 },
-      minZoom: 3,
-      maxZoom: 18,
-      attributionControl: false,
-    });
-
-    map.addControl(new maplibregl.NavigationControl({ showCompass: false }), 'top-right');
-    map.addControl(
-      new maplibregl.AttributionControl({ compact: true }),
-      'bottom-right',
-    );
-    map.addControl(new maplibregl.GeolocateControl({
-      positionOptions: { enableHighAccuracy: true },
-      trackUserLocation: true,
-    }), 'top-right');
-
-    // --- ヒントの表示制御（ズーム6未満では点が出ないため案内する）---
-    const hintEl = document.getElementById('hint');
-    function updateHint() {
-      hintEl.classList.toggle('hidden', map.getZoom() >= TILE_MIN_ZOOM);
+    /** 数値を「149万」「1,958」のような読みやすい表記にする。 */
+    function formatCount(n) {
+      if (n >= 10000) return `${Math.floor(n / 10000).toLocaleString('ja-JP')}万`;
+      return n.toLocaleString('ja-JP');
     }
-    map.on('zoom', updateHint);
-    map.on('load', updateHint);
 
-    // --- 施設クリックでポップアップ ---
-    map.on('click', 'facilities-circle', (e) => {
-      const p = e.features[0].properties || {};
-      const esc = (s) => String(s ?? '').replace(/[&<>"]/g, (c) =>
-        ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
-      const rows = [];
-      if (p.business_type) rows.push(`<p class="fac-row"><span class="k">業種</span>${esc(p.business_type)}</p>`);
-      const loc = [p.pref, p.city].filter(Boolean).join(' ');
-      if (loc) rows.push(`<p class="fac-row"><span class="k">所在</span>${esc(loc)}</p>`);
-      new maplibregl.Popup({ offset: 8, maxWidth: '280px' })
-        .setLngLat(e.lngLat)
-        .setHTML(`<p class="fac-name">${esc(p.name) || '（名称なし）'}</p>${rows.join('')}`)
-        .addTo(map);
-    });
-    map.on('mouseenter', 'facilities-circle', () => { map.getCanvas().style.cursor = 'pointer'; });
-    map.on('mouseleave', 'facilities-circle', () => { map.getCanvas().style.cursor = ''; });
-
-    // --- 統計（index.json）を取得してヘッダーに反映 ---
+    // 都道府県・市区町村の数は facilities/index.json（都道府県 → 市区町村配列）から数える。
     fetch(`${API_BASE}/facilities/index.json`)
       .then((r) => (r.ok ? r.json() : Promise.reject(r.status)))
       .then((json) => {
@@ -247,13 +388,24 @@
         const cities = prefs.reduce((n, p) => n + (json.data[p]?.length || 0), 0);
         document.getElementById('stat-pref').textContent = prefs.length.toLocaleString('ja-JP');
         document.getElementById('stat-city').textContent = cities.toLocaleString('ja-JP');
+        // 最終更新日（UNIX 秒）が取れたら更新頻度の注記に添える。
         if (json.meta?.updated) {
           const d = new Date(json.meta.updated * 1000);
           const ymd = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
-          document.getElementById('updated').textContent = `最終更新 ${ymd}`;
+          document.getElementById('stats-note').textContent = `毎週月曜に自動更新 — 最終更新 ${ymd}`;
         }
       })
-      .catch(() => { /* 統計が取れなくても地図本体は動く */ });
+      .catch(() => { /* 統計が取れなくてもページは成立する */ });
+
+    // 施設数は検索インデックスのマニフェスト（meta.count）から取る。
+    fetch(`${API_BASE}/search-index.json`)
+      .then((r) => (r.ok ? r.json() : Promise.reject(r.status)))
+      .then((json) => {
+        if (json.meta?.count) {
+          document.getElementById('stat-facility').textContent = formatCount(json.meta.count);
+        }
+      })
+      .catch(() => { /* 同上 */ });
   </script>
 </body>
 </html>

--- a/map.html
+++ b/map.html
@@ -1,0 +1,260 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>🍽️ Japan Facilities API — データプレビュー地図</title>
+  <meta name="description" content="日本全国の飲食施設オープンデータ（食品営業許可・届出）を地図上でプレビューできます。">
+
+  <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css">
+  <style>
+    :root {
+      --accent: #e8563f;
+      --ink: #1f2933;
+      --panel-bg: rgba(255, 255, 255, 0.94);
+      --border: rgba(31, 41, 51, 0.12);
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; height: 100%; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Noto Sans JP", sans-serif;
+      color: var(--ink);
+    }
+    #map { position: absolute; inset: 0; }
+
+    /* ヘッダー（左上） */
+    .panel {
+      position: absolute;
+      top: 12px;
+      left: 12px;
+      z-index: 2;
+      max-width: min(340px, calc(100vw - 24px));
+      background: var(--panel-bg);
+      backdrop-filter: blur(8px);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      box-shadow: 0 4px 20px rgba(0, 0, 0, 0.12);
+      padding: 14px 16px;
+    }
+    .panel h1 {
+      margin: 0 0 4px;
+      font-size: 16px;
+      line-height: 1.35;
+      letter-spacing: 0.01em;
+    }
+    .panel .sub {
+      margin: 0 0 12px;
+      font-size: 12px;
+      color: #52606d;
+      line-height: 1.5;
+    }
+    .stats {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 8px;
+      margin-bottom: 10px;
+    }
+    .stat {
+      background: #f7f8fa;
+      border-radius: 8px;
+      padding: 8px 6px;
+      text-align: center;
+    }
+    .stat .num {
+      display: block;
+      font-size: 18px;
+      font-weight: 700;
+      color: var(--accent);
+      line-height: 1.1;
+    }
+    .stat .lbl { font-size: 10px; color: #616e7c; }
+    .meta-line { font-size: 11px; color: #7b8794; }
+    .meta-line a { color: var(--accent); text-decoration: none; }
+    .meta-line a:hover { text-decoration: underline; }
+
+    /* ズームヒント（下中央） */
+    .hint {
+      position: absolute;
+      left: 50%;
+      bottom: 28px;
+      transform: translateX(-50%);
+      z-index: 2;
+      background: rgba(31, 41, 51, 0.86);
+      color: #fff;
+      font-size: 12px;
+      padding: 8px 14px;
+      border-radius: 999px;
+      box-shadow: 0 2px 10px rgba(0, 0, 0, 0.25);
+      transition: opacity 0.3s;
+      pointer-events: none;
+      white-space: nowrap;
+    }
+    .hint.hidden { opacity: 0; }
+
+    /* ポップアップ */
+    .maplibregl-popup-content {
+      font-family: inherit;
+      padding: 12px 14px;
+      border-radius: 10px;
+      box-shadow: 0 4px 18px rgba(0, 0, 0, 0.18);
+    }
+    .fac-name { font-weight: 700; font-size: 14px; margin: 0 0 6px; }
+    .fac-row { font-size: 12px; color: #52606d; margin: 2px 0; }
+    .fac-row .k { color: #9aa5b1; margin-right: 6px; }
+
+    .legend-dot {
+      display: inline-block;
+      width: 10px; height: 10px;
+      border-radius: 50%;
+      background: var(--accent);
+      border: 1.5px solid #fff;
+      box-shadow: 0 0 0 1px rgba(0,0,0,0.15);
+      vertical-align: middle;
+      margin-right: 6px;
+    }
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+
+  <div class="panel">
+    <h1>🍽️ Japan Facilities API</h1>
+    <p class="sub">日本全国の飲食施設オープンデータ（食品営業許可・届出）のプレビュー地図です。</p>
+    <div class="stats">
+      <div class="stat"><span class="num" id="stat-pref">–</span><span class="lbl">都道府県</span></div>
+      <div class="stat"><span class="num" id="stat-city">–</span><span class="lbl">市区町村</span></div>
+      <div class="stat"><span class="num" id="stat-fac">70万+</span><span class="lbl">施設</span></div>
+    </div>
+    <p class="meta-line">
+      <span class="legend-dot"></span>各点＝1施設
+      <span id="updated"></span><br>
+      <a href="./">トップ</a> ·
+      <a href="https://github.com/gl20percentclub/japan-facilities-api">GitHub リポジトリ</a> ·
+      <a href="https://github.com/gl20percentclub/japan-facilities-api#-api-リファレンス">API リファレンス</a> ·
+      <a href="./attribution.html">出典・ライセンス</a>
+    </p>
+  </div>
+
+  <div class="hint" id="hint">🔍 ズームインすると施設ピンが表示されます</div>
+
+  <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
+  <script>
+    // データ配信ベース URL（このページと同じ gh-pages 上）。相対参照でローカルでも動く。
+    const API_BASE = './api';
+    // ベクトルタイルのズーム範囲（scripts/gen-tiles.js の設定と一致させる）
+    const TILE_MIN_ZOOM = 6;
+    const TILE_MAX_ZOOM = 12;
+    // 日本のおおよその範囲 [west, south, east, north]
+    const JAPAN_BOUNDS = [122, 20, 154, 46];
+
+    const map = new maplibregl.Map({
+      container: 'map',
+      // 国土地理院 淡色地図をベースにした最小構成スタイル（API キー不要）
+      style: {
+        version: 8,
+        glyphs: 'https://glyphs.geolonia.com/fonts/{fontstack}/{range}.pbf',
+        sources: {
+          gsi: {
+            type: 'raster',
+            tiles: ['https://cyberjapandata.gsi.go.jp/xyz/pale/{z}/{x}/{y}.png'],
+            tileSize: 256,
+            minzoom: 2,
+            maxzoom: 18,
+            attribution:
+              '<a href="https://maps.gsi.go.jp/development/ichiran.html" target="_blank" rel="noopener">地理院タイル</a>',
+          },
+          facilities: {
+            type: 'vector',
+            tiles: [`${location.href.replace(/[^/]*$/, '')}api/tiles/{z}/{x}/{y}.pbf`],
+            minzoom: TILE_MIN_ZOOM,
+            maxzoom: TILE_MAX_ZOOM,
+            bounds: JAPAN_BOUNDS,
+            attribution:
+              '施設データ: <a href="https://github.com/gl20percentclub/japan-facilities-api" target="_blank" rel="noopener">Japan Facilities API</a>'
+              + '（<a href="./attribution.html">各自治体オープンデータの出典一覧</a>）',
+          },
+        },
+        layers: [
+          { id: 'gsi', type: 'raster', source: 'gsi' },
+          {
+            id: 'facilities-circle',
+            type: 'circle',
+            source: 'facilities',
+            'source-layer': 'facilities',
+            paint: {
+              'circle-color': '#e8563f',
+              'circle-opacity': 0.75,
+              'circle-stroke-color': '#ffffff',
+              'circle-stroke-width': 0.6,
+              // ズームに応じて点を大きくする
+              'circle-radius': [
+                'interpolate', ['linear'], ['zoom'],
+                6, 1.6,
+                9, 2.8,
+                12, 4.5,
+                16, 7,
+              ],
+            },
+          },
+        ],
+      },
+      bounds: JAPAN_BOUNDS,
+      fitBoundsOptions: { padding: 20 },
+      minZoom: 3,
+      maxZoom: 18,
+      attributionControl: false,
+    });
+
+    map.addControl(new maplibregl.NavigationControl({ showCompass: false }), 'top-right');
+    map.addControl(
+      new maplibregl.AttributionControl({ compact: true }),
+      'bottom-right',
+    );
+    map.addControl(new maplibregl.GeolocateControl({
+      positionOptions: { enableHighAccuracy: true },
+      trackUserLocation: true,
+    }), 'top-right');
+
+    // --- ヒントの表示制御（ズーム6未満では点が出ないため案内する）---
+    const hintEl = document.getElementById('hint');
+    function updateHint() {
+      hintEl.classList.toggle('hidden', map.getZoom() >= TILE_MIN_ZOOM);
+    }
+    map.on('zoom', updateHint);
+    map.on('load', updateHint);
+
+    // --- 施設クリックでポップアップ ---
+    map.on('click', 'facilities-circle', (e) => {
+      const p = e.features[0].properties || {};
+      const esc = (s) => String(s ?? '').replace(/[&<>"]/g, (c) =>
+        ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+      const rows = [];
+      if (p.business_type) rows.push(`<p class="fac-row"><span class="k">業種</span>${esc(p.business_type)}</p>`);
+      const loc = [p.pref, p.city].filter(Boolean).join(' ');
+      if (loc) rows.push(`<p class="fac-row"><span class="k">所在</span>${esc(loc)}</p>`);
+      new maplibregl.Popup({ offset: 8, maxWidth: '280px' })
+        .setLngLat(e.lngLat)
+        .setHTML(`<p class="fac-name">${esc(p.name) || '（名称なし）'}</p>${rows.join('')}`)
+        .addTo(map);
+    });
+    map.on('mouseenter', 'facilities-circle', () => { map.getCanvas().style.cursor = 'pointer'; });
+    map.on('mouseleave', 'facilities-circle', () => { map.getCanvas().style.cursor = ''; });
+
+    // --- 統計（index.json）を取得してヘッダーに反映 ---
+    fetch(`${API_BASE}/facilities/index.json`)
+      .then((r) => (r.ok ? r.json() : Promise.reject(r.status)))
+      .then((json) => {
+        const prefs = Object.keys(json.data || {});
+        const cities = prefs.reduce((n, p) => n + (json.data[p]?.length || 0), 0);
+        document.getElementById('stat-pref').textContent = prefs.length.toLocaleString('ja-JP');
+        document.getElementById('stat-city').textContent = cities.toLocaleString('ja-JP');
+        if (json.meta?.updated) {
+          const d = new Date(json.meta.updated * 1000);
+          const ymd = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+          document.getElementById('updated').textContent = `最終更新 ${ymd}`;
+        }
+      })
+      .catch(() => { /* 統計が取れなくても地図本体は動く */ });
+  </script>
+</body>
+</html>

--- a/scripts/gen-attribution.js
+++ b/scripts/gen-attribution.js
@@ -351,6 +351,18 @@ export function renderHtml(entries) {
       --muted: #9aa5b1;
       --border: rgba(31, 41, 51, 0.12);
       --panel: #f7f8fa;
+      --bg: #ffffff;
+    }
+    /* 端末のダークモード設定に追随する（LP・地図と配色をそろえる） */
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --ink: #e4e7eb;
+        --sub: #b0b8c0;
+        --muted: #7b8794;
+        --border: rgba(228, 231, 235, 0.16);
+        --panel: #1c2229;
+        --bg: #14181d;
+      }
     }
     * { box-sizing: border-box; }
     body {
@@ -358,7 +370,7 @@ export function renderHtml(entries) {
       font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Noto Sans JP", sans-serif;
       color: var(--ink);
       line-height: 1.7;
-      background: #fff;
+      background: var(--bg);
     }
     .wrap { max-width: 920px; margin: 0 auto; padding: 32px 20px 80px; }
     a { color: var(--accent); }
@@ -493,7 +505,10 @@ ${sections.map(renderSection).join('\n')}
         <a href="${REPO_URL}/blob/main/scripts/gen-attribution.js">scripts/gen-attribution.js</a> が自動生成しています。
         誤りを見つけた場合は <a href="${REPO_URL}/issues">Issue</a> でお知らせください。
       </p>
-      <p><a href="${SITE_URL}">← プレビュー地図に戻る</a> · <a href="${REPO_URL}">GitHub リポジトリ</a></p>
+      <p>
+        <a href="./">← トップへ戻る</a> · <a href="./map.html">プレビュー地図</a> ·
+        <a href="${REPO_URL}">GitHub リポジトリ</a>
+      </p>
     </footer>
   </div>
 

--- a/scripts/gen-attribution.test.js
+++ b/scripts/gen-attribution.test.js
@@ -131,6 +131,16 @@ assert(
   '全ソースのアンカー（key）がページに載っている',
 );
 
+// --- LP（index.html）に書いたソース数が config と一致しているか ---
+// LP は静的に「98 データソース」と表示するため、ソースを増減したら書き換えが要る。
+const lp = fs.readFileSync(new URL('../index.html', import.meta.url), 'utf-8');
+const lpCounts = [...lp.matchAll(/data-source-count>(\d[\d,]*)</g)].map((m) => Number(m[1].replaceAll(',', '')));
+assert(lpCounts.length > 0, 'LP にソース数の記載（data-source-count）がある');
+assert(
+  lpCounts.every((n) => n === sources.length),
+  `LP のソース数の記載が config と一致する（記載: ${lpCounts.join(', ')} / 実際: ${sources.length}）`,
+);
+
 if (failures > 0) {
   console.error(`\n❌ ${failures}件のチェックに失敗`);
   process.exit(1);

--- a/scripts/preview-map.test.js
+++ b/scripts/preview-map.test.js
@@ -1,9 +1,9 @@
-// プレビュー地図(index.html)と gen-tiles.js の生成物との整合性テスト。
+// プレビュー地図(map.html)と gen-tiles.js の生成物との整合性テスト。
 //   node scripts/preview-map.test.js
 //
-// index.html はベクトルタイル(api/tiles)を直接読むため、レイヤ名・ズーム範囲・
+// map.html はベクトルタイル(api/tiles)を直接読むため、レイヤ名・ズーム範囲・
 // タイルパス・利用する属性が gen-tiles.js の出力とズレると地図が黙って壊れる。
-// ここでは実際に generateTiles を走らせた生成物と index.html の記述を突き合わせ、
+// ここでは実際に generateTiles を走らせた生成物と map.html の記述を突き合わせ、
 // 両者が食い違ったら失敗させることで、その回帰を防ぐ。
 
 import assert from 'node:assert/strict';
@@ -15,7 +15,7 @@ import { buildFeatureCollection, generateTiles } from './gen-tiles.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const HTML = fs.readFileSync(path.join(ROOT, 'index.html'), 'utf-8');
+const HTML = fs.readFileSync(path.join(ROOT, 'map.html'), 'utf-8');
 
 let passed = 0;
 function test(name, fn) {
@@ -24,10 +24,10 @@ function test(name, fn) {
   console.log(`  ✓ ${name}`);
 }
 
-// index.html から地図設定に使っている値を素朴に抽出する（フルパーサは不要）。
+// map.html から地図設定に使っている値を素朴に抽出する（フルパーサは不要）。
 function htmlValue(re, label) {
   const m = HTML.match(re);
-  assert.ok(m, `index.html から ${label} を抽出できる`);
+  assert.ok(m, `map.html から ${label} を抽出できる`);
   return m[1];
 }
 
@@ -83,7 +83,7 @@ test('タイルURLテンプレートが「api/tiles/ + metadata.tiles[0]」の�
     generateTiles({ minZoom: 6, maxZoom: 12, facilitiesDir: path.join(dir, 'facilities'), outDir });
     const meta = JSON.parse(fs.readFileSync(path.join(outDir, 'metadata.json'), 'utf-8'));
     const expectedPath = `api/tiles/${meta.tiles[0]}`; // = api/tiles/{z}/{x}/{y}.pbf
-    assert.ok(HTML.includes(expectedPath), `index.html がタイルパス ${expectedPath} を参照する`);
+    assert.ok(HTML.includes(expectedPath), `map.html がタイルパス ${expectedPath} を参照する`);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -94,11 +94,11 @@ test('ポップアップで参照する施設属性がすべて生成featureに�
   try {
     const fc = buildFeatureCollection(path.join(dir, 'facilities'));
     const props = fc.features[0].properties;
-    // index.html が p.<prop> として参照している属性を抽出する。
+    // map.html が p.<prop> として参照している属性を抽出する。
     const referenced = new Set(
       [...HTML.matchAll(/\bp\.([a-z_]+)\b/g)].map((m) => m[1]),
     );
-    assert.ok(referenced.size >= 3, `index.html が施設属性を参照している (${[...referenced].join(',')})`);
+    assert.ok(referenced.size >= 3, `map.html が施設属性を参照している (${[...referenced].join(',')})`);
     for (const key of referenced) {
       assert.ok(key in props, `属性 ${key} が生成feature.properties に存在する`);
     }


### PR DESCRIPTION
## 概要

配信サイトのランディングページ（LP）を追加します。あわせて、これまでルート（`index.html`）にあったプレビュー地図を `map.html` へ移動し、サイトの入口を LP にします。

> ⚠️ **このPRは #39（出典表示ページ）を土台にしています。** base を `attribution-page` にしているため、#39 をマージすると自動で `main` に付け替わります。#39 → 本PR の順にマージしてください。

## ページ構成（マージ後）

| URL | ファイル | 内容 |
|---|---|---|
| `/` | `index.html`（新規） | ランディングページ |
| `/map.html` | `map.html`（旧 `index.html`） | プレビュー地図 |
| `/attribution.html` | `attribution.html` | 出典・ライセンス表示（#39） |

⚠️ プレビュー地図の URL がルートから `/map.html` に変わります。地図へは LP のヒーロー（「地図で見てみる」）とフッターから遷移できます。

## LP の内容

- **ヒーロー** — 「登録不要・API キー不要・無料」の訴求＋CTA（クイックスタート / 地図デモ / GitHub）
- **統計** — ユニーク施設・都道府県・市区町村・データソース数。配信中の `api/facilities/index.json` と `api/search-index.json` から取得して差し替え、取得できなければ HTML の既定値を表示（最終更新日も注記に反映）
- **特徴** — 全国カバー / 緯度経度つき / 形式の正規化 / 毎週自動更新 / 4形式で配信 / 静的配信で無料
- **クイックスタート** — curl・JavaScript・MapLibre のコード例とレスポンス例（`geocoding_level` の意味つき）
- **配信している形式** — 市区町村別 JSON / 検索インデックス / 全国結合 CSV / ベクトルタイルの用途とパス
- **出典・ライセンス** — 出典表示ページへの導線、緯度経度が独自付与である旨、公式サービスではない旨
- **コントリビュート** — ソース追加の導線

依存ライブラリなしの静的 HTML 1枚（インライン CSS / JS）。レスポンシブ対応、`prefers-color-scheme` でダークモードにも追随します。

## その他の変更

- `map.html` — パネルに「トップ」への導線を追加
- `attribution.html` / `scripts/gen-attribution.js` — ダークモード対応、フッターの導線を LP・地図に合わせて更新
- `scripts/preview-map.test.js` — 参照先を `index.html` → `map.html` に変更
- `scripts/gen-attribution.test.js` — LP に静的に書いたデータソース数（`data-source-count`）が `config/sources.yaml` と一致するかを検証（ソース追加時の書き換え漏れ防止）
- `README.md` — 冒頭リンクに公式サイト・プレビュー地図を追加、gh-pages のページ構成表を追記

## テスト・確認

- `node scripts/gen-attribution.test.js` — 合格（24 チェック）
- `node scripts/preview-map.test.js` — 合格（参照先を map.html に変更後も整合）
- ローカルサーバーで LP / 地図 / 出典ページの表示・相互リンク・レスポンシブ・ダークモードを確認
