### PR TITLE
feat: AIエージェント向け llms.txt / llms-full.txt を配信する

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -72,17 +72,17 @@ jobs:
       - name: Validate
         run: npm test
 
-      # README の統計（件数・サイズ）と出典表示ページだけを main に反映する。
+      # README の統計（件数・サイズ）・出典表示ページ・llms.txt だけを main に反映する。
       # 生成物 api/ は Git 管理せず（.gitignore）、配信は gh-pages のみで行う（履歴肥大を避けるため）。
       # クロール中に他の push で main が進むことがあるため、rebase してリトライする。
       - name: Commit README stats
         run: |
-          if git diff --quiet README.md attribution.html; then
-            echo "README / attribution.html 変更なし"; exit 0
+          if git diff --quiet README.md attribution.html llms.txt llms-full.txt; then
+            echo "README / attribution.html / llms*.txt 変更なし"; exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add README.md attribution.html
+          git add README.md attribution.html llms.txt llms-full.txt
           git commit -m "chore: update README data stats and attribution page"
           for i in 1 2 3; do
             if git pull --rebase --autostash origin main && git push; then

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,6 +10,8 @@ on:
       - 'index.html'
       - 'map.html'
       - 'attribution.html'
+      - 'llms.txt'
+      - 'llms-full.txt'
       - '_headers'
       - '.github/workflows/pages.yml'
   workflow_dispatch:

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,21 +1,14 @@
-<div align="center">
+<!-- このファイルは README.md から自動生成されています（scripts/gen-llms.js）。直接編集しないでください。 -->
 
-# 🍽️ Japan Food Facilities Data
+# 🍽️ Japan Facilities Data
 
 **全国の食品営業許可・届出データを、共通形式で無料配信するオープンデータプロジェクト**
 
-[![Contributors](https://img.shields.io/github/contributors/gl20percentclub/japan-food-facilities-api)](https://github.com/gl20percentclub/japan-food-facilities-api/graphs/contributors)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![GitHub Issues](https://img.shields.io/github/issues/gl20percentclub/japan-food-facilities-api)](https://github.com/gl20percentclub/japan-food-facilities-api/issues)
-[![Weekly Crawl](https://img.shields.io/badge/更新-毎週自動-blue)](#更新頻度)
-
-[公式サイト](https://gl20percentclub.github.io/japan-food-facilities-api/) ·
-[地図で見る](https://gl20percentclub.github.io/japan-food-facilities-api/map.html) ·
-[CSVをダウンロード](https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv) ·
-[収録状況](docs/COVERAGE.md) ·
-[出典・ライセンス](https://gl20percentclub.github.io/japan-food-facilities-api/attribution.html)
-
-</div>
+[公式サイト](https://gl20percentclub.github.io/japan-facilities-api/) ·
+[地図で見る](https://gl20percentclub.github.io/japan-facilities-api/map.html) ·
+[CSVをダウンロード](https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv.gz) ·
+[収録状況](https://raw.githubusercontent.com/gl20percentclub/japan-facilities-api/main/docs/COVERAGE.md) ·
+[出典・ライセンス](https://gl20percentclub.github.io/japan-facilities-api/attribution.html)
 
 ---
 
@@ -49,20 +42,23 @@
 
 | ファイル | URL |
 |---|---|
-| 全件CSV | https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv |
+| gzip圧縮版（推奨） | https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv.gz |
+| 非圧縮版 | https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv |
 
-- 文字コード: UTF-8（BOMなし）
+- 文字コード: UTF-8 BOM付き
+- Excelで直接読み込み可能
 - 全列が一致する重複レコードは除去済み
 
 ```bash
-curl -O https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv
+curl -O https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv.gz
+gunzip facilities-all.csv.gz
 ```
 
 ```python
 import pandas as pd
 
 df = pd.read_csv(
-    "https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv"
+    "https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv.gz"
 )
 ```
 
@@ -76,7 +72,7 @@ df = pd.read_csv(
 map.addSource("facilities", {
   type: "vector",
   tiles: [
-    "https://gl20percentclub.github.io/japan-food-facilities-api/api/tiles/{z}/{x}/{y}.pbf",
+    "https://gl20percentclub.github.io/japan-facilities-api/api/tiles/{z}/{x}/{y}.pbf",
   ],
   minzoom: 6,
   maxzoom: 12,
@@ -85,9 +81,9 @@ map.addSource("facilities", {
 
 - レイヤー名: `facilities`
 - 主な属性: `name` / `business_type` / `pref` / `city`
-- 詳細: [`api/tiles/metadata.json`](https://gl20percentclub.github.io/japan-food-facilities-api/api/tiles/metadata.json)
+- 詳細: [`api/tiles/metadata.json`](https://gl20percentclub.github.io/japan-facilities-api/api/tiles/metadata.json)
 
-収録データは[プレビュー地図](https://gl20percentclub.github.io/japan-food-facilities-api/map.html)でも確認できます。
+収録データは[プレビュー地図](https://gl20percentclub.github.io/japan-facilities-api/map.html)でも確認できます。
 
 ### AIエージェントから使う
 
@@ -129,7 +125,7 @@ Claude Code や Codex などのコーディングエージェントでこのデ�
 2. 都道府県など、管轄する保健所設置主体のオープンデータ
 3. 厚生労働省「食品衛生申請等システム（i2fas）」のオープンデータ
 
-自治体ごとの収録状況と取得元は、[`docs/COVERAGE.md`](docs/COVERAGE.md) で確認できます。
+自治体ごとの収録状況と取得元は、[`docs/COVERAGE.md`](https://raw.githubusercontent.com/gl20percentclub/japan-facilities-api/main/docs/COVERAGE.md) で確認できます。
 
 ## データの精度と注意事項
 
@@ -177,8 +173,8 @@ GitHub Actionsで毎週月曜18:00 UTC（日本時間 火曜3:00）に更新し�
 
 ```html
 出典:
-<a href="https://github.com/gl20percentclub/japan-food-facilities-api">
-  Japan Food Facilities Data
+<a href="https://github.com/gl20percentclub/japan-facilities-api">
+  Japan Facilities Data
 </a>
 （各自治体の食品営業許可オープンデータを加工して作成）
 ```
@@ -186,12 +182,12 @@ GitHub Actionsで毎週月曜18:00 UTC（日本時間 火曜3:00）に更新し�
 地図上では、次のように表示できます。
 
 ```text
-© Japan Food Facilities Data（各自治体オープンデータ）
+© Japan Facilities Data（各自治体オープンデータ）
 ```
 
 特定自治体のデータだけを利用する場合は、CSVの `sources` 列に記載された自治体名も併記してください。
 
-自治体ごとの出典表示文は、[出典・ライセンス表示ページ](https://gl20percentclub.github.io/japan-food-facilities-api/attribution.html)で確認できます。
+自治体ごとの出典表示文は、[出典・ライセンス表示ページ](https://gl20percentclub.github.io/japan-facilities-api/attribution.html)で確認できます。
 
 ## 免責事項
 
@@ -204,4 +200,65 @@ GitHub Actionsで毎週月曜18:00 UTC（日本時間 火曜3:00）に更新し�
 
 バグ報告、データソース追加、ドキュメント改善、機能提案を歓迎します。
 
-開発環境のセットアップやプルリクエストの手順は、[`CONTRIBUTING.md`](CONTRIBUTING.md) を参照してください。
+開発環境のセットアップやプルリクエストの手順は、[`CONTRIBUTING.md`](https://raw.githubusercontent.com/gl20percentclub/japan-facilities-api/main/CONTRIBUTING.md) を参照してください。
+
+---
+
+## 付録: AI エージェント向け利用レシピ
+
+このデータを使うアプリをコーディングエージェント（Claude Code / Codex 等）が書くための、
+コピペで動く最小コード例。
+
+### CSV から必要な範囲を抽出する（DuckDB・推奨）
+
+540MB の CSV 全体をメモリに載せずに、リモートの gzip CSV へ直接クエリできる。
+
+```sql
+INSTALL httpfs; LOAD httpfs;
+SELECT name, address, lat, lng
+FROM read_csv_auto('https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv.gz')
+WHERE prefecture = '沖縄県' AND city = '那覇市' AND business_type = '飲食店営業';
+```
+
+### pandas で読む
+
+```python
+import pandas as pd
+
+df = pd.read_csv('https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv.gz')
+naha = df[(df['prefecture'] == '沖縄県') & (df['city'] == '那覇市')]
+```
+
+### 地図に表示する（MapLibre GL JS・タイル利用）
+
+ブラウザで施設を地図表示する場合は CSV ではなくベクトルタイルを使う（軽量・タイルサーバー不要）。
+
+```js
+map.addSource('facilities', {
+  type: 'vector',
+  tiles: ['https://gl20percentclub.github.io/japan-facilities-api/api/tiles/{z}/{x}/{y}.pbf'],
+  minzoom: 6,
+  maxzoom: 12,
+});
+map.addLayer({
+  id: 'facilities-points',
+  type: 'circle',
+  source: 'facilities',
+  'source-layer': 'facilities', // レイヤ名は facilities 固定
+  paint: { 'circle-radius': 4, 'circle-color': '#e74c3c' },
+});
+```
+
+### 実装時の注意
+
+- **ブラウザから 540MB の CSV を fetch しない。** 地図表示はタイル、データ抽出はサーバー側
+  （または DuckDB-Wasm + HTTP range request）で行う。
+- CSV は UTF-8 **BOM付き**。Node.js 等でパースする際は先頭の BOM（\uFEFF）を除去する。
+- `lat` / `lng` は座標を補完できなかった施設では空になる。地図利用時は必ず除外する。
+- `geocoding_level` が小さいほど座標は大まか（1=都道府県、2=市区町村、3=町丁目、8=街区・地番）。
+  建物単位の精度が必要なら level を確認する。
+- 同一施設が業種違いで複数レコード存在する。ユニーク施設が必要なら name + lat/lng で重複排除する。
+- キーワード検索・位置検索（「近くのラーメン屋」等）を提供したい場合は、静的 CSV では
+  実現できないため [geosearch](https://github.com/naogify/geosearch) の検索 API を利用する。
+- データ利用時は出典表示が必要（CC BY 4.0）:
+  「© Japan Facilities Data（各自治体オープンデータ）」

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,38 @@
+# Japan Facilities Data
+
+> 日本全国の食品営業許可・届出施設（飲食店・喫茶店・食品製造業など）を収集し、
+> 全国共通フォーマットの全件CSVとベクトルタイルで無料配信するオープンデータ。
+> 登録不要・APIキー不要・商用利用可（データは CC BY 4.0）。毎週自動更新。
+
+重要な事実:
+
+- 全件CSV（gzip 推奨）: https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv.gz
+- 全件CSV（非圧縮・約540MB）: https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv
+- CSV は UTF-8（BOM付き）。列: prefecture, city, city_raw, name, name_kana,
+  business_type, address, lat, lng, geocoding_level, phone, license_no,
+  license_date, expire_date, sources, licenses
+- ベクトルタイル（MVT）: https://gl20percentclub.github.io/japan-facilities-api/api/tiles/{z}/{x}/{y}.pbf （レイヤ名 facilities、z6–12）
+- 市区町村別 JSON や検索 API は配信していない。抽出は CSV から、地図表示はタイルで行う
+- 全ファイル CORS 開放済み（Access-Control-Allow-Origin: *）。URL は更新後も不変
+- 毎週月曜 18:00 UTC（JST 火曜 3:00）に自動更新
+
+**最終更新: 2026-07-24**
+
+| 項目 | 値 |
+|---|---|
+| 施設レコード数 | 1,495,048 件 |
+| 都道府県 | 52 |
+| 市区町村 | 1,958 |
+
+## ドキュメント
+
+- [llms-full.txt](https://gl20percentclub.github.io/japan-facilities-api/llms-full.txt): データ仕様・利用例・注意事項の全文（まずこれを読む）
+- [README](https://raw.githubusercontent.com/gl20percentclub/japan-facilities-api/main/README.md): プロジェクト概要
+- [収録状況](https://raw.githubusercontent.com/gl20percentclub/japan-facilities-api/main/docs/COVERAGE.md): 自治体ごとの収録有無・取得元・ライセンスの一覧
+- [タイルメタデータ](https://gl20percentclub.github.io/japan-facilities-api/api/tiles/metadata.json): TileJSON（レイヤ定義・ズーム範囲・bounds）
+- [出典・ライセンス表示](https://gl20percentclub.github.io/japan-facilities-api/attribution.html): 利用時に必要な出典表示の文例
+
+## 関連ツール
+
+- [geosearch](https://github.com/naogify/geosearch): この CSV をキーワード・位置情報で検索できる
+  API（SQLite in Lambda）とタイル配信に変換する IaC。全文検索が必要な場合はこちら

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
     "build": "node scripts/crawl.js",
     "build:dry": "node scripts/crawl.js --dry-run",
     "build:attribution": "node scripts/gen-attribution.js",
+    "build:llms": "node scripts/gen-llms.js",
     "fetch:i2fas": "node scripts/fetch-i2fas.mjs",
-    "test:unit": "node scripts/crawl.test.js && node scripts/lib/config.test.js && node scripts/build-merged-csv.test.js && node scripts/gen-tiles.test.js && node scripts/preview-map.test.js && node scripts/gen-readme-stats.test.js && node scripts/gen-attribution.test.js && node scripts/workflows.test.js",
+    "test:unit": "node scripts/crawl.test.js && node scripts/lib/config.test.js && node scripts/build-merged-csv.test.js && node scripts/gen-tiles.test.js && node scripts/preview-map.test.js && node scripts/gen-readme-stats.test.js && node scripts/gen-llms.test.js && node scripts/gen-attribution.test.js && node scripts/workflows.test.js",
     "test": "npm run test:unit && node scripts/test.js"
   },
   "dependencies": {

--- a/scripts/crawl.js
+++ b/scripts/crawl.js
@@ -37,6 +37,7 @@ import { buildCityNormMap, applyPrefCity } from './lib/city-normmap.js';
 import { buildMergedCsv } from './build-merged-csv.js';
 import { generateTiles } from './gen-tiles.js';
 import { generateReadmeStats } from './gen-readme-stats.js';
+import { generateLlmsFiles } from './gen-llms.js';
 
 const CACHE_DIR = path.join(ROOT, '.cache');
 const API_DIR = path.join(ROOT, 'api');
@@ -145,6 +146,9 @@ async function main() {
   // CSV に載らない重複点がタイルに入り、配信物どうしで件数が食い違う。
   const tiles = generateTiles(csv.unique, { updated, stats: csv });
   generateReadmeStats({ updated, csv, tiles });
+  // README の統計更新後に、AI エージェント向けの llms.txt / llms-full.txt を
+  // README から再生成する（統計込みで最新化するため、必ず統計更新の後に呼ぶ）
+  generateLlmsFiles();
 
   console.log(
     `\n✅ 生成完了: ${csv.prefectures}都道府県 / ${csv.cities}市区町村 / ${csv.rowsOut}レコード`,

--- a/scripts/gen-llms.js
+++ b/scripts/gen-llms.js
@@ -1,0 +1,229 @@
+// ---------------------------------------------------------------------------
+// AI エージェント向けの llms.txt / llms-full.txt を README.md から生成する。
+//
+//   llms.txt       … llms.txt 仕様（https://llmstxt.org）に沿った索引。
+//                    プロジェクト概要・配信 URL・主要ドキュメントへのリンク集。
+//   llms-full.txt  … README 全文（相対リンクを絶対 URL 化）＋ AI エージェント向けの
+//                    利用レシピを 1 ファイルにまとめた全仕様。URL を 1 つ渡すだけで
+//                    コーディングエージェントがアプリを書ける状態にする。
+//
+// README を単一の情報源とし、統計ブロック（STATS マーカー間）も README から
+// 抽出して埋め込む。クロール（crawl.js）の最後に呼ばれるため、週次更新のたびに
+// 最新の統計へ追従する。生成物はリポジトリ直下に置かれ、gh-pages 配信で
+// サイトルート（/llms.txt /llms-full.txt）から取得できる。
+//
+//   node scripts/gen-llms.js   単体実行（README.md を読んで2ファイルを書き出す）
+// ---------------------------------------------------------------------------
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const README_PATH = path.join(ROOT, 'README.md');
+
+// 配信 URL の基点。Pages はデータとページの配信先、RAW はリポジトリ内 Markdown の取得先。
+const PAGES = 'https://gl20percentclub.github.io/japan-facilities-api';
+const REPO = 'https://github.com/gl20percentclub/japan-facilities-api';
+const RAW = 'https://raw.githubusercontent.com/gl20percentclub/japan-facilities-api/main';
+
+const STATS_START = '<!-- STATS:START -->';
+const STATS_END = '<!-- STATS:END -->';
+
+/**
+ * README から統計ブロック（STATS マーカー間）を抽出する（純粋関数）。
+ * blockquote の `> ` 接頭辞は除去し、素の Markdown テーブルとして返す。
+ * マーカーが無ければ空文字列を返す。
+ */
+export function extractStats(readme) {
+  const start = readme.indexOf(STATS_START);
+  const end = readme.indexOf(STATS_END);
+  if (start === -1 || end === -1 || end < start) return '';
+  return readme
+    .slice(start + STATS_START.length, end)
+    .split('\n')
+    // blockquote を外してプレーンな Markdown にする（llms.txt では引用装飾が不要なため）
+    .map((line) => line.replace(/^>\s?/, ''))
+    .join('\n')
+    .trim();
+}
+
+/**
+ * README 内の相対リンクを絶対 URL に変換する（純粋関数）。
+ * llms-full.txt は単体ファイルとして読まれるため、相対リンクのままだと
+ * エージェントがリンク先を辿れない。リンク先の拡張子で基点を出し分ける:
+ *   - .md   → GitHub raw（Markdown をそのまま fetch できる）
+ *   - それ以外（.html 等） → GitHub Pages（配信されている実体）
+ * http(s)・ページ内アンカー（#）・mailto は変換しない。
+ */
+export function absolutizeLinks(markdown) {
+  return markdown.replace(
+    /\]\((?!https?:\/\/|#|mailto:)([^)]+)\)/g,
+    (_, target) => (target.endsWith('.md') ? `](${RAW}/${target})` : `](${PAGES}/${target})`),
+  );
+}
+
+/**
+ * README からバッジ画像・HTML 装飾（<div> 等）を取り除く（純粋関数）。
+ * llms 系ファイルはプレーンな Markdown として読まれるため、
+ * shields.io バッジや center 寄せの HTML はノイズにしかならない。
+ */
+export function stripHtmlNoise(markdown) {
+  return markdown
+    .split('\n')
+    // バッジ行（shields.io への画像リンク）と div タグ行を落とす
+    .filter((line) => !line.includes('img.shields.io') && !/^<\/?div/.test(line.trim()))
+    .join('\n')
+    // 行削除で 3 連以上になった空行を 2 連（段落区切り）まで詰める
+    .replace(/\n{3,}/g, '\n\n');
+}
+
+/**
+ * llms.txt（索引）を組み立てる（純粋関数）。`readme` は README.md の全文。
+ * 先頭に H1 と blockquote 要約を置き、続けて重要な事実・リンク集を並べる
+ * llms.txt 仕様の構成に従う。
+ */
+export function renderLlmsTxt(readme) {
+  const stats = extractStats(readme);
+  return `# Japan Facilities Data
+
+> 日本全国の食品営業許可・届出施設（飲食店・喫茶店・食品製造業など）を収集し、
+> 全国共通フォーマットの全件CSVとベクトルタイルで無料配信するオープンデータ。
+> 登録不要・APIキー不要・商用利用可（データは CC BY 4.0）。毎週自動更新。
+
+重要な事実:
+
+- 全件CSV（gzip 推奨）: ${PAGES}/api/facilities-all.csv.gz
+- 全件CSV（非圧縮・約540MB）: ${PAGES}/api/facilities-all.csv
+- CSV は UTF-8（BOM付き）。列: prefecture, city, city_raw, name, name_kana,
+  business_type, address, lat, lng, geocoding_level, phone, license_no,
+  license_date, expire_date, sources, licenses
+- ベクトルタイル（MVT）: ${PAGES}/api/tiles/{z}/{x}/{y}.pbf （レイヤ名 facilities、z6–12）
+- 市区町村別 JSON や検索 API は配信していない。抽出は CSV から、地図表示はタイルで行う
+- 全ファイル CORS 開放済み（Access-Control-Allow-Origin: *）。URL は更新後も不変
+- 毎週月曜 18:00 UTC（JST 火曜 3:00）に自動更新
+
+${stats}
+
+## ドキュメント
+
+- [llms-full.txt](${PAGES}/llms-full.txt): データ仕様・利用例・注意事項の全文（まずこれを読む）
+- [README](${RAW}/README.md): プロジェクト概要
+- [収録状況](${RAW}/docs/COVERAGE.md): 自治体ごとの収録有無・取得元・ライセンスの一覧
+- [タイルメタデータ](${PAGES}/api/tiles/metadata.json): TileJSON（レイヤ定義・ズーム範囲・bounds）
+- [出典・ライセンス表示](${PAGES}/attribution.html): 利用時に必要な出典表示の文例
+
+## 関連ツール
+
+- [geosearch](https://github.com/naogify/geosearch): この CSV をキーワード・位置情報で検索できる
+  API（SQLite in Lambda）とタイル配信に変換する IaC。全文検索が必要な場合はこちら
+`;
+}
+
+/**
+ * llms-full.txt（全仕様）を組み立てる（純粋関数）。`readme` は README.md の全文。
+ * README を絶対リンク化・ノイズ除去した本文に、AI エージェント向けの
+ * 利用レシピ（コピペで動くコード例）を付録として連結する。
+ */
+export function renderLlmsFullTxt(readme) {
+  const body = absolutizeLinks(stripHtmlNoise(readme)).trim();
+  return `<!-- このファイルは README.md から自動生成されています（scripts/gen-llms.js）。直接編集しないでください。 -->
+
+${body}
+
+---
+
+## 付録: AI エージェント向け利用レシピ
+
+このデータを使うアプリをコーディングエージェント（Claude Code / Codex 等）が書くための、
+コピペで動く最小コード例。
+
+### CSV から必要な範囲を抽出する（DuckDB・推奨）
+
+540MB の CSV 全体をメモリに載せずに、リモートの gzip CSV へ直接クエリできる。
+
+\`\`\`sql
+INSTALL httpfs; LOAD httpfs;
+SELECT name, address, lat, lng
+FROM read_csv_auto('${PAGES}/api/facilities-all.csv.gz')
+WHERE prefecture = '沖縄県' AND city = '那覇市' AND business_type = '飲食店営業';
+\`\`\`
+
+### pandas で読む
+
+\`\`\`python
+import pandas as pd
+
+df = pd.read_csv('${PAGES}/api/facilities-all.csv.gz')
+naha = df[(df['prefecture'] == '沖縄県') & (df['city'] == '那覇市')]
+\`\`\`
+
+### 地図に表示する（MapLibre GL JS・タイル利用）
+
+ブラウザで施設を地図表示する場合は CSV ではなくベクトルタイルを使う（軽量・タイルサーバー不要）。
+
+\`\`\`js
+map.addSource('facilities', {
+  type: 'vector',
+  tiles: ['${PAGES}/api/tiles/{z}/{x}/{y}.pbf'],
+  minzoom: 6,
+  maxzoom: 12,
+});
+map.addLayer({
+  id: 'facilities-points',
+  type: 'circle',
+  source: 'facilities',
+  'source-layer': 'facilities', // レイヤ名は facilities 固定
+  paint: { 'circle-radius': 4, 'circle-color': '#e74c3c' },
+});
+\`\`\`
+
+### 実装時の注意
+
+- **ブラウザから 540MB の CSV を fetch しない。** 地図表示はタイル、データ抽出はサーバー側
+  （または DuckDB-Wasm + HTTP range request）で行う。
+- CSV は UTF-8 **BOM付き**。Node.js 等でパースする際は先頭の BOM（\\uFEFF）を除去する。
+- \`lat\` / \`lng\` は座標を補完できなかった施設では空になる。地図利用時は必ず除外する。
+- \`geocoding_level\` が小さいほど座標は大まか（1=都道府県、2=市区町村、3=町丁目、8=街区・地番）。
+  建物単位の精度が必要なら level を確認する。
+- 同一施設が業種違いで複数レコード存在する。ユニーク施設が必要なら name + lat/lng で重複排除する。
+- キーワード検索・位置検索（「近くのラーメン屋」等）を提供したい場合は、静的 CSV では
+  実現できないため [geosearch](https://github.com/naogify/geosearch) の検索 API を利用する。
+- データ利用時は出典表示が必要（CC BY 4.0）:
+  「© Japan Facilities Data（各自治体オープンデータ）」
+`;
+}
+
+/**
+ * README.md を読み、llms.txt / llms-full.txt をリポジトリ直下に書き出す。
+ * 変更が無ければ書き込まない（タイムスタンプ更新による無駄な差分を避ける）。
+ * 戻り値は書き出した（または既存と一致した）ファイルパスの配列。
+ */
+export function generateLlmsFiles() {
+  const readme = fs.readFileSync(README_PATH, 'utf-8');
+  const outputs = [
+    ['llms.txt', renderLlmsTxt(readme)],
+    ['llms-full.txt', renderLlmsFullTxt(readme)],
+  ];
+  const written = [];
+  for (const [name, content] of outputs) {
+    const outPath = path.join(ROOT, name);
+    // 既存内容と比較し、変わったときだけ書き込む
+    const prev = fs.existsSync(outPath) ? fs.readFileSync(outPath, 'utf-8') : null;
+    if (prev !== content) {
+      fs.writeFileSync(outPath, content);
+      console.log(`  ${name} を更新`);
+    } else {
+      console.log(`  ${name} に変更なし`);
+    }
+    written.push(outPath);
+  }
+  return written;
+}
+
+// 単体実行（node scripts/gen-llms.js）されたときだけ生成を走らせる
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  console.log('llms.txt / llms-full.txt を生成');
+  generateLlmsFiles();
+}

--- a/scripts/gen-llms.test.js
+++ b/scripts/gen-llms.test.js
@@ -1,0 +1,99 @@
+// gen-llms.js の整形ロジックを検証する。
+// renderLlmsTxt() / renderLlmsFullTxt() / extractStats() / absolutizeLinks() は
+// 純粋関数なので固定入力で検証する。
+//
+//   node scripts/gen-llms.test.js
+
+import {
+  extractStats,
+  absolutizeLinks,
+  stripHtmlNoise,
+  renderLlmsTxt,
+  renderLlmsFullTxt,
+} from './gen-llms.js';
+
+let failures = 0;
+/** 条件を検証して結果を出力する（失敗数を数える）。 */
+function assert(cond, msg) {
+  if (cond) {
+    console.log(`  ✓ ${msg}`);
+  } else {
+    console.error(`  ✗ ${msg}`);
+    failures++;
+  }
+}
+
+console.log('gen-llms テスト\n');
+
+// テスト用の README（統計ブロック・相対リンク・バッジを含む最小構成）
+const readme = `<div align="center">
+
+# 🍽️ Japan Facilities Data
+
+[![Contributors](https://img.shields.io/github/contributors/x)](https://github.com/x)
+
+</div>
+
+## 概要
+
+<!-- STATS:START -->
+> **最終更新: 2026-07-24**
+>
+> | 項目 | 値 |
+> |---|---|
+> | 施設レコード数 | 1,495,048 件 |
+<!-- STATS:END -->
+
+詳細は [収録状況](docs/COVERAGE.md) と [出典表示](attribution.html) と
+[外部リンク](https://example.com/page) と [節](#概要) を参照。
+`;
+
+// --- extractStats ---
+const stats = extractStats(readme);
+assert(stats.includes('| 施設レコード数 | 1,495,048 件 |'), '統計テーブルが抽出される');
+assert(!stats.includes('> '), 'blockquote の接頭辞が除去される');
+assert(extractStats('マーカー無し') === '', 'マーカーが無ければ空文字列を返す');
+
+// --- absolutizeLinks ---
+const abs = absolutizeLinks(readme);
+assert(
+  abs.includes('](https://raw.githubusercontent.com/gl20percentclub/japan-facilities-api/main/docs/COVERAGE.md)'),
+  '.md への相対リンクは GitHub raw に変換される',
+);
+assert(
+  abs.includes('](https://gl20percentclub.github.io/japan-facilities-api/attribution.html)'),
+  '.html への相対リンクは Pages に変換される',
+);
+assert(abs.includes('](https://example.com/page)'), '絶対 URL は変換されない');
+assert(abs.includes('](#概要)'), 'ページ内アンカーは変換されない');
+
+// --- stripHtmlNoise ---
+const stripped = stripHtmlNoise(readme);
+assert(!stripped.includes('img.shields.io'), 'バッジ行が除去される');
+assert(!stripped.includes('<div'), 'div タグ行が除去される');
+assert(stripped.includes('# 🍽️ Japan Facilities Data'), '見出しは残る');
+assert(!/\n{3,}/.test(stripped), '3連以上の空行が残らない');
+
+// --- renderLlmsTxt ---
+const llms = renderLlmsTxt(readme);
+assert(llms.startsWith('# Japan Facilities Data'), 'H1 で始まる（llms.txt 仕様）');
+assert(llms.split('\n')[2].startsWith('> '), 'H1 直後に blockquote の要約がある');
+assert(llms.includes('facilities-all.csv.gz'), 'CSV の URL が載る');
+assert(llms.includes('{z}/{x}/{y}.pbf'), 'タイルの URL テンプレートが載る');
+assert(llms.includes('| 施設レコード数 | 1,495,048 件 |'), 'README の統計が埋め込まれる');
+assert(llms.includes('llms-full.txt'), 'llms-full.txt へのリンクがある');
+
+// --- renderLlmsFullTxt ---
+const full = renderLlmsFullTxt(readme);
+assert(full.includes('自動生成されています'), '自動生成の注意書きがある');
+assert(!full.includes('img.shields.io'), 'バッジが除去されている');
+assert(full.includes('raw.githubusercontent.com'), 'リンクが絶対 URL 化されている');
+assert(full.includes('AI エージェント向け利用レシピ'), '利用レシピの付録がある');
+assert(full.includes('read_csv_auto'), 'DuckDB のコード例がある');
+assert(full.includes("'source-layer': 'facilities'"), 'MapLibre のコード例がある');
+
+if (failures > 0) {
+  console.error(`\n❌ ${failures}件のチェックに失敗`);
+  process.exit(1);
+}
+console.log('\n✅ gen-llms テストに合格');


### PR DESCRIPTION
README を単一の情報源として llms.txt（索引）と llms-full.txt（全仕様＋
利用レシピ）を自動生成し、Pages ルートで配信する。週次クロールの最後に
再生成して統計に追従させ、main への push で pages.yml が配信する。

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>