### PR TITLE
docs: リポジトリ名変更を llms.txt / AGENTS.md / README に反映

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,13 +6,13 @@ AI コーディングエージェント（Claude Code / Codex 等）向けのガ
 
 ## このデータでアプリを作る場合
 
-**まず https://gl20percentclub.github.io/japan-facilities-api/llms-full.txt を読むこと。**
+**まず https://gl20percentclub.github.io/japan-food-facilities-api/llms-full.txt を読むこと。**
 データ仕様・コピペで動く利用例・注意事項がすべてまとまっている。要点だけ挙げる:
 
-- 全件CSV（gzip）: `https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv.gz`
+- 全件CSV（gzip）: `https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv.gz`
   - UTF-8 **BOM付き**、約150万レコード、非圧縮で約540MB
   - 列: `prefecture, city, city_raw, name, name_kana, business_type, address, lat, lng, geocoding_level, phone, license_no, license_date, expire_date, sources, licenses`
-- ベクトルタイル（MVT）: `https://gl20percentclub.github.io/japan-facilities-api/api/tiles/{z}/{x}/{y}.pbf`
+- ベクトルタイル（MVT）: `https://gl20percentclub.github.io/japan-food-facilities-api/api/tiles/{z}/{x}/{y}.pbf`
   - レイヤ名 `facilities`、z6–12、属性 `name` / `business_type` / `pref` / `city`
 - 市区町村別 JSON や検索 API は**配信していない**。データ抽出は CSV（DuckDB 推奨）、
   地図表示はタイルを使う。ブラウザから非圧縮 CSV を直接 fetch しない

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ Claude Code や Codex などのコーディングエージェントでこのデ�
 
 | ファイル | URL |
 |---|---|
-| llms.txt（索引） | https://gl20percentclub.github.io/japan-facilities-api/llms.txt |
-| llms-full.txt（全仕様） | https://gl20percentclub.github.io/japan-facilities-api/llms-full.txt |
+| llms.txt（索引） | https://gl20percentclub.github.io/japan-food-facilities-api/llms.txt |
+| llms-full.txt（全仕様） | https://gl20percentclub.github.io/japan-food-facilities-api/llms-full.txt |
 
 ## データ項目
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -7,7 +7,7 @@
 [公式サイト](https://gl20percentclub.github.io/japan-food-facilities-api/) ·
 [地図で見る](https://gl20percentclub.github.io/japan-food-facilities-api/map.html) ·
 [CSVをダウンロード](https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv) ·
-[収録状況](https://raw.githubusercontent.com/gl20percentclub/japan-facilities-api/main/docs/COVERAGE.md) ·
+[収録状況](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities-api/main/docs/COVERAGE.md) ·
 [出典・ライセンス](https://gl20percentclub.github.io/japan-food-facilities-api/attribution.html)
 
 ---
@@ -88,8 +88,8 @@ Claude Code や Codex などのコーディングエージェントでこのデ�
 
 | ファイル | URL |
 |---|---|
-| llms.txt（索引） | https://gl20percentclub.github.io/japan-facilities-api/llms.txt |
-| llms-full.txt（全仕様） | https://gl20percentclub.github.io/japan-facilities-api/llms-full.txt |
+| llms.txt（索引） | https://gl20percentclub.github.io/japan-food-facilities-api/llms.txt |
+| llms-full.txt（全仕様） | https://gl20percentclub.github.io/japan-food-facilities-api/llms-full.txt |
 
 ## データ項目
 
@@ -120,7 +120,7 @@ Claude Code や Codex などのコーディングエージェントでこのデ�
 2. 都道府県など、管轄する保健所設置主体のオープンデータ
 3. 厚生労働省「食品衛生申請等システム（i2fas）」のオープンデータ
 
-自治体ごとの収録状況と取得元は、[`docs/COVERAGE.md`](https://raw.githubusercontent.com/gl20percentclub/japan-facilities-api/main/docs/COVERAGE.md) で確認できます。
+自治体ごとの収録状況と取得元は、[`docs/COVERAGE.md`](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities-api/main/docs/COVERAGE.md) で確認できます。
 
 ## データの精度と注意事項
 
@@ -195,7 +195,7 @@ GitHub Actionsで毎週月曜18:00 UTC（日本時間 火曜3:00）に更新し�
 
 バグ報告、データソース追加、ドキュメント改善、機能提案を歓迎します。
 
-開発環境のセットアップやプルリクエストの手順は、[`CONTRIBUTING.md`](https://raw.githubusercontent.com/gl20percentclub/japan-facilities-api/main/CONTRIBUTING.md) を参照してください。
+開発環境のセットアップやプルリクエストの手順は、[`CONTRIBUTING.md`](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities-api/main/CONTRIBUTING.md) を参照してください。
 
 ---
 
@@ -211,7 +211,7 @@ GitHub Actionsで毎週月曜18:00 UTC（日本時間 火曜3:00）に更新し�
 ```sql
 INSTALL httpfs; LOAD httpfs;
 SELECT name, address, lat, lng
-FROM read_csv_auto('https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv.gz')
+FROM read_csv_auto('https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv.gz')
 WHERE prefecture = '沖縄県' AND city = '那覇市' AND business_type = '飲食店営業';
 ```
 
@@ -220,7 +220,7 @@ WHERE prefecture = '沖縄県' AND city = '那覇市' AND business_type = '飲�
 ```python
 import pandas as pd
 
-df = pd.read_csv('https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv.gz')
+df = pd.read_csv('https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv.gz')
 naha = df[(df['prefecture'] == '沖縄県') & (df['city'] == '那覇市')]
 ```
 
@@ -231,7 +231,7 @@ naha = df[(df['prefecture'] == '沖縄県') & (df['city'] == '那覇市')]
 ```js
 map.addSource('facilities', {
   type: 'vector',
-  tiles: ['https://gl20percentclub.github.io/japan-facilities-api/api/tiles/{z}/{x}/{y}.pbf'],
+  tiles: ['https://gl20percentclub.github.io/japan-food-facilities-api/api/tiles/{z}/{x}/{y}.pbf'],
   minzoom: 6,
   maxzoom: 12,
 });

--- a/llms.txt
+++ b/llms.txt
@@ -6,12 +6,12 @@
 
 重要な事実:
 
-- 全件CSV（gzip 推奨）: https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv.gz
-- 全件CSV（非圧縮・約540MB）: https://gl20percentclub.github.io/japan-facilities-api/api/facilities-all.csv
+- 全件CSV（gzip 推奨）: https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv.gz
+- 全件CSV（非圧縮・約540MB）: https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv
 - CSV は UTF-8（BOM付き）。列: prefecture, city, city_raw, name, name_kana,
   business_type, address, lat, lng, geocoding_level, phone, license_no,
   license_date, expire_date, sources, licenses
-- ベクトルタイル（MVT）: https://gl20percentclub.github.io/japan-facilities-api/api/tiles/{z}/{x}/{y}.pbf （レイヤ名 facilities、z6–12）
+- ベクトルタイル（MVT）: https://gl20percentclub.github.io/japan-food-facilities-api/api/tiles/{z}/{x}/{y}.pbf （レイヤ名 facilities、z6–12）
 - 市区町村別 JSON や検索 API は配信していない。抽出は CSV から、地図表示はタイルで行う
 - 全ファイル CORS 開放済み（Access-Control-Allow-Origin: *）。URL は更新後も不変
 - 毎週月曜 18:00 UTC（JST 火曜 3:00）に自動更新
@@ -26,8 +26,8 @@
 
 ## ドキュメント
 
-- [llms-full.txt](https://gl20percentclub.github.io/japan-facilities-api/llms-full.txt): データ仕様・利用例・注意事項の全文（まずこれを読む）
-- [README](https://raw.githubusercontent.com/gl20percentclub/japan-facilities-api/main/README.md): プロジェクト概要
-- [収録状況](https://raw.githubusercontent.com/gl20percentclub/japan-facilities-api/main/docs/COVERAGE.md): 自治体ごとの収録有無・取得元・ライセンスの一覧
-- [タイルメタデータ](https://gl20percentclub.github.io/japan-facilities-api/api/tiles/metadata.json): TileJSON（レイヤ定義・ズーム範囲・bounds）
-- [出典・ライセンス表示](https://gl20percentclub.github.io/japan-facilities-api/attribution.html): 利用時に必要な出典表示の文例
+- [llms-full.txt](https://gl20percentclub.github.io/japan-food-facilities-api/llms-full.txt): データ仕様・利用例・注意事項の全文（まずこれを読む）
+- [README](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities-api/main/README.md): プロジェクト概要
+- [収録状況](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities-api/main/docs/COVERAGE.md): 自治体ごとの収録有無・取得元・ライセンスの一覧
+- [タイルメタデータ](https://gl20percentclub.github.io/japan-food-facilities-api/api/tiles/metadata.json): TileJSON（レイヤ定義・ズーム範囲・bounds）
+- [出典・ライセンス表示](https://gl20percentclub.github.io/japan-food-facilities-api/attribution.html): 利用時に必要な出典表示の文例

--- a/scripts/gen-llms.js
+++ b/scripts/gen-llms.js
@@ -24,9 +24,9 @@ const ROOT = path.resolve(__dirname, '..');
 const README_PATH = path.join(ROOT, 'README.md');
 
 // 配信 URL の基点。Pages はデータとページの配信先、RAW はリポジトリ内 Markdown の取得先。
-const PAGES = 'https://gl20percentclub.github.io/japan-facilities-api';
-const REPO = 'https://github.com/gl20percentclub/japan-facilities-api';
-const RAW = 'https://raw.githubusercontent.com/gl20percentclub/japan-facilities-api/main';
+const PAGES = 'https://gl20percentclub.github.io/japan-food-facilities-api';
+const REPO = 'https://github.com/gl20percentclub/japan-food-facilities-api';
+const RAW = 'https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities-api/main';
 
 const STATS_START = '<!-- STATS:START -->';
 const STATS_END = '<!-- STATS:END -->';

--- a/scripts/gen-llms.test.js
+++ b/scripts/gen-llms.test.js
@@ -57,11 +57,11 @@ assert(extractStats('マーカー無し') === '', 'マーカーが無ければ�
 // --- absolutizeLinks ---
 const abs = absolutizeLinks(readme);
 assert(
-  abs.includes('](https://raw.githubusercontent.com/gl20percentclub/japan-facilities-api/main/docs/COVERAGE.md)'),
+  abs.includes('](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities-api/main/docs/COVERAGE.md)'),
   '.md への相対リンクは GitHub raw に変換される',
 );
 assert(
-  abs.includes('](https://gl20percentclub.github.io/japan-facilities-api/attribution.html)'),
+  abs.includes('](https://gl20percentclub.github.io/japan-food-facilities-api/attribution.html)'),
   '.html への相対リンクは Pages に変換される',
 );
 assert(abs.includes('](https://example.com/page)'), '絶対 URL は変換されない');


### PR DESCRIPTION
## 概要

リポジトリ名変更（japan-facilities-api → japan-food-facilities-api）の参照更新のうち、#49 / #50 で入ったファイルが旧名のままだったので追従させる。GitHub Pages の URL はリネームでリダイレクトされないため、旧 URL のままだと 404 になる。

- `scripts/gen-llms.js` — Pages / リポジトリ / raw の URL 定数を更新
- `scripts/gen-llms.test.js` — 期待 URL を更新
- `llms.txt` / `llms-full.txt` — 再生成
- `README.md` — 「AIエージェントから使う」セクションの llms.txt URL を更新
- `AGENTS.md` — 各 URL を更新

index.html / attribution.html / map.html 等は対応済みのため対象外。

## テスト

- `npm run test:unit` ✅