### PR TITLE
gh-pages 配信を修正（ページが反映されない／api/ が全消えする問題）

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -88,10 +88,13 @@ jobs:
           echo "::warning::README stats の push に失敗（gh-pages への配信は別ステップで実施）"
 
       # 生成した api/ を gh-pages へ配信する（データの唯一の配信先）。
+      # publish_dir が . なので .gitignore も配信対象に含まれてしまう。gh-pages 側では
+      # actions-gh-pages が git add --all するため、api/ を無視する .gitignore が
+      # 配信先に置かれると生成物が一切コミットされない。必ず除外する。
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: .
           publish_branch: gh-pages
-          exclude_assets: 'node_modules,.cache,scripts,.github'
+          exclude_assets: 'node_modules,.cache,scripts,.github,.gitignore'

--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -18,6 +18,11 @@ on:
 permissions:
   contents: write
 
+# gh-pages への push が pages.yml と競合しないよう、配信は常に1本ずつ流す。
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
+
 jobs:
   crawl:
     runs-on: ubuntu-latest

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,44 @@
+name: Deploy Pages
+
+# 静的ページ（LP・プレビュー地図・出典表示）を main への push で gh-pages に反映する。
+# データ（api/）の生成は重いため crawl.yml 側で週次に行う。ここではページだけを
+# 上書きし、既存の api/ には触れない（keep_files: true）。
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'index.html'
+      - 'map.html'
+      - 'attribution.html'
+      - '_headers'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+# crawl.yml の配信ステップと同じグループ。gh-pages への同時 push を避ける。
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # keep_files: true なので gh-pages 上の api/ は残したまま、ページだけ上書きされる。
+      # 反面ファイル削除は反映されないため、リネームや削除の掃除は crawl.yml の
+      # 配信（keep_files: false）に任せる。
+      # .gitignore は api/ を無視するため、配信先に置くと次回以降の api/ 更新が
+      # コミットされなくなる。crawl.yml と同じく除外する。
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: .
+          publish_branch: gh-pages
+          keep_files: true
+          exclude_assets: 'node_modules,.cache,scripts,.github,.gitignore'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "okinawa-facilities-api",
+  "name": "japan-facilities-data",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "okinawa-facilities-api",
+      "name": "japan-facilities-data",
       "dependencies": {
         "@geolonia/normalize-japanese-addresses": "^3.1.3",
         "fflate": "^0.8.3",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build:dry": "node scripts/crawl.js --dry-run",
     "build:attribution": "node scripts/gen-attribution.js",
     "fetch:i2fas": "node scripts/fetch-i2fas.mjs",
-    "test:unit": "node scripts/crawl.test.js && node scripts/lib/config.test.js && node scripts/build-merged-csv.test.js && node scripts/gen-tiles.test.js && node scripts/preview-map.test.js && node scripts/gen-readme-stats.test.js && node scripts/gen-attribution.test.js",
+    "test:unit": "node scripts/crawl.test.js && node scripts/lib/config.test.js && node scripts/build-merged-csv.test.js && node scripts/gen-tiles.test.js && node scripts/preview-map.test.js && node scripts/gen-readme-stats.test.js && node scripts/gen-attribution.test.js && node scripts/workflows.test.js",
     "test": "npm run test:unit && node scripts/test.js"
   },
   "dependencies": {

--- a/scripts/workflows.test.js
+++ b/scripts/workflows.test.js
@@ -1,0 +1,114 @@
+// gh-pages への配信ワークフローの設定を検証する。
+//
+//   node scripts/workflows.test.js
+//
+// 過去に、publish_dir が . のため .gitignore ごと配信され、配信先で git add --all
+// された結果 api/ が一切コミットされず（.gitignore が api/ を無視するため）、
+// gh-pages 上のデータが全削除される事故があった。同じ壊れ方を繰り返さないよう、
+// 配信ステップの設定をテストで固定する。
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as yaml from 'js-yaml';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+let failures = 0;
+/** 条件を検証して結果を出力する（失敗数を数える）。 */
+function assert(cond, msg) {
+  if (cond) {
+    console.log(`  ✓ ${msg}`);
+  } else {
+    console.error(`  ✗ ${msg}`);
+    failures++;
+  }
+}
+
+/** ワークフロー YAML を読む。`on:` は YAML 1.1 では真偽値 true になるため両方見る。 */
+function loadWorkflow(name) {
+  const doc = yaml.load(fs.readFileSync(path.join(ROOT, '.github/workflows', name), 'utf8'));
+  return { ...doc, on: doc.on ?? doc[true] };
+}
+
+/** 全ジョブから actions-gh-pages の配信ステップを集める。 */
+function deploySteps(workflow) {
+  return Object.values(workflow.jobs ?? {})
+    .flatMap((job) => job.steps ?? [])
+    .filter((step) => (step.uses ?? '').startsWith('peaceiris/actions-gh-pages'));
+}
+
+console.log('ワークフロー設定テスト\n');
+
+const crawl = loadWorkflow('crawl.yml');
+const pages = loadWorkflow('pages.yml');
+
+// --- .gitignore が api/ を無視している前提を確認する ---
+// この前提が崩れたら以降の除外チェックの意味も変わるため、最初に固定する。
+const gitignore = fs.readFileSync(path.join(ROOT, '.gitignore'), 'utf8');
+const ignoresApi = gitignore.split('\n').some((line) => line.trim() === 'api/');
+assert(ignoresApi, '.gitignore が api/ を無視している（配信物は Git 管理しない）');
+
+// --- 配信ステップは .gitignore を配信対象から除外する ---
+const allDeploySteps = [
+  ...deploySteps(crawl).map((step) => ['crawl.yml', step]),
+  ...deploySteps(pages).map((step) => ['pages.yml', step]),
+];
+assert(allDeploySteps.length === 2, '配信ステップが crawl.yml と pages.yml に1つずつある');
+
+for (const [file, step] of allDeploySteps) {
+  const withInputs = step.with ?? {};
+  const excluded = String(withInputs.exclude_assets ?? '')
+    .split(',')
+    .map((s) => s.trim());
+  assert(
+    withInputs.publish_branch === 'gh-pages',
+    `${file}: 配信先ブランチが gh-pages である`,
+  );
+  assert(
+    !ignoresApi || withInputs.publish_dir !== '.' || excluded.includes('.gitignore'),
+    `${file}: publish_dir が . のとき .gitignore を除外している（api/ 消失の防止）`,
+  );
+  assert(
+    excluded.includes('node_modules') && excluded.includes('.cache'),
+    `${file}: node_modules と .cache を配信しない`,
+  );
+}
+
+// --- それぞれの役割 ---
+// crawl.yml は生成し直した api/ をまるごと入れ替える（削除も反映する掃除役）。
+// pages.yml はページだけを上書きし、既存の api/ を消さない。
+const crawlDeploy = deploySteps(crawl)[0]?.with ?? {};
+const pagesDeploy = deploySteps(pages)[0]?.with ?? {};
+assert(
+  crawlDeploy.keep_files !== true,
+  'crawl.yml: keep_files を有効にしない（旧生成物を掃除する）',
+);
+assert(
+  pagesDeploy.keep_files === true,
+  'pages.yml: keep_files が true（既存の api/ を消さない）',
+);
+
+// --- gh-pages への同時 push を避ける ---
+assert(
+  crawl.concurrency?.group != null && crawl.concurrency?.group === pages.concurrency?.group,
+  '2つのワークフローが同じ concurrency グループで直列化される',
+);
+
+// --- ページの変更が push で配信される ---
+const pushPaths = pages.on?.push?.paths ?? [];
+assert(pages.on?.push?.branches?.includes('main'), 'pages.yml: main への push で動く');
+for (const page of ['index.html', 'map.html', 'attribution.html']) {
+  assert(pushPaths.includes(page), `pages.yml: ${page} の変更を配信対象にしている`);
+}
+// 配信されるページがリポジトリに実在することも確認する（リネーム時の追従漏れ防止）。
+for (const page of pushPaths.filter((p) => p.endsWith('.html'))) {
+  assert(fs.existsSync(path.join(ROOT, page)), `pages.yml: ${page} がリポジトリに存在する`);
+}
+
+console.log('');
+if (failures > 0) {
+  console.error(`❌ ワークフロー設定テストに ${failures} 件の失敗`);
+  process.exit(1);
+}
+console.log('✅ ワークフロー設定テストに合格');


### PR DESCRIPTION
## 背景・解決したい課題

gh-pages への配信が2重に壊れていて、配信サイトが実質死んでいます。

1. **ページが反映されない** — gh-pages を更新するのは `crawl.yml`（週次 or 手動）だけで、main への push で配信する仕組みがありません。#41 で追加した LP とプレビュー地図は 2026-07-26 にマージ済みですが、最後の配信が 07-24 のため未反映です（`/map.html`・`/attribution.html` は現在 404）。
2. **データが全消えしている** — 07-24 の配信で `api/` 以下 1,896 万行が削除されました。`/api/facilities-all.csv.gz` も `/api/tiles/metadata.json` も 404 で、README が案内している配信 URL がすべて死んでいます。

②の原因は `.gitignore` です。`publish_dir: .` なのでリポジトリ直下の `.gitignore` も gh-pages へコピーされ、actions-gh-pages が配信先で `git add --all` した際に `api/`（`.gitignore` に記載）が add されません。そこへ `keep_files: false` の掃除が効くため、既存の配信物だけが消えて何も入らない状態になっていました。皮肉にも「生成物はコミットしない（CIで生成し gh-pages へ配信）」というコメント付きの行が配信を止めていました。

## 変更内容

- `crawl.yml` — `exclude_assets` に `.gitignore` を追加（②の修正）
- `pages.yml`（新規）— main への push で静的ページを配信。`keep_files: true` で既存の `api/` に触れない（①の修正）
- 2つのワークフローを同じ `concurrency` グループに入れ、gh-pages への同時 push を直列化
- `scripts/workflows.test.js`（新規）— 配信設定の回帰テスト
- `package-lock.json` — `npm install` でリポジトリ名の追従漏れ（`okinawa-facilities-api`）が自動修正されたもの。本 PR とは無関係ですが放置すると毎回差分が出るため同梱

## 採用したアプローチと意図

**役割を2本に分ける**構成にしました。

| | crawl.yml | pages.yml |
|---|---|---|
| 契機 | 週次 / 手動 | main への push |
| 対象 | データ再生成＋全体入れ替え | 静的ページのみ |
| keep_files | false（掃除役） | true（`api/` を消さない） |

- **代替案: crawl.yml を push でも動かす** — ページの1行修正のたびに全国クロール（約36分）が走るので却下
- **代替案: pages.yml も keep_files: false** — `api/` を消してしまうため不可
- `keep_files: true` の副作用として、ページを削除・リネームしても gh-pages に古いファイルが残ります。その掃除は `keep_files: false` の crawl.yml 側に任せる想定です（コメントに明記）

`exclude_assets` が `.gitignore` を確実に消せるかは、pin されている SHA（`84c30a8`）の `deleteExcludedAssets` を読んで確認済みです。

## テスト

- ユニットテスト `scripts/workflows.test.js` を追加（`npm run test:unit` に組み込み、18 チェック）
  - `.gitignore` が `api/` を無視している前提の固定
  - `publish_dir: .` の配信ステップすべてで `.gitignore` を除外していること（②の回帰防止）
  - crawl は `keep_files: false` / pages は `keep_files: true` という役割分担
  - 2つのワークフローが同じ concurrency グループであること
  - pages.yml の paths に各ページが入っていて、かつそのファイルが実在すること（リネーム時の追従漏れ防止）
- `exclude_assets` から `.gitignore` を外した状態でテストが落ちることを確認（テストが実際に効くことの検証）
- `npm run test:unit` 全体が合格

`npm test` に含まれる `scripts/test.js` は生成済みの `api/` を検証するものでローカルでは実行不可です（CI ではクロール後に走ります）。

## 確認してほしいポイント

- **マージ後の手順** — この PR は `.github/workflows/pages.yml` を含むので、マージ時点で pages.yml が発火し LP・地図・出典ページが反映されます。ただし `api/` の復旧にはクロールの手動実行が別途必要です。マージ後に `Crawl Facilities` を workflow_dispatch してください（こちらで実行する場合は指示ください）。
- `concurrency` を crawl.yml 全体にかけているため、クロール実行中（約36分）に main へ push するとページ配信がその分待たされます。正しさを優先しましたが、気になるようなら分離も可能です。
