### PR TITLE
リポジトリ名を japan-food-facilities-api に変更（参照・表記の一括更新）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 <div align="center">
 
-# 🍽️ Japan Facilities Data
+# 🍽️ Japan Food Facilities Data
 
 **全国の食品営業許可・届出データを、共通形式で無料配信するオープンデータプロジェクト**
 
-[![Contributors](https://img.shields.io/github/contributors/gl20percentclub/japan-facilities-api)](https://github.com/gl20percentclub/japan-facilities-api/graphs/contributors)
+[![Contributors](https://img.shields.io/github/contributors/gl20percentclub/japan-food-facilities-api)](https://github.com/gl20percentclub/japan-food-facilities-api/graphs/contributors)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![GitHub Issues](https://img.shields.io/github/issues/gl20percentclub/japan-facilities-api)](https://github.com/gl20percentclub/japan-facilities-api/issues)
+[![GitHub Issues](https://img.shields.io/github/issues/gl20percentclub/japan-food-facilities-api)](https://github.com/gl20percentclub/japan-food-facilities-api/issues)
 [![Weekly Crawl](https://img.shields.io/badge/更新-毎週自動-blue)](#更新頻度)
 
-[公式サイト](https://gl20percentclub.github.io/japan-facilities-api/) ·
-[地図で見る](https://gl20percentclub.github.io/japan-facilities-api/map.html) ·
-[CSVをダウンロード](https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv) ·
+[公式サイト](https://gl20percentclub.github.io/japan-food-facilities-api/) ·
+[地図で見る](https://gl20percentclub.github.io/japan-food-facilities-api/map.html) ·
+[CSVをダウンロード](https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv) ·
 [収録状況](docs/COVERAGE.md) ·
-[出典・ライセンス](https://gl20percentclub.github.io/japan-facilities-api/attribution.html)
+[出典・ライセンス](https://gl20percentclub.github.io/japan-food-facilities-api/attribution.html)
 
 </div>
 
@@ -49,20 +49,20 @@
 
 | ファイル | URL |
 |---|---|
-| 全件CSV | https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv |
+| 全件CSV | https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv |
 
 - 文字コード: UTF-8（BOMなし）
 - 全列が一致する重複レコードは除去済み
 
 ```bash
-curl -O https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv
+curl -O https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv
 ```
 
 ```python
 import pandas as pd
 
 df = pd.read_csv(
-    "https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv"
+    "https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv"
 )
 ```
 
@@ -76,7 +76,7 @@ df = pd.read_csv(
 map.addSource("facilities", {
   type: "vector",
   tiles: [
-    "https://gl20percentclub.github.io/japan-facilities-api/api/tiles/{z}/{x}/{y}.pbf",
+    "https://gl20percentclub.github.io/japan-food-facilities-api/api/tiles/{z}/{x}/{y}.pbf",
   ],
   minzoom: 6,
   maxzoom: 12,
@@ -85,9 +85,9 @@ map.addSource("facilities", {
 
 - レイヤー名: `facilities`
 - 主な属性: `name` / `business_type` / `pref` / `city`
-- 詳細: [`api/tiles/metadata.json`](https://gl20percentclub.github.io/japan-facilities-api/api/tiles/metadata.json)
+- 詳細: [`api/tiles/metadata.json`](https://gl20percentclub.github.io/japan-food-facilities-api/api/tiles/metadata.json)
 
-収録データは[プレビュー地図](https://gl20percentclub.github.io/japan-facilities-api/map.html)でも確認できます。
+収録データは[プレビュー地図](https://gl20percentclub.github.io/japan-food-facilities-api/map.html)でも確認できます。
 
 ## データ項目
 
@@ -166,8 +166,8 @@ GitHub Actionsで毎週月曜18:00 UTC（日本時間 火曜3:00）に更新し�
 
 ```html
 出典:
-<a href="https://github.com/gl20percentclub/japan-facilities-api">
-  Japan Facilities Data
+<a href="https://github.com/gl20percentclub/japan-food-facilities-api">
+  Japan Food Facilities Data
 </a>
 （各自治体の食品営業許可オープンデータを加工して作成）
 ```
@@ -175,12 +175,12 @@ GitHub Actionsで毎週月曜18:00 UTC（日本時間 火曜3:00）に更新し�
 地図上では、次のように表示できます。
 
 ```text
-© Japan Facilities Data（各自治体オープンデータ）
+© Japan Food Facilities Data（各自治体オープンデータ）
 ```
 
 特定自治体のデータだけを利用する場合は、CSVの `sources` 列に記載された自治体名も併記してください。
 
-自治体ごとの出典表示文は、[出典・ライセンス表示ページ](https://gl20percentclub.github.io/japan-facilities-api/attribution.html)で確認できます。
+自治体ごとの出典表示文は、[出典・ライセンス表示ページ](https://gl20percentclub.github.io/japan-food-facilities-api/attribution.html)で確認できます。
 
 ## 免責事項
 

--- a/attribution.html
+++ b/attribution.html
@@ -7,8 +7,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>出典・ライセンス表示 — Japan Facilities API</title>
-  <meta name="description" content="Japan Facilities API が収録する全データソースの出典URL・ライセンスと、各データの出典表示形式に沿った表示文の一覧です。">
+  <title>出典・ライセンス表示 — Japan Food Facilities API</title>
+  <meta name="description" content="Japan Food Facilities API が収録する全データソースの出典URL・ライセンスと、各データの出典表示形式に沿った表示文の一覧です。">
   <style>
     :root {
       --accent: #e8563f;
@@ -136,7 +136,7 @@
   <div class="wrap">
     <h1>出典・ライセンス表示（Attribution）</h1>
     <p class="lead">
-      <a href="https://gl20percentclub.github.io/japan-facilities-api/">Japan Facilities API</a> は、各自治体・省庁が公開する食品営業許可・届出のオープンデータを
+      <a href="https://gl20percentclub.github.io/japan-food-facilities-api/">Japan Food Facilities API</a> は、各自治体・省庁が公開する食品営業許可・届出のオープンデータを
       取得し、全国共通フォーマットへの正規化と緯度経度の付与を行って配信しています。
       本ページは収録している全 98 ソースの出典 URL とライセンス、および
       各データが求める出典表示形式に沿った表示文の一覧です。
@@ -149,7 +149,7 @@
     </p>
     <p>全国データをまとめて利用する場合は、次の一括表記でも構いません（個別ソースの一覧として本ページを参照させてください）。</p>
     <div class="callout">
-      <code>出典：Japan Facilities API（各自治体・厚生労働省が公開する食品営業許可オープンデータを加工して作成）<br>https://gl20percentclub.github.io/japan-facilities-api/attribution.html</code>
+      <code>出典：Japan Food Facilities API（各自治体・厚生労働省が公開する食品営業許可オープンデータを加工して作成）<br>https://gl20percentclub.github.io/japan-food-facilities-api/attribution.html</code>
     </div>
     <p class="lead" style="margin-top:12px">
       緯度経度は本サービスが住所からジオコーディングして独自に付与した参考情報であり、各自治体が提供しているものではありません。
@@ -1577,13 +1577,13 @@
 
     <footer>
       <p>
-        このページは <a href="https://github.com/gl20percentclub/japan-facilities-api/blob/main/config/sources.yaml">config/sources.yaml</a> から
-        <a href="https://github.com/gl20percentclub/japan-facilities-api/blob/main/scripts/gen-attribution.js">scripts/gen-attribution.js</a> が自動生成しています。
-        誤りを見つけた場合は <a href="https://github.com/gl20percentclub/japan-facilities-api/issues">Issue</a> でお知らせください。
+        このページは <a href="https://github.com/gl20percentclub/japan-food-facilities-api/blob/main/config/sources.yaml">config/sources.yaml</a> から
+        <a href="https://github.com/gl20percentclub/japan-food-facilities-api/blob/main/scripts/gen-attribution.js">scripts/gen-attribution.js</a> が自動生成しています。
+        誤りを見つけた場合は <a href="https://github.com/gl20percentclub/japan-food-facilities-api/issues">Issue</a> でお知らせください。
       </p>
       <p>
         <a href="./">← トップへ戻る</a> · <a href="./map.html">プレビュー地図</a> ·
-        <a href="https://github.com/gl20percentclub/japan-facilities-api">GitHub リポジトリ</a>
+        <a href="https://github.com/gl20percentclub/japan-food-facilities-api">GitHub リポジトリ</a>
       </p>
     </footer>
   </div>

--- a/index.html
+++ b/index.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Japan Facilities API — 日本全国の飲食施設オープンデータを無料の静的 API で</title>
+  <title>Japan Food Facilities API — 日本全国の飲食施設オープンデータを無料の静的 API で</title>
   <meta name="description" content="全国の自治体が公開する食品営業許可・届出のオープンデータを、正規化・ジオコーディングして無料で配信。登録不要・API キー不要で、全件 CSV とベクトルタイルをそのまま利用できます。">
 
   <!-- SNS シェア時のカード表示（画像は用意していないためテキストのみ） -->
   <meta property="og:type" content="website">
-  <meta property="og:title" content="Japan Facilities API">
+  <meta property="og:title" content="Japan Food Facilities API">
   <meta property="og:description" content="日本全国の飲食施設オープンデータ（食品営業許可・届出）を、登録不要・無料の静的 API として配信。">
-  <meta property="og:url" content="https://gl20percentclub.github.io/japan-facilities-api/">
+  <meta property="og:url" content="https://gl20percentclub.github.io/japan-food-facilities-api/">
   <meta name="twitter:card" content="summary">
 
   <style>
@@ -173,7 +173,7 @@
       <div class="cta">
         <a class="btn primary" href="#quickstart">クイックスタート</a>
         <a class="btn ghost" href="./map.html">地図で見てみる</a>
-        <a class="btn ghost" href="https://github.com/gl20percentclub/japan-facilities-api">GitHub</a>
+        <a class="btn ghost" href="https://github.com/gl20percentclub/japan-food-facilities-api">GitHub</a>
       </div>
 
       <!-- 統計は配信中の api/ から読み込んで更新する（取得できなければ下の既定値のまま） -->
@@ -234,16 +234,16 @@
       <h2>クイックスタート</h2>
       <p class="lead">
         配信しているのは <strong>全件CSV</strong> と <strong>ベクトルタイル</strong> の2つだけです。
-        ベース URL は <code>https://gl20percentclub.github.io/japan-facilities-api/api/</code>。
+        ベース URL は <code>https://gl20percentclub.github.io/japan-food-facilities-api/api/</code>。
       </p>
 
       <p class="step">1. 全件CSV をダウンロードする（約 540MB）</p>
-<pre><code>curl -O https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv</code></pre>
+<pre><code>curl -O https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv</code></pre>
 
       <p class="step">2. pandas で読み込む（URL 直指定でもいけます）</p>
 <pre><code>import pandas as pd
 
-df = pd.read_csv('https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv')
+df = pd.read_csv('https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv')
 <span class="c"># 那覇市の飲食店営業だけ抜き出す</span>
 naha = df[(df.city == '那覇市') &amp; (df.business_type == '飲食店営業')]
 print(naha[['name', 'address', 'lat', 'lng']].head())</code></pre>
@@ -251,7 +251,7 @@ print(naha[['name', 'address', 'lat', 'lng']].head())</code></pre>
       <p class="step">3. 地図に出す（MapLibre GL JS・タイルサーバー不要）</p>
 <pre><code>map.addSource('facilities', {
   type: 'vector',
-  tiles: ['https://gl20percentclub.github.io/japan-facilities-api/api/tiles/{z}/{x}/{y}.pbf'],
+  tiles: ['https://gl20percentclub.github.io/japan-food-facilities-api/api/tiles/{z}/{x}/{y}.pbf'],
   minzoom: 6, maxzoom: 12,
 });
 <span class="c">// レイヤ名は "facilities"、属性は name / business_type / pref / city</span></code></pre>
@@ -292,8 +292,8 @@ print(naha[['name', 'address', 'lat', 'lng']].head())</code></pre>
       </div>
       <p class="lead" style="margin:20px 0 0">
         地域や業種を絞りたい場合は、CSV をダウンロードしてフィルタしてください。
-        各列の詳細は <a href="https://github.com/gl20percentclub/japan-facilities-api#どんなデータか">README</a>、
-        自治体ごとの収録状況は <a href="https://github.com/gl20percentclub/japan-facilities-api/blob/main/docs/COVERAGE.md">収録状況一覧</a> を参照してください。
+        各列の詳細は <a href="https://github.com/gl20percentclub/japan-food-facilities-api#どんなデータか">README</a>、
+        自治体ごとの収録状況は <a href="https://github.com/gl20percentclub/japan-food-facilities-api/blob/main/docs/COVERAGE.md">収録状況一覧</a> を参照してください。
       </p>
     </div>
   </section>
@@ -330,8 +330,8 @@ print(naha[['name', 'address', 'lat', 'lng']].head())</code></pre>
         バグ報告・データ品質の問題報告・ドキュメント改善も歓迎です。
       </p>
       <div class="cta" style="justify-content:flex-start">
-        <a class="btn primary" href="https://github.com/gl20percentclub/japan-facilities-api#-コントリビューション">コントリビュート方法</a>
-        <a class="btn ghost" href="https://github.com/gl20percentclub/japan-facilities-api/issues/new">Issue を立てる</a>
+        <a class="btn primary" href="https://github.com/gl20percentclub/japan-food-facilities-api#-コントリビューション">コントリビュート方法</a>
+        <a class="btn ghost" href="https://github.com/gl20percentclub/japan-food-facilities-api/issues/new">Issue を立てる</a>
       </div>
     </div>
   </section>
@@ -341,10 +341,10 @@ print(naha[['name', 'address', 'lat', 'lng']].head())</code></pre>
       <p>
         <a href="./map.html">プレビュー地図</a> ·
         <a href="./attribution.html">出典・ライセンス</a> ·
-        <a href="https://github.com/gl20percentclub/japan-facilities-api">GitHub</a> ·
-        <a href="https://github.com/gl20percentclub/japan-facilities-api/issues">Issues</a>
+        <a href="https://github.com/gl20percentclub/japan-food-facilities-api">GitHub</a> ·
+        <a href="https://github.com/gl20percentclub/japan-food-facilities-api/issues">Issues</a>
       </p>
-      <p>各自治体が公開するオープンデータを加工して作成 — Japan Facilities API</p>
+      <p>各自治体が公開するオープンデータを加工して作成 — Japan Food Facilities API</p>
     </div>
   </footer>
 

--- a/map.html
+++ b/map.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>🍽️ Japan Facilities API — データプレビュー地図</title>
+  <title>🍽️ Japan Food Facilities API — データプレビュー地図</title>
   <meta name="description" content="日本全国の飲食施設オープンデータ（食品営業許可・届出）を地図上でプレビューできます。">
 
   <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css">
@@ -118,7 +118,7 @@
   <div id="map"></div>
 
   <div class="panel">
-    <h1>🍽️ Japan Facilities API</h1>
+    <h1>🍽️ Japan Food Facilities API</h1>
     <p class="sub">日本全国の飲食施設オープンデータ（食品営業許可・届出）のプレビュー地図です。</p>
     <div class="stats">
       <div class="stat"><span class="num" id="stat-pref">–</span><span class="lbl">都道府県</span></div>
@@ -129,8 +129,8 @@
       <span class="legend-dot"></span>各点＝1施設
       <span id="updated"></span><br>
       <a href="./">トップ</a> ·
-      <a href="https://github.com/gl20percentclub/japan-facilities-api">GitHub リポジトリ</a> ·
-      <a href="https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv">全件CSV</a> ·
+      <a href="https://github.com/gl20percentclub/japan-food-facilities-api">GitHub リポジトリ</a> ·
+      <a href="https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv">全件CSV</a> ·
       <a href="./attribution.html">出典・ライセンス</a>
     </p>
   </div>
@@ -170,7 +170,7 @@
             maxzoom: TILE_MAX_ZOOM,
             bounds: JAPAN_BOUNDS,
             attribution:
-              '施設データ: <a href="https://github.com/gl20percentclub/japan-facilities-api" target="_blank" rel="noopener">Japan Facilities API</a>'
+              '施設データ: <a href="https://github.com/gl20percentclub/japan-food-facilities-api" target="_blank" rel="noopener">Japan Food Facilities API</a>'
               + '（<a href="./attribution.html">各自治体オープンデータの出典一覧</a>）',
           },
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "japan-facilities-data",
+  "name": "japan-food-facilities-data",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "japan-facilities-data",
+      "name": "japan-food-facilities-data",
       "dependencies": {
         "@geolonia/normalize-japanese-addresses": "^3.1.3",
         "fflate": "^0.8.3",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "japan-facilities-data",
+  "name": "japan-food-facilities-data",
   "type": "module",
   "scripts": {
     "build": "node scripts/crawl.js",

--- a/scripts/gen-attribution.js
+++ b/scripts/gen-attribution.js
@@ -23,9 +23,9 @@ import { loadConfig, ROOT } from './lib/config.js';
 export const OUTPUT_PATH = path.join(ROOT, 'attribution.html');
 
 /** 公開サイトの URL（一括表記の例で使う）。 */
-const SITE_URL = 'https://gl20percentclub.github.io/japan-facilities-api/';
+const SITE_URL = 'https://gl20percentclub.github.io/japan-food-facilities-api/';
 /** リポジトリ URL（ページ内リンクで使う）。 */
-const REPO_URL = 'https://github.com/gl20percentclub/japan-facilities-api';
+const REPO_URL = 'https://github.com/gl20percentclub/japan-food-facilities-api';
 
 /** 都道府県名（`source` の先頭から提供者を推定する際に使う）。 */
 const PREFECTURES = [
@@ -341,8 +341,8 @@ export function renderHtml(entries) {
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>出典・ライセンス表示 — Japan Facilities API</title>
-  <meta name="description" content="Japan Facilities API が収録する全データソースの出典URL・ライセンスと、各データの出典表示形式に沿った表示文の一覧です。">
+  <title>出典・ライセンス表示 — Japan Food Facilities API</title>
+  <meta name="description" content="Japan Food Facilities API が収録する全データソースの出典URL・ライセンスと、各データの出典表示形式に沿った表示文の一覧です。">
   <style>
     :root {
       --accent: #e8563f;
@@ -470,7 +470,7 @@ export function renderHtml(entries) {
   <div class="wrap">
     <h1>出典・ライセンス表示（Attribution）</h1>
     <p class="lead">
-      <a href="${SITE_URL}">Japan Facilities API</a> は、各自治体・省庁が公開する食品営業許可・届出のオープンデータを
+      <a href="${SITE_URL}">Japan Food Facilities API</a> は、各自治体・省庁が公開する食品営業許可・届出のオープンデータを
       取得し、全国共通フォーマットへの正規化と緯度経度の付与を行って配信しています。
       本ページは収録している全 ${entries.length} ソースの出典 URL とライセンス、および
       各データが求める出典表示形式に沿った表示文の一覧です。
@@ -483,7 +483,7 @@ export function renderHtml(entries) {
     </p>
     <p>全国データをまとめて利用する場合は、次の一括表記でも構いません（個別ソースの一覧として本ページを参照させてください）。</p>
     <div class="callout">
-      <code>出典：Japan Facilities API（各自治体・厚生労働省が公開する食品営業許可オープンデータを加工して作成）<br>${SITE_URL}attribution.html</code>
+      <code>出典：Japan Food Facilities API（各自治体・厚生労働省が公開する食品営業許可オープンデータを加工して作成）<br>${SITE_URL}attribution.html</code>
     </div>
     <p class="lead" style="margin-top:12px">
       緯度経度は本サービスが住所からジオコーディングして独自に付与した参考情報であり、各自治体が提供しているものではありません。

--- a/scripts/lib/acquire.js
+++ b/scripts/lib/acquire.js
@@ -9,7 +9,7 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 // bot 対策で User-Agent 等を求めるサーバがあるため、常識的なヘッダを付ける。
 const DEFAULT_HEADERS = {
-  'User-Agent': 'Mozilla/5.0 (compatible; japan-facilities-api/1.0; +https://github.com/gl20percentclub/japan-facilities-api)',
+  'User-Agent': 'Mozilla/5.0 (compatible; japan-food-facilities-api/1.0; +https://github.com/gl20percentclub/japan-food-facilities-api)',
   'Accept-Language': 'ja,en;q=0.8',
   Accept: '*/*',
 };


### PR DESCRIPTION
## 概要
- リポジトリ名を `japan-facilities-api` から `japan-food-facilities-api` に変更するのに伴い、リポジトリ内の URL・表示名・パッケージ名を一括更新する
- ⚠️ **GitHub 上のリポジトリ名変更（Settings → Rename）は別途手動で実施が必要**（このPRのマージと同時に行うこと）

## 変更内容
- GitHub / GitHub Pages の URL: `japan-facilities-api` → `japan-food-facilities-api`（README.md, index.html, map.html, attribution.html, scripts/gen-attribution.js, scripts/lib/acquire.js）
- サイト・ドキュメントの表示名: `Japan Facilities API` → `Japan Food Facilities API`、`Japan Facilities Data` → `Japan Food Facilities Data`
- パッケージ名: `japan-facilities-data` → `japan-food-facilities-data`（package.json / package-lock.json）
- attribution.html は `npm run build:attribution`（scripts/gen-attribution.js）で再生成

## テスト計画
- `npm run test:unit` 全119件パスを確認済み
- 旧名称（`japan-facilities-api` / `Japan Facilities`）の残存が無いことを grep で確認済み
- マージ後: Pages デプロイ後に `https://gl20percentclub.github.io/japan-food-facilities-api/` で表示・リンクを確認

## 破壊的変更
- リポジトリ名変更後、旧 GitHub Pages URL（`…/japan-facilities-api/…` の CSV・タイル等）は 404 になる（GitHub Pages はリダイレクトされないため）。既存利用者への周知が必要
- git リモート URL・リポジトリ URL は GitHub のリダイレクトにより旧名でも当面アクセス可能

## 関連Issue
なし