### PR TITLE
結合CSVをBOMなしUTF-8の1本に統一し、gzip圧縮版の配布を廃止

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 [公式サイト](https://gl20percentclub.github.io/japan-facilities-api/) ·
 [地図で見る](https://gl20percentclub.github.io/japan-facilities-api/map.html) ·
-[CSVをダウンロード](https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv.gz) ·
+[CSVをダウンロード](https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv) ·
 [収録状況](docs/COVERAGE.md) ·
 [出典・ライセンス](https://gl20percentclub.github.io/japan-facilities-api/attribution.html)
 
@@ -49,23 +49,20 @@
 
 | ファイル | URL |
 |---|---|
-| gzip圧縮版（推奨） | https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv.gz |
-| 非圧縮版 | https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv |
+| 全件CSV | https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv |
 
-- 文字コード: UTF-8 BOM付き
-- Excelで直接読み込み可能
+- 文字コード: UTF-8（BOMなし）
 - 全列が一致する重複レコードは除去済み
 
 ```bash
-curl -O https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv.gz
-gunzip facilities-all.csv.gz
+curl -O https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv
 ```
 
 ```python
 import pandas as pd
 
 df = pd.read_csv(
-    "https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv.gz"
+    "https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv"
 )
 ```
 

--- a/index.html
+++ b/index.html
@@ -237,14 +237,13 @@
         ベース URL は <code>https://gl20percentclub.github.io/japan-facilities-api/api/</code>。
       </p>
 
-      <p class="step">1. 全件CSV をダウンロードする（gzip 約 60MB）</p>
-<pre><code>curl -O https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv.gz
-gunzip facilities-all.csv.gz</code></pre>
+      <p class="step">1. 全件CSV をダウンロードする（約 540MB）</p>
+<pre><code>curl -O https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv</code></pre>
 
       <p class="step">2. pandas で読み込む（URL 直指定でもいけます）</p>
 <pre><code>import pandas as pd
 
-df = pd.read_csv('https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv.gz')
+df = pd.read_csv('https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv')
 <span class="c"># 那覇市の飲食店営業だけ抜き出す</span>
 naha = df[(df.city == '那覇市') &amp; (df.business_type == '飲食店営業')]
 print(naha[['name', 'address', 'lat', 'lng']].head())</code></pre>
@@ -280,8 +279,8 @@ print(naha[['name', 'address', 'lat', 'lng']].head())</code></pre>
           <tbody>
             <tr>
               <td>全件 CSV</td>
-              <td><code>api/facilities-all.csv.gz</code>（約 60MB / 非圧縮 約 540MB）</td>
-              <td>Excel・pandas・BI ツール・DB 取り込みで分析する。全項目入り・UTF-8 BOM 付きです。</td>
+              <td><code>api/facilities-all.csv</code>（約 540MB）</td>
+              <td>pandas・BI ツール・DB 取り込みで分析する。全項目入り・BOM なし UTF-8 です。</td>
             </tr>
             <tr>
               <td>ベクトルタイル</td>

--- a/map.html
+++ b/map.html
@@ -130,7 +130,7 @@
       <span id="updated"></span><br>
       <a href="./">トップ</a> ·
       <a href="https://github.com/gl20percentclub/japan-facilities-api">GitHub リポジトリ</a> ·
-      <a href="https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv.gz">全件CSV</a> ·
+      <a href="https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv">全件CSV</a> ·
       <a href="./attribution.html">出典・ライセンス</a>
     </p>
   </div>

--- a/scripts/build-merged-csv.js
+++ b/scripts/build-merged-csv.js
@@ -1,8 +1,10 @@
-// 全件配布用の結合CSV生成（api/facilities-all.csv[.gz]）。
+// 全件配布用の結合CSV生成（api/facilities-all.csv）。
 //
 // 全国の施設レコードを1本の CSV に書き出す。都道府県・市区町村は名寄せ済みの値
 // （lib/city-normmap.js が付与した pref / city）を使い、元データの生表記は
 // city_raw 列に残す。
+//
+// 配布形式は BOM なし UTF-8 の CSV 1本のみ（gzip 圧縮版は配布しない）。
 //
 // 出力時に以下の浄化を行う:
 //   - 全列完全一致の重複レコードを除去（出典・ライセンス列は判定から除く。
@@ -15,8 +17,6 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import zlib from 'node:zlib';
-import { pipeline } from 'node:stream/promises';
 
 /** 結合CSV の列（この順で出力する）。 */
 export const CSV_COLUMNS = [
@@ -54,14 +54,13 @@ function write(stream, chunk) {
 }
 
 /**
- * 結合CSV（と gzip 版）を書き出す。
- * 統計 `{ rowsIn, rowsOut, dupSkipped, prefectures, cities, bytes, gzipBytes }` を返す。
+ * 結合CSV を書き出す（BOM なし UTF-8）。
+ * 統計 `{ rowsIn, rowsOut, dupSkipped, prefectures, cities, bytes }` を返す。
  */
-export async function buildMergedCsv(facilities, { outPath, gzip = true, log = console.log } = {}) {
+export async function buildMergedCsv(facilities, { outPath, log = console.log } = {}) {
   fs.mkdirSync(path.dirname(outPath), { recursive: true });
   const out = fs.createWriteStream(outPath, { encoding: 'utf-8' });
 
-  await write(out, '﻿'); // Excel 互換 UTF-8 BOM
   await write(out, CSV_COLUMNS.join(',') + '\n');
 
   let rowsIn = 0;
@@ -97,24 +96,12 @@ export async function buildMergedCsv(facilities, { outPath, gzip = true, log = c
   });
 
   const bytes = fs.statSync(outPath).size;
-  let gzipBytes = 0;
-  if (gzip) {
-    // 540MB 級になるためストリームで圧縮する（メモリに載せない）。
-    const gzPath = `${outPath}.gz`;
-    await pipeline(
-      fs.createReadStream(outPath),
-      zlib.createGzip({ level: 6 }),
-      fs.createWriteStream(gzPath),
-    );
-    gzipBytes = fs.statSync(gzPath).size;
-  }
 
   log(
     `  結合CSV: ${rowsOut.toLocaleString('en-US')}行` +
       `（重複 ${dupSkipped.toLocaleString('en-US')}行を除去）` +
       ` / ${prefs.size}都道府県 / ${cities.size}市区町村` +
-      ` / ${(bytes / 1024 / 1024).toFixed(1)} MB` +
-      (gzip ? `（gzip ${(gzipBytes / 1024 / 1024).toFixed(1)} MB）` : ''),
+      ` / ${(bytes / 1024 / 1024).toFixed(1)} MB`,
   );
 
   return {
@@ -124,6 +111,5 @@ export async function buildMergedCsv(facilities, { outPath, gzip = true, log = c
     prefectures: prefs.size,
     cities: cities.size,
     bytes,
-    gzipBytes,
   };
 }

--- a/scripts/build-merged-csv.test.js
+++ b/scripts/build-merged-csv.test.js
@@ -8,7 +8,6 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import zlib from 'node:zlib';
 import { buildMergedCsv, CSV_COLUMNS, csvCell } from './build-merged-csv.js';
 import { readCsvRows } from './lib/csv-read.js';
 import { resolvePrefCity, applyPrefCity, collectCityPairs } from './lib/city-normmap.js';
@@ -54,10 +53,12 @@ await test('csvCell: 特殊文字を含むときだけ引用符で囲む', () =>
 });
 
 // --- 書き出し → 読み戻し ---
-await test('CSV: ヘッダーと BOM を出し、値が往復で保たれる', async () => {
+await test('CSV: BOM なし UTF-8 でヘッダーを出し、値が往復で保たれる', async () => {
   const { dir, outPath, header, rows } = await writeCsv([fac()]);
   try {
-    assert.ok(fs.readFileSync(outPath, 'utf-8').startsWith('﻿'), 'BOM 付き');
+    const buf = fs.readFileSync(outPath);
+    assert.notDeepEqual([...buf.subarray(0, 3)], [0xef, 0xbb, 0xbf], 'UTF-8 BOM が付かない');
+    assert.ok(buf.toString('utf-8').startsWith('prefecture,'), '1バイト目から列名が始まる');
     assert.deepEqual(header, CSV_COLUMNS);
     assert.equal(rows.length, 1);
     assert.equal(rows[0][col.prefecture], '東京都');
@@ -127,14 +128,12 @@ await test('CSV: 都道府県・市区町村の異なり数を数える', async 
   }
 });
 
-await test('CSV: gzip 版が生成され、展開すると元の内容に一致する', async () => {
+await test('CSV: gzip 版は生成しない（配布は非圧縮CSVのみ）', async () => {
   const { dir, outPath, stats } = await writeCsv([fac()]);
   try {
-    const gz = `${outPath}.gz`;
-    assert.ok(fs.existsSync(gz), 'gz が生成される');
-    assert.equal(stats.gzipBytes, fs.statSync(gz).size);
-    const unzipped = zlib.gunzipSync(fs.readFileSync(gz)).toString('utf-8');
-    assert.equal(unzipped, fs.readFileSync(outPath, 'utf-8'), '展開結果が元CSVと一致');
+    assert.ok(!fs.existsSync(`${outPath}.gz`), '.csv.gz を作らない');
+    assert.ok(!('gzipBytes' in stats), '統計に gzipBytes を含めない');
+    assert.equal(stats.bytes, fs.statSync(outPath).size);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }

--- a/scripts/gen-readme-stats.js
+++ b/scripts/gen-readme-stats.js
@@ -36,7 +36,6 @@ function num(n) {
  */
 export function renderStats(s) {
   const date = s.updated ? new Date(s.updated * 1000).toISOString().slice(0, 10) : '—';
-  const gz = s.csv.gzipBytes ? `（gzip ${humanSize(s.csv.gzipBytes)}）` : '';
   return [
     `> **最終更新: ${date}**`,
     '>',
@@ -46,7 +45,7 @@ export function renderStats(s) {
     `> | 座標を持つ施設 | ${num(s.tiles.points)} 件 |`,
     `> | 都道府県 | ${num(s.csv.prefectures)} |`,
     `> | 市区町村 | ${num(s.csv.cities)} |`,
-    `> | 結合CSV | ${humanSize(s.csv.bytes)}${gz} |`,
+    `> | 結合CSV | ${humanSize(s.csv.bytes)} |`,
     `> | ベクトルタイル | ${num(s.tiles.tiles)} 枚 / ${humanSize(s.tiles.bytes)} |`,
   ].join('\n');
 }

--- a/scripts/gen-readme-stats.test.js
+++ b/scripts/gen-readme-stats.test.js
@@ -24,7 +24,6 @@ const fixed = {
     prefectures: 47,
     cities: 1741,
     bytes: 540 * 1024 * 1024,
-    gzipBytes: 60 * 1024 * 1024,
   },
   tiles: { tiles: 12345, points: 1106198, bytes: 250 * 1024 * 1024 },
 };
@@ -35,12 +34,9 @@ assert(md.includes('| 施設レコード数 | 1,495,048 件 |'), '施設レコ�
 assert(md.includes('| 座標を持つ施設 | 1,106,198 件 |'), '座標ありの件数が出る');
 assert(md.includes('| 都道府県 | 47 |'), '都道府県数が出る');
 assert(md.includes('| 市区町村 | 1,741 |'), '市区町村数が出る');
-assert(md.includes('約 540.0 MB（gzip 約 60.0 MB）'), 'CSV サイズが gzip 併記で出る');
+assert(md.includes('| 結合CSV | 約 540.0 MB |'), 'CSV サイズが出る');
+assert(!md.includes('gzip'), 'gzip 表記は出さない（非圧縮CSVのみ配布）');
 assert(md.includes('| ベクトルタイル | 12,345 枚 / 約 250.0 MB |'), 'タイル枚数とサイズが出る');
-
-// gzip が無い場合は併記しない。
-const noGz = renderStats({ ...fixed, csv: { ...fixed.csv, gzipBytes: 0 } });
-assert(!noGz.includes('gzip'), 'gzipBytes が 0 なら gzip 表記を出さない');
 
 // updated が無い場合はダッシュ表記。
 const noDate = renderStats({ ...fixed, updated: 0 });

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -93,14 +93,13 @@ for (const row of readCsvRows(CSV_PATH)) {
   }
 }
 
-// BOM は readCsvRows が除去するため、ヘッダーは列名だけと一致する。
 assert(
   JSON.stringify(header) === JSON.stringify(CSV_COLUMNS),
   `CSV ヘッダーが定義どおり（${CSV_COLUMNS.length}列）`,
 );
 assert(
-  fs.readFileSync(CSV_PATH, { encoding: 'utf-8', start: 0, end: 3 }).startsWith('﻿'),
-  'CSV が UTF-8 BOM 付き（Excel でそのまま開ける）',
+  !fs.readFileSync(CSV_PATH, { encoding: 'utf-8', start: 0, end: 3 }).startsWith('﻿'),
+  'CSV が BOM なし UTF-8',
 );
 assert(rowCount > 0, `CSV にレコードがある (${rowCount.toLocaleString('en-US')}件)`);
 assert(withCoords > 0, `座標を持つレコードがある (${withCoords.toLocaleString('en-US')}件)`);
@@ -109,12 +108,8 @@ for (const [kind, n] of reported) {
   if (n > 3) console.error(`  … ${kind} のエラーは他に ${n - 3} 件`);
 }
 
-// gzip 版も配信するため存在と圧縮を確認する。
-const gzPath = `${CSV_PATH}.gz`;
-assert(fs.existsSync(gzPath), 'api/facilities-all.csv.gz が存在する');
-if (fs.existsSync(gzPath)) {
-  assert(fs.statSync(gzPath).size < fs.statSync(CSV_PATH).size, 'gzip 版が非圧縮版より小さい');
-}
+// 配布は非圧縮CSV のみ。gzip 版が残っていると配信物が二重になるため、無いことを確認する。
+assert(!fs.existsSync(`${CSV_PATH}.gz`), 'api/facilities-all.csv.gz を配信しない');
 
 // --- 2. ベクトルタイル ------------------------------------------------------
 const metaPath = path.join(TILES_DIR, 'metadata.json');


### PR DESCRIPTION
## 背景・解決したい課題

配布物が「gzip圧縮版（推奨）」と「非圧縮版」の2本立てで、さらにCSVがUTF-8 BOM付きだった。

- 配信物が2本あると更新タイミングのズレ・案内先の分岐が生じ、どちらが正なのか利用者に伝わりにくい
- BOM付きはExcelでは便利な一方、pandas/DB取り込み/一般のCSVパーサで先頭列名に `﻿` が混じる事故の原因になる

配布形式を **BOMなしUTF-8のCSV 1本** に統一する。

## 変更内容

- `scripts/build-merged-csv.js`: BOM の書き出しを削除。gzip 生成（`gzip` オプション・`zlib`/`pipeline` 依存・戻り値の `gzipBytes`）も削除
- `scripts/test.js`（配信物バリデーション）: 「BOM付き」検証を「BOMなし」に反転。`.csv.gz` の存在チェックを、逆に**存在しないこと**の検証へ変更
- `scripts/gen-readme-stats.js`: README統計のCSVサイズから gzip 併記を削除
- ドキュメント（`README.md` / `index.html` / `map.html`）: `.csv.gz` へのリンク・`curl`＋`gunzip` 手順・pandas の例・配信形式表を非圧縮CSVに統一し、文字コード表記を「UTF-8（BOMなし）」に修正

## 採用したアプローチと意図

- gzip 版は「作らない」方針にした。ファイルを残したまま案内から消す形だと、gh-pages に古い `.csv.gz` が残り続けて陳腐化データを配ることになるため
- GitHub Pages は転送時に Content-Encoding: gzip を効かせるので、`.csv.gz` を別途置かなくても実回線の転送量は大きく増えない（ブラウザ・curl の圧縮転送で吸収される）
- BOM除去は「一般的なCSVパーサでの素直な読み込み」を優先する判断。トレードオフは下記

## テスト

- ユニットテスト `scripts/build-merged-csv.test.js`
  - 「BOMなしUTF-8でヘッダーを出す」— 先頭3バイトが `EF BB BF` でないこと、1バイト目から `prefecture,` が始まることを検証
  - 「gzip版は生成しない」— `.csv.gz` が作られないこと、統計に `gzipBytes` を含まないことを検証
- ユニットテスト `scripts/gen-readme-stats.test.js`: 統計表に gzip 表記が出ないことを検証
- `npm run test:unit` 全件合格（結合CSV/名寄せ 12件、gen-readme-stats、gen-attribution 他）
- `node scripts/test.js`（配信物バリデーション）はローカルに生成済み `api/` が無いため未実行。クロール後のCI（Validate ステップ）で走る

## 確認してほしいポイント

- **Excel利用者への影響**: BOMなしCSVをExcelでダブルクリックすると文字化けする（インポート時にUTF-8指定が必要）。今回は依頼どおりBOMなしにしているが、Excel向けの案内文をREADMEに一言添えるか否かは判断を仰ぎたい
- **既存の `.csv.gz` の後片付け**: 次回クロールのデプロイ（`peaceiris/actions-gh-pages`、`publish_dir: .`）で gh-pages 上の旧 `api/facilities-all.csv.gz` が消える想定だが、消え残る場合は手動削除が必要
- CSVサイズが実質540MB一本になるため、`curl` 例の記載サイズ（約540MB）が実測とズレていないか
