### PR TITLE
ベクトルタイルの点数が結合CSVと食い違う問題を修正（クロールが配信前に失敗する）

### DIFF
--- a/scripts/build-merged-csv.js
+++ b/scripts/build-merged-csv.js
@@ -55,7 +55,12 @@ function write(stream, chunk) {
 
 /**
  * 結合CSV（と gzip 版）を書き出す。
- * 統計 `{ rowsIn, rowsOut, dupSkipped, prefectures, cities, bytes, gzipBytes }` を返す。
+ * 統計 `{ rowsIn, rowsOut, dupSkipped, prefectures, cities, bytes, gzipBytes }` と、
+ * 重複を除いたあとの施設 `unique` を返す。
+ *
+ * `unique` はベクトルタイルの生成にも使う。重複判定はここでしか行わないため、
+ * これを渡さずに元の配列からタイルを作ると、CSV には無い重複点がタイルに載り、
+ * metadata.json の records（CSV基準）と points（タイル基準）がズレる。
  */
 export async function buildMergedCsv(facilities, { outPath, gzip = true, log = console.log } = {}) {
   fs.mkdirSync(path.dirname(outPath), { recursive: true });
@@ -70,6 +75,7 @@ export async function buildMergedCsv(facilities, { outPath, gzip = true, log = c
   const seen = new Set(); // 出典を除く全列一致の重複判定
   const prefs = new Set();
   const cities = new Set();
+  const unique = []; // CSV に書いた施設（＝タイルに載せる施設）
 
   for (const f of facilities) {
     rowsIn++;
@@ -86,6 +92,7 @@ export async function buildMergedCsv(facilities, { outPath, gzip = true, log = c
     const backpressure = write(out, row.map(csvCell).join(',') + '\n');
     if (backpressure) await backpressure;
     rowsOut++;
+    unique.push(f);
     prefs.add(f.pref);
     cities.add(`${f.pref}/${f.city}`);
   }
@@ -125,5 +132,6 @@ export async function buildMergedCsv(facilities, { outPath, gzip = true, log = c
     cities: cities.size,
     bytes,
     gzipBytes,
+    unique,
   };
 }

--- a/scripts/build-merged-csv.test.js
+++ b/scripts/build-merged-csv.test.js
@@ -10,6 +10,7 @@ import os from 'node:os';
 import path from 'node:path';
 import zlib from 'node:zlib';
 import { buildMergedCsv, CSV_COLUMNS, csvCell } from './build-merged-csv.js';
+import { generateTiles } from './gen-tiles.js';
 import { readCsvRows } from './lib/csv-read.js';
 import { resolvePrefCity, applyPrefCity, collectCityPairs } from './lib/city-normmap.js';
 
@@ -113,6 +114,47 @@ await test('CSV: 出典を除く全列一致の重複を1行に寄せる', async
   }
 });
 
+// ベクトルタイルは stats.unique から作る。ここが CSV に書いた集合と食い違うと、
+// metadata.json の records（CSV基準）と points（タイル基準）がズレて配信物の
+// バリデーションが落ちる。
+await test('CSV: unique が実際に書き出した施設と一致する', async () => {
+  const kept = fac();
+  const other = fac({ business_type: '喫茶店営業' });
+  const { dir, rows, stats } = await writeCsv([
+    kept,
+    fac(), // 完全重複
+    fac({ _source: '別ソース' }), // 出典だけ違う＝同じ施設
+    other,
+  ]);
+  try {
+    assert.equal(stats.unique.length, stats.rowsOut, 'unique の件数が CSV 行数と一致する');
+    assert.equal(stats.unique.length, rows.length);
+    assert.deepEqual(
+      stats.unique.map((f) => f.business_type),
+      [kept.business_type, other.business_type],
+      '重複は除かれ、最初に出会った施設が残る',
+    );
+    assert.equal(stats.unique[0], kept, '施設オブジェクトの参照をそのまま返す');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+await test('CSV: 座標つきの重複は unique から落ちる（タイルの点数が CSV と揃う）', async () => {
+  const { dir, stats } = await writeCsv([
+    fac(),
+    fac(), // 座標を持つ完全重複
+    fac({ name: '店B', lat: null, lng: null }),
+  ]);
+  try {
+    const withCoords = stats.unique.filter((f) => f.lat != null && f.lng != null).length;
+    assert.equal(stats.dupSkipped, 1);
+    assert.equal(withCoords, 1, '重複を数え上げず、座標ありは1件');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 await test('CSV: 都道府県・市区町村の異なり数を数える', async () => {
   const { dir, stats } = await writeCsv([
     fac(),
@@ -184,6 +226,50 @@ await test('collectCityPairs: ユニークな (都道府県, 市区町村) を�
   assert.equal(pairs.length, 3);
   assert.equal(pairs.find((p) => p.city === '港区').addr, '東京都港区赤坂1-1', '空でない住所を代表にする');
   assert.ok(pairs.some((p) => p.pref === '不明' && p.city === '不明'));
+});
+
+// --- 配信物どうしの整合 ---
+// scripts/test.js が本番データで確認している不変条件を、小さなフィクスチャで先に潰す。
+// 実際に metadata.stats.points（タイル基準）と CSV の座標あり件数がズレて
+// クロールが失敗したことがある（タイルだけ重複除去前の配列から作っていた）。
+await test('配信物: metadata.stats が CSV の件数と一致する', async () => {
+  const { dir, outPath, stats, rows } = await writeCsv(
+    [
+      fac(),
+      fac(), // 座標つきの完全重複
+      fac({ name: '店B' }),
+      fac({ name: '店C', lat: null, lng: null }), // 座標なし
+    ],
+    { gzip: false },
+  );
+  try {
+    const outDir = path.join(path.dirname(outPath), 'tiles');
+    generateTiles(stats.unique, { minZoom: 12, maxZoom: 12, outDir, stats, log: () => {} });
+    const meta = JSON.parse(fs.readFileSync(path.join(outDir, 'metadata.json'), 'utf-8'));
+
+    const withCoords = rows.filter((r) => r[col.lat] !== '' && r[col.lng] !== '').length;
+    assert.equal(meta.stats.records, rows.length, 'records が CSV 行数と一致する');
+    assert.equal(meta.stats.points, withCoords, 'points が CSV の座標あり件数と一致する');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+await test('配信物: 重複除去前の配列からタイルを作ろうとすると止まる', async () => {
+  const facilities = [fac(), fac()];
+  const { dir, outPath, stats } = await writeCsv(facilities, { gzip: false });
+  try {
+    assert.throws(
+      () => generateTiles(facilities, {
+        outDir: path.join(path.dirname(outPath), 'tiles'),
+        stats,
+        log: () => {},
+      }),
+      /stats\.unique/,
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 console.log(`\n✅ 結合CSV / 名寄せ テスト: ${passed}件すべて合格`);

--- a/scripts/crawl.js
+++ b/scripts/crawl.js
@@ -141,7 +141,9 @@ async function main() {
 
   const updated = Math.floor(Date.now() / 1000);
   const csv = await buildMergedCsv(facilities, { outPath: CSV_PATH });
-  const tiles = generateTiles(facilities, { updated, stats: csv });
+  // タイルは CSV と同じ集合（重複除去後）から作る。元の facilities を渡すと
+  // CSV に載らない重複点がタイルに入り、配信物どうしで件数が食い違う。
+  const tiles = generateTiles(csv.unique, { updated, stats: csv });
   generateReadmeStats({ updated, csv, tiles });
 
   console.log(

--- a/scripts/gen-tiles.js
+++ b/scripts/gen-tiles.js
@@ -76,6 +76,13 @@ export function generateTiles(facilities, {
   stats = null,
   log = console.log,
 } = {}) {
+  // metadata.json には CSV 側で数えた records と、ここで数える points が並ぶ。
+  // 別々の集合から数えると両者が食い違い、配信物バリデーションで落ちる。
+  // 重複除去後の施設（stats.unique）を渡し忘れた場合はここで止める。
+  if (stats?.unique && stats.unique !== facilities) {
+    throw new Error('ベクトルタイルは結合CSV と同じ施設集合（stats.unique）から生成すること');
+  }
+
   const fc = buildFeatureCollection(facilities);
   if (fc.features.length === 0) {
     console.warn('  座標を持つ施設が無いため ベクトルタイルの生成をスキップ');


### PR DESCRIPTION
## 背景・解決したい課題

#46 で配信の仕組みを直したあと、`api/` を復旧するためクロールを手動実行したところ（[run 30236023734](https://github.com/gl20percentclub/japan-facilities-api/actions/runs/30236023734)）、`Validate` で落ちて配信ステップがスキップされました。データはまだ復旧できていません。

```
✓ 座標を持つレコードがある (1,352,258件)
✓ metadata.stats.records(1481282) が CSV 行数と一致
✗ metadata.stats.points(1357347) が座標ありレコード数と一致
```

原因は **重複除去が結合CSV にしか効いていない** ことです。

- `buildMergedCsv` が「出典を除く全列一致」で重複を落とす（今回 5,089 件が座標つき重複）
- `generateTiles` には**除去前の** `facilities` をそのまま渡していた
- 結果、`metadata.json` の `records` は CSV 基準（除去後）、`points` はタイル基準（除去前）になり、同じファイルの中で数え方が食い違っていた

配信物の不整合であると同時に、**タイルにも CSV に無い重複点が焼かれていた**（地図上でマーカーが重なる）ので、バリデーションの指摘は正当です。#43 でこの配信形式に切り替えて以降、初めての実クロールで露呈しました。

## 変更内容

- `buildMergedCsv` が実際に書き出した施設を `unique` として返す
- `crawl.js` — タイル生成に `csv.unique` を渡す
- `generateTiles` — `stats.unique` と渡された配列が別物なら例外で止める（渡し忘れの再発防止）

## 採用したアプローチと意図

**重複判定の置き場所は1箇所のままにする**方針です。

- **代替案: gen-tiles 側にも同じ重複判定を実装** — 判定キー（`DEDUP_INDEXES`）が二重管理になり、片方だけ変わると静かにズレるので却下
- **代替案: バリデーションを緩める** — タイルに重複点が載っている事実は変わらないので却下

`unique` は施設オブジェクトへの参照配列なので、追加のメモリは 1.5M 件でも十数MB程度です（実体は既存の `facilities` と共有）。

`generateTiles` の例外は保険です。ここが崩れると症状が「10分後のバリデーション失敗」という遠い場所に出てしまうため、渡した時点で落とします。

## テスト

`scripts/build-merged-csv.test.js` に3件追加（`npm run test:unit` は全 8 スイート合格）:

- `unique` が CSV に書き出した施設と一致する（件数・順序・オブジェクト参照）
- 座標つきの重複が `unique` から落ちる
- 結合CSV → タイル生成を通し、`metadata.stats` の `records` / `points` が CSV と一致する（本番で落ちた不変条件をフィクスチャで再現）
- 除去前の配列を `generateTiles` に渡すと例外になる

## 確認してほしいポイント

- マージ後にクロールを再実行して `api/` を復旧する必要があります（こちらで実行する場合は指示ください）。
- `generateTiles` の同一性チェックを参照比較（`!==`）にしています。呼び出し側が `unique` を加工して渡すユースケースが将来出ると引っかかりますが、現状その使い方は無く、渡し忘れを確実に捕まえる方を優先しました。
