### PR TITLE
リポジトリ名 japan-food-facilities への変更に合わせてサイト・ドキュメントの全参照を更新

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,21 +6,21 @@ AI コーディングエージェント（Claude Code / Codex 等）向けのガ
 
 ## このデータでアプリを作る場合
 
-**まず https://gl20percentclub.github.io/japan-food-facilities-api/llms-full.txt を読むこと。**
+**まず https://gl20percentclub.github.io/japan-food-facilities/llms-full.txt を読むこと。**
 データ仕様・コピペで動く利用例・注意事項がすべてまとまっている。要点だけ挙げる:
 
-- 全件CSV（gzip）: `https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv.gz`
+- 全件CSV（gzip）: `https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv.gz`
   - UTF-8 **BOM付き**、約150万レコード、非圧縮で約540MB
   - 列: `prefecture, city, city_raw, name, name_kana, business_type, address, lat, lng, geocoding_level, phone, license_no, license_date, expire_date, sources, licenses`
-- ベクトルタイル（MVT）: `https://gl20percentclub.github.io/japan-food-facilities-api/api/tiles/{z}/{x}/{y}.pbf`
+- ベクトルタイル（MVT）: `https://gl20percentclub.github.io/japan-food-facilities/api/tiles/{z}/{x}/{y}.pbf`
   - レイヤ名 `facilities`、z6–12、属性 `name` / `business_type` / `pref` / `city`
-- 検索用 Parquet（都道府県別・列は CSV と同一）: `https://gl20percentclub.github.io/japan-food-facilities-api/api/parquet/{JISコード}.parquet`
+- 検索用 Parquet（都道府県別・列は CSV と同一）: `https://gl20percentclub.github.io/japan-food-facilities/api/parquet/{JISコード}.parquet`
   - 例: `13.parquet` = 東京都、`99.parquet` = 都道府県不明。一覧は同ディレクトリの `manifest.json`
   - DuckDB（CLI / Python / Wasm）の `read_parquet()` でそのまま検索できる。
     ブラウザで試すには `playground.html`（検索プレイグラウンド）
 - サーバー型の検索 API や市区町村別 JSON は**配信していない**。キーワード検索は Parquet、
   一括抽出は CSV（DuckDB 推奨）、地図表示はタイルを使う。ブラウザから非圧縮 CSV を直接 fetch しない
-- データは CC BY 4.0。出典表示: 「© Japan Facilities Data（各自治体オープンデータ）」
+- データは CC BY 4.0。出典表示: 「© Japan Food Facilities Data（各自治体オープンデータ）」
 
 ## 開発コマンド
 

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@
 
 **全国の食品営業許可・届出データを、共通形式で無料配信するオープンデータプロジェクト**
 
-[![Contributors](https://img.shields.io/github/contributors/gl20percentclub/japan-food-facilities-api)](https://github.com/gl20percentclub/japan-food-facilities-api/graphs/contributors)
+[![Contributors](https://img.shields.io/github/contributors/gl20percentclub/japan-food-facilities)](https://github.com/gl20percentclub/japan-food-facilities/graphs/contributors)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![GitHub Issues](https://img.shields.io/github/issues/gl20percentclub/japan-food-facilities-api)](https://github.com/gl20percentclub/japan-food-facilities-api/issues)
+[![GitHub Issues](https://img.shields.io/github/issues/gl20percentclub/japan-food-facilities)](https://github.com/gl20percentclub/japan-food-facilities/issues)
 [![Weekly Crawl](https://img.shields.io/badge/更新-毎週自動-blue)](#更新頻度)
 
-[公式サイト](https://gl20percentclub.github.io/japan-food-facilities-api/) ·
-[地図で見る](https://gl20percentclub.github.io/japan-food-facilities-api/map.html) ·
-[検索プレイグラウンド](https://gl20percentclub.github.io/japan-food-facilities-api/playground.html) ·
-[CSVをダウンロード](https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv) ·
+[公式サイト](https://gl20percentclub.github.io/japan-food-facilities/) ·
+[地図で見る](https://gl20percentclub.github.io/japan-food-facilities/map.html) ·
+[検索プレイグラウンド](https://gl20percentclub.github.io/japan-food-facilities/playground.html) ·
+[CSVをダウンロード](https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv) ·
 [収録状況](docs/COVERAGE.md) ·
-[出典・ライセンス](https://gl20percentclub.github.io/japan-food-facilities-api/attribution.html)
+[出典・ライセンス](https://gl20percentclub.github.io/japan-food-facilities/attribution.html)
 
 </div>
 
@@ -53,20 +53,20 @@
 
 | ファイル | URL |
 |---|---|
-| 全件CSV | https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv |
+| 全件CSV | https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv |
 
 - 文字コード: UTF-8（BOMなし）
 - 全列が一致する重複レコードは除去済み
 
 ```bash
-curl -O https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv
+curl -O https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv
 ```
 
 ```python
 import pandas as pd
 
 df = pd.read_csv(
-    "https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv"
+    "https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv"
 )
 ```
 
@@ -80,7 +80,7 @@ df = pd.read_csv(
 map.addSource("facilities", {
   type: "vector",
   tiles: [
-    "https://gl20percentclub.github.io/japan-food-facilities-api/api/tiles/{z}/{x}/{y}.pbf",
+    "https://gl20percentclub.github.io/japan-food-facilities/api/tiles/{z}/{x}/{y}.pbf",
   ],
   minzoom: 6,
   maxzoom: 12,
@@ -89,9 +89,9 @@ map.addSource("facilities", {
 
 - レイヤー名: `facilities`
 - 主な属性: `name` / `business_type` / `pref` / `city`
-- 詳細: [`api/tiles/metadata.json`](https://gl20percentclub.github.io/japan-food-facilities-api/api/tiles/metadata.json)
+- 詳細: [`api/tiles/metadata.json`](https://gl20percentclub.github.io/japan-food-facilities/api/tiles/metadata.json)
 
-収録データは[プレビュー地図](https://gl20percentclub.github.io/japan-food-facilities-api/map.html)でも確認できます。
+収録データは[プレビュー地図](https://gl20percentclub.github.io/japan-food-facilities/map.html)でも確認できます。
 
 ### 検索用Parquet
 
@@ -99,17 +99,17 @@ map.addSource("facilities", {
 
 | ファイル | URL |
 |---|---|
-| 都道府県別Parquet | `https://gl20percentclub.github.io/japan-food-facilities-api/api/parquet/{都道府県コード}.parquet` |
-| ファイル一覧（manifest） | https://gl20percentclub.github.io/japan-food-facilities-api/api/parquet/manifest.json |
+| 都道府県別Parquet | `https://gl20percentclub.github.io/japan-food-facilities/api/parquet/{都道府県コード}.parquet` |
+| ファイル一覧（manifest） | https://gl20percentclub.github.io/japan-food-facilities/api/parquet/manifest.json |
 
 - 都道府県コードは JIS X 0401（`01`=北海道 〜 `47`=沖縄県、`99`=都道府県不明）
 - 列は全件CSVと同一
-- ブラウザで試すには[検索プレイグラウンド](https://gl20percentclub.github.io/japan-food-facilities-api/playground.html)を利用してください
+- ブラウザで試すには[検索プレイグラウンド](https://gl20percentclub.github.io/japan-food-facilities/playground.html)を利用してください
 
 ```sql
 -- DuckDB（CLI / Python / Wasm）からそのまま検索できます
 SELECT name, business_type, address, lat, lng
-FROM read_parquet('https://gl20percentclub.github.io/japan-food-facilities-api/api/parquet/13.parquet')  -- 13 = 東京都
+FROM read_parquet('https://gl20percentclub.github.io/japan-food-facilities/api/parquet/13.parquet')  -- 13 = 東京都
 WHERE name LIKE '%ラーメン%'
 LIMIT 100;
 ```
@@ -120,8 +120,8 @@ Claude Code や Codex などのコーディングエージェントでこのデ�
 
 | ファイル | URL |
 |---|---|
-| llms.txt（索引） | https://gl20percentclub.github.io/japan-food-facilities-api/llms.txt |
-| llms-full.txt（全仕様） | https://gl20percentclub.github.io/japan-food-facilities-api/llms-full.txt |
+| llms.txt（索引） | https://gl20percentclub.github.io/japan-food-facilities/llms.txt |
+| llms-full.txt（全仕様） | https://gl20percentclub.github.io/japan-food-facilities/llms-full.txt |
 
 ## データ項目
 
@@ -200,7 +200,7 @@ GitHub Actionsで毎週月曜18:00 UTC（日本時間 火曜3:00）に更新し�
 
 ```html
 出典:
-<a href="https://github.com/gl20percentclub/japan-food-facilities-api">
+<a href="https://github.com/gl20percentclub/japan-food-facilities">
   Japan Food Facilities Data
 </a>
 （各自治体の食品営業許可オープンデータを加工して作成）
@@ -214,7 +214,7 @@ GitHub Actionsで毎週月曜18:00 UTC（日本時間 火曜3:00）に更新し�
 
 特定自治体のデータだけを利用する場合は、CSVの `sources` 列に記載された自治体名も併記してください。
 
-自治体ごとの出典表示文は、[出典・ライセンス表示ページ](https://gl20percentclub.github.io/japan-food-facilities-api/attribution.html)で確認できます。
+自治体ごとの出典表示文は、[出典・ライセンス表示ページ](https://gl20percentclub.github.io/japan-food-facilities/attribution.html)で確認できます。
 
 ## 免責事項
 

--- a/attribution.html
+++ b/attribution.html
@@ -7,8 +7,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>出典・ライセンス表示 — Japan Food Facilities API</title>
-  <meta name="description" content="Japan Food Facilities API が収録する全データソースの出典URL・ライセンスと、各データの出典表示形式に沿った表示文の一覧です。">
+  <title>出典・ライセンス表示 — Japan Food Facilities</title>
+  <meta name="description" content="Japan Food Facilities が収録する全データソースの出典URL・ライセンスと、各データの出典表示形式に沿った表示文の一覧です。">
   <style>
     :root {
       --accent: #e8563f;
@@ -136,7 +136,7 @@
   <div class="wrap">
     <h1>出典・ライセンス表示（Attribution）</h1>
     <p class="lead">
-      <a href="https://gl20percentclub.github.io/japan-food-facilities-api/">Japan Food Facilities API</a> は、各自治体・省庁が公開する食品営業許可・届出のオープンデータを
+      <a href="https://gl20percentclub.github.io/japan-food-facilities/">Japan Food Facilities</a> は、各自治体・省庁が公開する食品営業許可・届出のオープンデータを
       取得し、全国共通フォーマットへの正規化と緯度経度の付与を行って配信しています。
       本ページは収録している全 82 ソースの出典 URL とライセンス、および
       各データが求める出典表示形式に沿った表示文の一覧です。
@@ -149,7 +149,7 @@
     </p>
     <p>全国データをまとめて利用する場合は、次の一括表記でも構いません（個別ソースの一覧として本ページを参照させてください）。</p>
     <div class="callout">
-      <code>出典：Japan Food Facilities API（各自治体・厚生労働省が公開する食品営業許可オープンデータを加工して作成）<br>https://gl20percentclub.github.io/japan-food-facilities-api/attribution.html</code>
+      <code>出典：Japan Food Facilities（各自治体・厚生労働省が公開する食品営業許可オープンデータを加工して作成）<br>https://gl20percentclub.github.io/japan-food-facilities/attribution.html</code>
     </div>
     <p class="lead" style="margin-top:12px">
       緯度経度は本サービスが住所からジオコーディングして独自に付与した参考情報であり、各自治体が提供しているものではありません。
@@ -1343,13 +1343,13 @@
 
     <footer>
       <p>
-        このページは <a href="https://github.com/gl20percentclub/japan-food-facilities-api/blob/main/config/sources.yaml">config/sources.yaml</a> から
-        <a href="https://github.com/gl20percentclub/japan-food-facilities-api/blob/main/scripts/gen-attribution.js">scripts/gen-attribution.js</a> が自動生成しています。
-        誤りを見つけた場合は <a href="https://github.com/gl20percentclub/japan-food-facilities-api/issues">Issue</a> でお知らせください。
+        このページは <a href="https://github.com/gl20percentclub/japan-food-facilities/blob/main/config/sources.yaml">config/sources.yaml</a> から
+        <a href="https://github.com/gl20percentclub/japan-food-facilities/blob/main/scripts/gen-attribution.js">scripts/gen-attribution.js</a> が自動生成しています。
+        誤りを見つけた場合は <a href="https://github.com/gl20percentclub/japan-food-facilities/issues">Issue</a> でお知らせください。
       </p>
       <p>
         <a href="./">← トップへ戻る</a> · <a href="./map.html">プレビュー地図</a> ·
-        <a href="https://github.com/gl20percentclub/japan-food-facilities-api">GitHub リポジトリ</a>
+        <a href="https://github.com/gl20percentclub/japan-food-facilities">GitHub リポジトリ</a>
       </p>
     </footer>
   </div>

--- a/index.html
+++ b/index.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Japan Food Facilities API — 日本全国の飲食施設オープンデータを無料の静的 API で</title>
+  <title>Japan Food Facilities — 日本全国の飲食施設オープンデータを無料の静的 API で</title>
   <meta name="description" content="全国の自治体が公開する食品営業許可・届出のオープンデータを、正規化・ジオコーディングして無料で配信。登録不要・API キー不要で、全件 CSV とベクトルタイルをそのまま利用できます。">
 
   <!-- SNS シェア時のカード表示（画像は用意していないためテキストのみ） -->
   <meta property="og:type" content="website">
-  <meta property="og:title" content="Japan Food Facilities API">
+  <meta property="og:title" content="Japan Food Facilities">
   <meta property="og:description" content="日本全国の飲食施設オープンデータ（食品営業許可・届出）を、登録不要・無料の静的 API として配信。">
-  <meta property="og:url" content="https://gl20percentclub.github.io/japan-food-facilities-api/">
+  <meta property="og:url" content="https://gl20percentclub.github.io/japan-food-facilities/">
   <meta name="twitter:card" content="summary">
 
   <style>
@@ -174,7 +174,7 @@
         <a class="btn primary" href="#quickstart">クイックスタート</a>
         <a class="btn ghost" href="./playground.html">検索プレイグラウンド</a>
         <a class="btn ghost" href="./map.html">地図で見てみる</a>
-        <a class="btn ghost" href="https://github.com/gl20percentclub/japan-food-facilities-api">GitHub</a>
+        <a class="btn ghost" href="https://github.com/gl20percentclub/japan-food-facilities">GitHub</a>
       </div>
 
       <!-- 統計は配信中の api/ から読み込んで更新する（取得できなければ下の既定値のまま） -->
@@ -235,16 +235,16 @@
       <h2>クイックスタート</h2>
       <p class="lead">
         配信しているのは <strong>全件CSV</strong>・<strong>ベクトルタイル</strong>・<strong>検索用 Parquet</strong> の3つだけです。
-        ベース URL は <code>https://gl20percentclub.github.io/japan-food-facilities-api/api/</code>。
+        ベース URL は <code>https://gl20percentclub.github.io/japan-food-facilities/api/</code>。
       </p>
 
       <p class="step">1. 全件CSV をダウンロードする（約 540MB）</p>
-<pre><code>curl -O https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv</code></pre>
+<pre><code>curl -O https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv</code></pre>
 
       <p class="step">2. pandas で読み込む（URL 直指定でもいけます）</p>
 <pre><code>import pandas as pd
 
-df = pd.read_csv('https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv')
+df = pd.read_csv('https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv')
 <span class="c"># 那覇市の飲食店営業だけ抜き出す</span>
 naha = df[(df.city == '那覇市') &amp; (df.business_type == '飲食店営業')]
 print(naha[['name', 'address', 'lat', 'lng']].head())</code></pre>
@@ -252,7 +252,7 @@ print(naha[['name', 'address', 'lat', 'lng']].head())</code></pre>
       <p class="step">3. 地図に出す（MapLibre GL JS・タイルサーバー不要）</p>
 <pre><code>map.addSource('facilities', {
   type: 'vector',
-  tiles: ['https://gl20percentclub.github.io/japan-food-facilities-api/api/tiles/{z}/{x}/{y}.pbf'],
+  tiles: ['https://gl20percentclub.github.io/japan-food-facilities/api/tiles/{z}/{x}/{y}.pbf'],
   minzoom: 6, maxzoom: 12,
 });
 <span class="c">// レイヤ名は "facilities"、属性は name / business_type / pref / city</span></code></pre>
@@ -298,8 +298,8 @@ print(naha[['name', 'address', 'lat', 'lng']].head())</code></pre>
       </div>
       <p class="lead" style="margin:20px 0 0">
         地域や業種を絞りたい場合は、<a href="./playground.html">検索プレイグラウンド</a>で SQL を組み立てるか、CSV をダウンロードしてフィルタしてください。
-        各列の詳細は <a href="https://github.com/gl20percentclub/japan-food-facilities-api#どんなデータか">README</a>、
-        自治体ごとの収録状況は <a href="https://github.com/gl20percentclub/japan-food-facilities-api/blob/main/docs/COVERAGE.md">収録状況一覧</a> を参照してください。
+        各列の詳細は <a href="https://github.com/gl20percentclub/japan-food-facilities#どんなデータか">README</a>、
+        自治体ごとの収録状況は <a href="https://github.com/gl20percentclub/japan-food-facilities/blob/main/docs/COVERAGE.md">収録状況一覧</a> を参照してください。
       </p>
     </div>
   </section>
@@ -336,8 +336,8 @@ print(naha[['name', 'address', 'lat', 'lng']].head())</code></pre>
         バグ報告・データ品質の問題報告・ドキュメント改善も歓迎です。
       </p>
       <div class="cta" style="justify-content:flex-start">
-        <a class="btn primary" href="https://github.com/gl20percentclub/japan-food-facilities-api#-コントリビューション">コントリビュート方法</a>
-        <a class="btn ghost" href="https://github.com/gl20percentclub/japan-food-facilities-api/issues/new">Issue を立てる</a>
+        <a class="btn primary" href="https://github.com/gl20percentclub/japan-food-facilities#-コントリビューション">コントリビュート方法</a>
+        <a class="btn ghost" href="https://github.com/gl20percentclub/japan-food-facilities/issues/new">Issue を立てる</a>
       </div>
     </div>
   </section>
@@ -348,10 +348,10 @@ print(naha[['name', 'address', 'lat', 'lng']].head())</code></pre>
         <a href="./map.html">プレビュー地図</a> ·
         <a href="./playground.html">検索プレイグラウンド</a> ·
         <a href="./attribution.html">出典・ライセンス</a> ·
-        <a href="https://github.com/gl20percentclub/japan-food-facilities-api">GitHub</a> ·
-        <a href="https://github.com/gl20percentclub/japan-food-facilities-api/issues">Issues</a>
+        <a href="https://github.com/gl20percentclub/japan-food-facilities">GitHub</a> ·
+        <a href="https://github.com/gl20percentclub/japan-food-facilities/issues">Issues</a>
       </p>
-      <p>各自治体が公開するオープンデータを加工して作成 — Japan Food Facilities API</p>
+      <p>各自治体が公開するオープンデータを加工して作成 — Japan Food Facilities</p>
     </div>
   </footer>
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4,12 +4,12 @@
 
 **全国の食品営業許可・届出データを、共通形式で無料配信するオープンデータプロジェクト**
 
-[公式サイト](https://gl20percentclub.github.io/japan-food-facilities-api/) ·
-[地図で見る](https://gl20percentclub.github.io/japan-food-facilities-api/map.html) ·
-[検索プレイグラウンド](https://gl20percentclub.github.io/japan-food-facilities-api/playground.html) ·
-[CSVをダウンロード](https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv) ·
-[収録状況](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities-api/main/docs/COVERAGE.md) ·
-[出典・ライセンス](https://gl20percentclub.github.io/japan-food-facilities-api/attribution.html)
+[公式サイト](https://gl20percentclub.github.io/japan-food-facilities/) ·
+[地図で見る](https://gl20percentclub.github.io/japan-food-facilities/map.html) ·
+[検索プレイグラウンド](https://gl20percentclub.github.io/japan-food-facilities/playground.html) ·
+[CSVをダウンロード](https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv) ·
+[収録状況](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities/main/docs/COVERAGE.md) ·
+[出典・ライセンス](https://gl20percentclub.github.io/japan-food-facilities/attribution.html)
 
 ---
 
@@ -46,20 +46,20 @@
 
 | ファイル | URL |
 |---|---|
-| 全件CSV | https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv |
+| 全件CSV | https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv |
 
 - 文字コード: UTF-8（BOMなし）
 - 全列が一致する重複レコードは除去済み
 
 ```bash
-curl -O https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv
+curl -O https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv
 ```
 
 ```python
 import pandas as pd
 
 df = pd.read_csv(
-    "https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv"
+    "https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv"
 )
 ```
 
@@ -73,7 +73,7 @@ df = pd.read_csv(
 map.addSource("facilities", {
   type: "vector",
   tiles: [
-    "https://gl20percentclub.github.io/japan-food-facilities-api/api/tiles/{z}/{x}/{y}.pbf",
+    "https://gl20percentclub.github.io/japan-food-facilities/api/tiles/{z}/{x}/{y}.pbf",
   ],
   minzoom: 6,
   maxzoom: 12,
@@ -82,9 +82,9 @@ map.addSource("facilities", {
 
 - レイヤー名: `facilities`
 - 主な属性: `name` / `business_type` / `pref` / `city`
-- 詳細: [`api/tiles/metadata.json`](https://gl20percentclub.github.io/japan-food-facilities-api/api/tiles/metadata.json)
+- 詳細: [`api/tiles/metadata.json`](https://gl20percentclub.github.io/japan-food-facilities/api/tiles/metadata.json)
 
-収録データは[プレビュー地図](https://gl20percentclub.github.io/japan-food-facilities-api/map.html)でも確認できます。
+収録データは[プレビュー地図](https://gl20percentclub.github.io/japan-food-facilities/map.html)でも確認できます。
 
 ### 検索用Parquet
 
@@ -92,17 +92,17 @@ map.addSource("facilities", {
 
 | ファイル | URL |
 |---|---|
-| 都道府県別Parquet | `https://gl20percentclub.github.io/japan-food-facilities-api/api/parquet/{都道府県コード}.parquet` |
-| ファイル一覧（manifest） | https://gl20percentclub.github.io/japan-food-facilities-api/api/parquet/manifest.json |
+| 都道府県別Parquet | `https://gl20percentclub.github.io/japan-food-facilities/api/parquet/{都道府県コード}.parquet` |
+| ファイル一覧（manifest） | https://gl20percentclub.github.io/japan-food-facilities/api/parquet/manifest.json |
 
 - 都道府県コードは JIS X 0401（`01`=北海道 〜 `47`=沖縄県、`99`=都道府県不明）
 - 列は全件CSVと同一
-- ブラウザで試すには[検索プレイグラウンド](https://gl20percentclub.github.io/japan-food-facilities-api/playground.html)を利用してください
+- ブラウザで試すには[検索プレイグラウンド](https://gl20percentclub.github.io/japan-food-facilities/playground.html)を利用してください
 
 ```sql
 -- DuckDB（CLI / Python / Wasm）からそのまま検索できます
 SELECT name, business_type, address, lat, lng
-FROM read_parquet('https://gl20percentclub.github.io/japan-food-facilities-api/api/parquet/13.parquet')  -- 13 = 東京都
+FROM read_parquet('https://gl20percentclub.github.io/japan-food-facilities/api/parquet/13.parquet')  -- 13 = 東京都
 WHERE name LIKE '%ラーメン%'
 LIMIT 100;
 ```
@@ -113,8 +113,8 @@ Claude Code や Codex などのコーディングエージェントでこのデ�
 
 | ファイル | URL |
 |---|---|
-| llms.txt（索引） | https://gl20percentclub.github.io/japan-food-facilities-api/llms.txt |
-| llms-full.txt（全仕様） | https://gl20percentclub.github.io/japan-food-facilities-api/llms-full.txt |
+| llms.txt（索引） | https://gl20percentclub.github.io/japan-food-facilities/llms.txt |
+| llms-full.txt（全仕様） | https://gl20percentclub.github.io/japan-food-facilities/llms-full.txt |
 
 ## データ項目
 
@@ -145,7 +145,7 @@ Claude Code や Codex などのコーディングエージェントでこのデ�
 2. 都道府県など、管轄する保健所設置主体のオープンデータ
 3. 厚生労働省「食品衛生申請等システム（i2fas）」のオープンデータ
 
-自治体ごとの収録状況と取得元は、[`docs/COVERAGE.md`](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities-api/main/docs/COVERAGE.md) で確認できます。
+自治体ごとの収録状況と取得元は、[`docs/COVERAGE.md`](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities/main/docs/COVERAGE.md) で確認できます。
 
 ## データの精度と注意事項
 
@@ -193,7 +193,7 @@ GitHub Actionsで毎週月曜18:00 UTC（日本時間 火曜3:00）に更新し�
 
 ```html
 出典:
-<a href="https://github.com/gl20percentclub/japan-food-facilities-api">
+<a href="https://github.com/gl20percentclub/japan-food-facilities">
   Japan Food Facilities Data
 </a>
 （各自治体の食品営業許可オープンデータを加工して作成）
@@ -207,7 +207,7 @@ GitHub Actionsで毎週月曜18:00 UTC（日本時間 火曜3:00）に更新し�
 
 特定自治体のデータだけを利用する場合は、CSVの `sources` 列に記載された自治体名も併記してください。
 
-自治体ごとの出典表示文は、[出典・ライセンス表示ページ](https://gl20percentclub.github.io/japan-food-facilities-api/attribution.html)で確認できます。
+自治体ごとの出典表示文は、[出典・ライセンス表示ページ](https://gl20percentclub.github.io/japan-food-facilities/attribution.html)で確認できます。
 
 ## 免責事項
 
@@ -220,7 +220,7 @@ GitHub Actionsで毎週月曜18:00 UTC（日本時間 火曜3:00）に更新し�
 
 バグ報告、データソース追加、ドキュメント改善、機能提案を歓迎します。
 
-開発環境のセットアップやプルリクエストの手順は、[`CONTRIBUTING.md`](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities-api/main/CONTRIBUTING.md) を参照してください。
+開発環境のセットアップやプルリクエストの手順は、[`CONTRIBUTING.md`](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities/main/CONTRIBUTING.md) を参照してください。
 
 ---
 
@@ -236,7 +236,7 @@ GitHub Actionsで毎週月曜18:00 UTC（日本時間 火曜3:00）に更新し�
 ```sql
 INSTALL httpfs; LOAD httpfs;
 SELECT name, address, lat, lng
-FROM read_csv_auto('https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv.gz')
+FROM read_csv_auto('https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv.gz')
 WHERE prefecture = '沖縄県' AND city = '那覇市' AND business_type = '飲食店営業';
 ```
 
@@ -247,20 +247,20 @@ WHERE prefecture = '沖縄県' AND city = '那覇市' AND business_type = '飲�
 
 ```sql
 SELECT name, business_type, address, lat, lng
-FROM read_parquet('https://gl20percentclub.github.io/japan-food-facilities-api/api/parquet/13.parquet')  -- 13 = 東京都
+FROM read_parquet('https://gl20percentclub.github.io/japan-food-facilities/api/parquet/13.parquet')  -- 13 = 東京都
 WHERE name LIKE '%ラーメン%'
 LIMIT 100;
 ```
 
 ブラウザからは DuckDB-Wasm で同じクエリを実行できる（実装例は
-[検索プレイグラウンド](https://gl20percentclub.github.io/japan-food-facilities-api/playground.html) のソースを参照）。
+[検索プレイグラウンド](https://gl20percentclub.github.io/japan-food-facilities/playground.html) のソースを参照）。
 
 ### pandas で読む
 
 ```python
 import pandas as pd
 
-df = pd.read_csv('https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv.gz')
+df = pd.read_csv('https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv.gz')
 naha = df[(df['prefecture'] == '沖縄県') & (df['city'] == '那覇市')]
 ```
 
@@ -271,7 +271,7 @@ naha = df[(df['prefecture'] == '沖縄県') & (df['city'] == '那覇市')]
 ```js
 map.addSource('facilities', {
   type: 'vector',
-  tiles: ['https://gl20percentclub.github.io/japan-food-facilities-api/api/tiles/{z}/{x}/{y}.pbf'],
+  tiles: ['https://gl20percentclub.github.io/japan-food-facilities/api/tiles/{z}/{x}/{y}.pbf'],
   minzoom: 6,
   maxzoom: 12,
 });
@@ -297,4 +297,4 @@ map.addLayer({
   全文検索や位置検索（「近くのラーメン屋」等）を本格的に提供したい場合は、
   CSV を SQLite や PostgreSQL 等に取り込んで自前の検索を実装する。
 - データ利用時は出典表示が必要（CC BY 4.0）:
-  「© Japan Facilities Data（各自治体オープンデータ）」
+  「© Japan Food Facilities Data（各自治体オープンデータ）」

--- a/llms.txt
+++ b/llms.txt
@@ -1,4 +1,4 @@
-# Japan Facilities Data
+# Japan Food Facilities Data
 
 > 日本全国の食品営業許可・届出施設（飲食店・喫茶店・食品製造業など）を収集し、
 > 全国共通フォーマットの全件CSV・ベクトルタイル・検索用Parquetで無料配信するオープンデータ。
@@ -6,14 +6,14 @@
 
 重要な事実:
 
-- 全件CSV（gzip 推奨）: https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv.gz
-- 全件CSV（非圧縮・約540MB）: https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv
+- 全件CSV（gzip 推奨）: https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv.gz
+- 全件CSV（非圧縮・約540MB）: https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv
 - CSV は UTF-8（BOM付き）。列: prefecture, city, city_raw, name, name_kana,
   business_type, address, lat, lng, geocoding_level, phone, license_no,
   license_date, expire_date, sources, licenses
-- ベクトルタイル（MVT）: https://gl20percentclub.github.io/japan-food-facilities-api/api/tiles/{z}/{x}/{y}.pbf （レイヤ名 facilities、z6–12）
-- 検索用 Parquet（都道府県別・列は CSV と同一）: https://gl20percentclub.github.io/japan-food-facilities-api/api/parquet/{JISコード}.parquet
-  （例: 13.parquet = 東京都。一覧は https://gl20percentclub.github.io/japan-food-facilities-api/api/parquet/manifest.json）
+- ベクトルタイル（MVT）: https://gl20percentclub.github.io/japan-food-facilities/api/tiles/{z}/{x}/{y}.pbf （レイヤ名 facilities、z6–12）
+- 検索用 Parquet（都道府県別・列は CSV と同一）: https://gl20percentclub.github.io/japan-food-facilities/api/parquet/{JISコード}.parquet
+  （例: 13.parquet = 東京都。一覧は https://gl20percentclub.github.io/japan-food-facilities/api/parquet/manifest.json）
 - サーバー型の検索 API や市区町村別 JSON は配信していない。キーワード検索は
   Parquet + DuckDB（CLI / Wasm）、一括抽出は CSV、地図表示はタイルで行う
 - 全ファイル CORS 開放済み（Access-Control-Allow-Origin: *）。URL は更新後も不変
@@ -32,9 +32,9 @@
 
 ## ドキュメント
 
-- [llms-full.txt](https://gl20percentclub.github.io/japan-food-facilities-api/llms-full.txt): データ仕様・利用例・注意事項の全文（まずこれを読む）
-- [README](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities-api/main/README.md): プロジェクト概要
-- [収録状況](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities-api/main/docs/COVERAGE.md): 自治体ごとの収録有無・取得元・ライセンスの一覧
-- [タイルメタデータ](https://gl20percentclub.github.io/japan-food-facilities-api/api/tiles/metadata.json): TileJSON（レイヤ定義・ズーム範囲・bounds）
-- [検索プレイグラウンド](https://gl20percentclub.github.io/japan-food-facilities-api/playground.html): ブラウザ内 DuckDB で Parquet を SQL 検索して試せる
-- [出典・ライセンス表示](https://gl20percentclub.github.io/japan-food-facilities-api/attribution.html): 利用時に必要な出典表示の文例
+- [llms-full.txt](https://gl20percentclub.github.io/japan-food-facilities/llms-full.txt): データ仕様・利用例・注意事項の全文（まずこれを読む）
+- [README](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities/main/README.md): プロジェクト概要
+- [収録状況](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities/main/docs/COVERAGE.md): 自治体ごとの収録有無・取得元・ライセンスの一覧
+- [タイルメタデータ](https://gl20percentclub.github.io/japan-food-facilities/api/tiles/metadata.json): TileJSON（レイヤ定義・ズーム範囲・bounds）
+- [検索プレイグラウンド](https://gl20percentclub.github.io/japan-food-facilities/playground.html): ブラウザ内 DuckDB で Parquet を SQL 検索して試せる
+- [出典・ライセンス表示](https://gl20percentclub.github.io/japan-food-facilities/attribution.html): 利用時に必要な出典表示の文例

--- a/map.html
+++ b/map.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>🍽️ Japan Food Facilities API — データプレビュー地図</title>
+  <title>🍽️ Japan Food Facilities — データプレビュー地図</title>
   <meta name="description" content="日本全国の飲食施設オープンデータ（食品営業許可・届出）を地図上でプレビューできます。">
 
   <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css">
@@ -118,7 +118,7 @@
   <div id="map"></div>
 
   <div class="panel">
-    <h1>🍽️ Japan Food Facilities API</h1>
+    <h1>🍽️ Japan Food Facilities</h1>
     <p class="sub">日本全国の飲食施設オープンデータ（食品営業許可・届出）のプレビュー地図です。</p>
     <div class="stats">
       <div class="stat"><span class="num" id="stat-pref">–</span><span class="lbl">都道府県</span></div>
@@ -129,8 +129,8 @@
       <span class="legend-dot"></span>各点＝1施設
       <span id="updated"></span><br>
       <a href="./">トップ</a> ·
-      <a href="https://github.com/gl20percentclub/japan-food-facilities-api">GitHub リポジトリ</a> ·
-      <a href="https://gl20percentclub.github.io/japan-food-facilities-api/api/facilities-all.csv">全件CSV</a> ·
+      <a href="https://github.com/gl20percentclub/japan-food-facilities">GitHub リポジトリ</a> ·
+      <a href="https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv">全件CSV</a> ·
       <a href="./attribution.html">出典・ライセンス</a>
     </p>
   </div>
@@ -170,7 +170,7 @@
             maxzoom: TILE_MAX_ZOOM,
             bounds: JAPAN_BOUNDS,
             attribution:
-              '施設データ: <a href="https://github.com/gl20percentclub/japan-food-facilities-api" target="_blank" rel="noopener">Japan Food Facilities API</a>'
+              '施設データ: <a href="https://github.com/gl20percentclub/japan-food-facilities" target="_blank" rel="noopener">Japan Food Facilities</a>'
               + '（<a href="./attribution.html">各自治体オープンデータの出典一覧</a>）',
           },
         },

--- a/playground.html
+++ b/playground.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>🛝 検索プレイグラウンド — Japan Food Facilities API</title>
+  <title>🛝 検索プレイグラウンド — Japan Food Facilities</title>
   <meta name="description" content="日本全国の飲食施設オープンデータ（食品営業許可・届出）を、ブラウザ内の DuckDB からその場で検索できるプレイグラウンドです。サーバー不要・登録不要。">
 
   <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css">
@@ -190,7 +190,7 @@
         <a href="./">トップ</a>
         <a href="./map.html">プレビュー地図</a>
         <a href="./attribution.html">出典・ライセンス</a>
-        <a href="https://github.com/gl20percentclub/japan-facilities-api" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://github.com/gl20percentclub/japan-food-facilities" target="_blank" rel="noopener">GitHub</a>
         <span id="meta-line"></span>
       </p>
     </div>

--- a/scripts/gen-attribution.js
+++ b/scripts/gen-attribution.js
@@ -23,9 +23,9 @@ import { loadConfig, ROOT } from './lib/config.js';
 export const OUTPUT_PATH = path.join(ROOT, 'attribution.html');
 
 /** 公開サイトの URL（一括表記の例で使う）。 */
-const SITE_URL = 'https://gl20percentclub.github.io/japan-food-facilities-api/';
+const SITE_URL = 'https://gl20percentclub.github.io/japan-food-facilities/';
 /** リポジトリ URL（ページ内リンクで使う）。 */
-const REPO_URL = 'https://github.com/gl20percentclub/japan-food-facilities-api';
+const REPO_URL = 'https://github.com/gl20percentclub/japan-food-facilities';
 
 /** 都道府県名（`source` の先頭から提供者を推定する際に使う）。 */
 const PREFECTURES = [
@@ -341,8 +341,8 @@ export function renderHtml(entries) {
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>出典・ライセンス表示 — Japan Food Facilities API</title>
-  <meta name="description" content="Japan Food Facilities API が収録する全データソースの出典URL・ライセンスと、各データの出典表示形式に沿った表示文の一覧です。">
+  <title>出典・ライセンス表示 — Japan Food Facilities</title>
+  <meta name="description" content="Japan Food Facilities が収録する全データソースの出典URL・ライセンスと、各データの出典表示形式に沿った表示文の一覧です。">
   <style>
     :root {
       --accent: #e8563f;
@@ -470,7 +470,7 @@ export function renderHtml(entries) {
   <div class="wrap">
     <h1>出典・ライセンス表示（Attribution）</h1>
     <p class="lead">
-      <a href="${SITE_URL}">Japan Food Facilities API</a> は、各自治体・省庁が公開する食品営業許可・届出のオープンデータを
+      <a href="${SITE_URL}">Japan Food Facilities</a> は、各自治体・省庁が公開する食品営業許可・届出のオープンデータを
       取得し、全国共通フォーマットへの正規化と緯度経度の付与を行って配信しています。
       本ページは収録している全 ${entries.length} ソースの出典 URL とライセンス、および
       各データが求める出典表示形式に沿った表示文の一覧です。
@@ -483,7 +483,7 @@ export function renderHtml(entries) {
     </p>
     <p>全国データをまとめて利用する場合は、次の一括表記でも構いません（個別ソースの一覧として本ページを参照させてください）。</p>
     <div class="callout">
-      <code>出典：Japan Food Facilities API（各自治体・厚生労働省が公開する食品営業許可オープンデータを加工して作成）<br>${SITE_URL}attribution.html</code>
+      <code>出典：Japan Food Facilities（各自治体・厚生労働省が公開する食品営業許可オープンデータを加工して作成）<br>${SITE_URL}attribution.html</code>
     </div>
     <p class="lead" style="margin-top:12px">
       緯度経度は本サービスが住所からジオコーディングして独自に付与した参考情報であり、各自治体が提供しているものではありません。

--- a/scripts/gen-llms.js
+++ b/scripts/gen-llms.js
@@ -24,9 +24,9 @@ const ROOT = path.resolve(__dirname, '..');
 const README_PATH = path.join(ROOT, 'README.md');
 
 // 配信 URL の基点。Pages はデータとページの配信先、RAW はリポジトリ内 Markdown の取得先。
-const PAGES = 'https://gl20percentclub.github.io/japan-food-facilities-api';
-const REPO = 'https://github.com/gl20percentclub/japan-food-facilities-api';
-const RAW = 'https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities-api/main';
+const PAGES = 'https://gl20percentclub.github.io/japan-food-facilities';
+const REPO = 'https://github.com/gl20percentclub/japan-food-facilities';
+const RAW = 'https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities/main';
 
 const STATS_START = '<!-- STATS:START -->';
 const STATS_END = '<!-- STATS:END -->';
@@ -86,7 +86,7 @@ export function stripHtmlNoise(markdown) {
  */
 export function renderLlmsTxt(readme) {
   const stats = extractStats(readme);
-  return `# Japan Facilities Data
+  return `# Japan Food Facilities Data
 
 > 日本全国の食品営業許可・届出施設（飲食店・喫茶店・食品製造業など）を収集し、
 > 全国共通フォーマットの全件CSV・ベクトルタイル・検索用Parquetで無料配信するオープンデータ。
@@ -206,7 +206,7 @@ map.addLayer({
   全文検索や位置検索（「近くのラーメン屋」等）を本格的に提供したい場合は、
   CSV を SQLite や PostgreSQL 等に取り込んで自前の検索を実装する。
 - データ利用時は出典表示が必要（CC BY 4.0）:
-  「© Japan Facilities Data（各自治体オープンデータ）」
+  「© Japan Food Facilities Data（各自治体オープンデータ）」
 `;
 }
 

--- a/scripts/gen-llms.test.js
+++ b/scripts/gen-llms.test.js
@@ -28,7 +28,7 @@ console.log('gen-llms テスト\n');
 // テスト用の README（統計ブロック・相対リンク・バッジを含む最小構成）
 const readme = `<div align="center">
 
-# 🍽️ Japan Facilities Data
+# 🍽️ Japan Food Facilities Data
 
 [![Contributors](https://img.shields.io/github/contributors/x)](https://github.com/x)
 
@@ -57,11 +57,11 @@ assert(extractStats('マーカー無し') === '', 'マーカーが無ければ�
 // --- absolutizeLinks ---
 const abs = absolutizeLinks(readme);
 assert(
-  abs.includes('](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities-api/main/docs/COVERAGE.md)'),
+  abs.includes('](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities/main/docs/COVERAGE.md)'),
   '.md への相対リンクは GitHub raw に変換される',
 );
 assert(
-  abs.includes('](https://gl20percentclub.github.io/japan-food-facilities-api/attribution.html)'),
+  abs.includes('](https://gl20percentclub.github.io/japan-food-facilities/attribution.html)'),
   '.html への相対リンクは Pages に変換される',
 );
 assert(abs.includes('](https://example.com/page)'), '絶対 URL は変換されない');
@@ -71,12 +71,12 @@ assert(abs.includes('](#概要)'), 'ページ内アンカーは変換されな�
 const stripped = stripHtmlNoise(readme);
 assert(!stripped.includes('img.shields.io'), 'バッジ行が除去される');
 assert(!stripped.includes('<div'), 'div タグ行が除去される');
-assert(stripped.includes('# 🍽️ Japan Facilities Data'), '見出しは残る');
+assert(stripped.includes('# 🍽️ Japan Food Facilities Data'), '見出しは残る');
 assert(!/\n{3,}/.test(stripped), '3連以上の空行が残らない');
 
 // --- renderLlmsTxt ---
 const llms = renderLlmsTxt(readme);
-assert(llms.startsWith('# Japan Facilities Data'), 'H1 で始まる（llms.txt 仕様）');
+assert(llms.startsWith('# Japan Food Facilities Data'), 'H1 で始まる（llms.txt 仕様）');
 assert(llms.split('\n')[2].startsWith('> '), 'H1 直後に blockquote の要約がある');
 assert(llms.includes('facilities-all.csv.gz'), 'CSV の URL が載る');
 assert(llms.includes('{z}/{x}/{y}.pbf'), 'タイルの URL テンプレートが載る');

--- a/scripts/lib/acquire.js
+++ b/scripts/lib/acquire.js
@@ -9,7 +9,7 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 // bot 対策で User-Agent 等を求めるサーバがあるため、常識的なヘッダを付ける。
 const DEFAULT_HEADERS = {
-  'User-Agent': 'Mozilla/5.0 (compatible; japan-food-facilities-api/1.0; +https://github.com/gl20percentclub/japan-food-facilities-api)',
+  'User-Agent': 'Mozilla/5.0 (compatible; japan-food-facilities/1.0; +https://github.com/gl20percentclub/japan-food-facilities)',
   'Accept-Language': 'ja,en;q=0.8',
   Accept: '*/*',
 };


### PR DESCRIPTION
## 概要
- リポジトリ名を `japan-food-facilities-api` から `japan-food-facilities` に変更するのに合わせ、サイト・ドキュメント・生成スクリプト内の全参照を更新する
- PR #48 / #53 時点で混在していた旧名（`japan-facilities-api`）の残存参照もまとめて解消する

## 変更内容
- GitHub / GitHub Pages / raw の URL をすべて `japan-food-facilities` に統一（`index.html` / `map.html` / `playground.html` / `README.md` / `AGENTS.md` / `scripts/gen-llms.js` / `scripts/gen-attribution.js`）
- クローラーの User-Agent 文字列を `japan-food-facilities/1.0` に更新（`scripts/lib/acquire.js`）
- 表示名を統一: 「Japan Food Facilities API」→「Japan Food Facilities」、「Japan Facilities Data」→「Japan Food Facilities Data」（出典表示文含む）
- `llms.txt` / `llms-full.txt` / `attribution.html` を再生成
- `scripts/gen-llms.test.js` のアサーションを新 URL・新表示名に更新

## テスト計画
- `npm run test:unit` 全合格（gen-llms / gen-attribution / playground 整合性テスト含む）
- `grep` で旧名（`japan-facilities-api` / `japan-food-facilities-api` / `Japan Food Facilities API` / `Japan Facilities Data`）の残存参照ゼロを確認

## 破壊的変更
- **GitHub Pages の URL が変わる**（`gl20percentclub.github.io/japan-food-facilities-api/...` → `.../japan-food-facilities/...`）。GitHub Pages はリポジトリ改名時に旧 URL をリダイレクトしないため、公開済みの CSV / タイル / llms.txt の旧 URL は 404 になる。**先に GitHub 上でリポジトリを `japan-food-facilities` に改名してから本 PR をマージすること**
- クロール成果物（gh-pages の `api/`）はリポジトリ改名に自動追従するが、外部利用者（geosearch 等）への URL 変更の周知が必要

## 関連Issue
なし