### PR TITLE
fix: ライセンス未確定16ソースを attribution.html から除外

### DIFF
--- a/attribution.html
+++ b/attribution.html
@@ -7,8 +7,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>出典・ライセンス表示 — Japan Facilities API</title>
-  <meta name="description" content="Japan Facilities API が収録する全データソースの出典URL・ライセンスと、各データの出典表示形式に沿った表示文の一覧です。">
+  <title>出典・ライセンス表示 — Japan Food Facilities</title>
+  <meta name="description" content="Japan Food Facilities が収録する全データソースの出典URL・ライセンスと、各データの出典表示形式に沿った表示文の一覧です。">
   <style>
     :root {
       --accent: #e8563f;
@@ -136,9 +136,9 @@
   <div class="wrap">
     <h1>出典・ライセンス表示（Attribution）</h1>
     <p class="lead">
-      <a href="https://gl20percentclub.github.io/japan-facilities-api/">Japan Facilities API</a> は、各自治体・省庁が公開する食品営業許可・届出のオープンデータを
+      <a href="https://gl20percentclub.github.io/japan-food-facilities/">Japan Food Facilities</a> は、各自治体・省庁が公開する食品営業許可・届出のオープンデータを
       取得し、全国共通フォーマットへの正規化と緯度経度の付与を行って配信しています。
-      本ページは収録している全 98 ソースの出典 URL とライセンス、および
+      本ページは収録している全 82 ソースの出典 URL とライセンス、および
       各データが求める出典表示形式に沿った表示文の一覧です。
     </p>
 
@@ -149,7 +149,7 @@
     </p>
     <p>全国データをまとめて利用する場合は、次の一括表記でも構いません（個別ソースの一覧として本ページを参照させてください）。</p>
     <div class="callout">
-      <code>出典：Japan Facilities API（各自治体・厚生労働省が公開する食品営業許可オープンデータを加工して作成）<br>https://gl20percentclub.github.io/japan-facilities-api/attribution.html</code>
+      <code>出典：Japan Food Facilities（各自治体・厚生労働省が公開する食品営業許可オープンデータを加工して作成）<br>https://gl20percentclub.github.io/japan-food-facilities/attribution.html</code>
     </div>
     <p class="lead" style="margin-top:12px">
       緯度経度は本サービスが住所からジオコーディングして独自に付与した参考情報であり、各自治体が提供しているものではありません。
@@ -165,8 +165,6 @@
       <li><a href="#cc-by-2-0">CC BY 2.0</a> <span class="count">2</span></li>
       <li><a href="#cc-by">CC BY（バージョン表記なし）</a> <span class="count">17</span></li>
       <li><a href="#pdl-1-0">公共データ利用規約（第1.0版・PDL1.0）</a> <span class="count">2</span></li>
-      <li><a href="#local-terms">自治体独自の利用規約</a> <span class="count">7</span></li>
-      <li><a href="#unconfirmed">ライセンス表記が未確認</a> <span class="count">9</span></li>
       </ul>
     </nav>
 
@@ -1342,248 +1340,16 @@
         </div>
       </article>
     </section>
-    <section class="license" id="local-terms">
-      <h2>自治体独自の利用規約 <span class="count">7 ソース</span></h2>
-      <p class="requirement">各自治体が定める独自の利用規約に従ってください（いずれも出典の明示が必要です）。規約の内容は各行の出典ページから確認できます。</p>
-      <article class="src" id="src-hiroshima-pref">
-        <h3>広島県<span class="dataset">食品営業許可施設一覧</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://www.pref.hiroshima.lg.jp/soshiki/172/eigyoukyokaninnteisisetuitirann.html" target="_blank" rel="noopener">https://www.pref.hiroshima.lg.jp/soshiki/172/eigyoukyokaninnteisisetuitirann.html</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://www.pref.hiroshima.lg.jp/uploaded/attachment/664836.xlsx" target="_blank" rel="noopener">https://www.pref.hiroshima.lg.jp/uploaded/attachment/664836.xlsx</a></dd>
-        </dl>
-        <span class="badge">元の表記: 広島県利用規約</span>
-        <div class="attr">
-          <code>出典：広島県「食品営業許可施設一覧」（https://www.pref.hiroshima.lg.jp/soshiki/172/eigyoukyokaninnteisisetuitirann.html）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：広島県「食品営業許可施設一覧」（https://www.pref.hiroshima.lg.jp/soshiki/172/eigyoukyokaninnteisisetuitirann.html）を加工して作成">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-shiga-pref">
-        <h3>滋賀県<span class="dataset">食品営業許可施設一覧</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://www.pref.shiga.lg.jp/ippan/kurashi/syokunoanzen/300273.html" target="_blank" rel="noopener">https://www.pref.shiga.lg.jp/ippan/kurashi/syokunoanzen/300273.html</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://www.pref.shiga.lg.jp/ippan/kurashi/syokunoanzen/300273.html" target="_blank" rel="noopener">https://www.pref.shiga.lg.jp/ippan/kurashi/syokunoanzen/300273.html</a></dd>
-        </dl>
-        <span class="badge">元の表記: 滋賀県OD利用規約</span>
-        <div class="attr">
-          <code>出典：滋賀県「食品営業許可施設一覧」（https://www.pref.shiga.lg.jp/ippan/kurashi/syokunoanzen/300273.html）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：滋賀県「食品営業許可施設一覧」（https://www.pref.shiga.lg.jp/ippan/kurashi/syokunoanzen/300273.html）を加工して作成">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-ishikawa-pref">
-        <h3>石川県<span class="dataset">営業許可施設一覧</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://www.pref.ishikawa.lg.jp/yakuji/syokuhin/opendate.html" target="_blank" rel="noopener">https://www.pref.ishikawa.lg.jp/yakuji/syokuhin/opendate.html</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://www.pref.ishikawa.lg.jp/yakuji/syokuhin/documents/nendor7.xlsx" target="_blank" rel="noopener">https://www.pref.ishikawa.lg.jp/yakuji/syokuhin/documents/nendor7.xlsx</a></dd>
-        </dl>
-        <span class="badge">元の表記: 石川県利用規約</span>
-        <div class="attr">
-          <code>出典：石川県「営業許可施設一覧」（https://www.pref.ishikawa.lg.jp/yakuji/syokuhin/opendate.html）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：石川県「営業許可施設一覧」（https://www.pref.ishikawa.lg.jp/yakuji/syokuhin/opendate.html）を加工して作成">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-nagano-pref">
-        <h3>長野県<span class="dataset">食品営業許可施設</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/opendata.html" target="_blank" rel="noopener">https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/opendata.html</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv" target="_blank" rel="noopener">https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/document…</a></dd>
-        </dl>
-        <span class="badge">元の表記: 長野県オープンデータ利用規約</span>
-        <div class="attr">
-          <code>出典：長野県「食品営業許可施設」（https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/opendata.html）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：長野県「食品営業許可施設」（https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/opendata.html）を加工して作成">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-fujisawa">
-        <h3>藤沢市<span class="dataset">食品営業許可施設情報</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://www.city.fujisawa.kanagawa.jp/seiei/shokuhineisei/opendatabase.html" target="_blank" rel="noopener">https://www.city.fujisawa.kanagawa.jp/seiei/shokuhineisei/opendatabase.html</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://www.city.fujisawa.kanagawa.jp/seiei/shokuhineisei/opendatabase.html" target="_blank" rel="noopener">https://www.city.fujisawa.kanagawa.jp/seiei/shokuhineisei/opendatabase.…</a></dd>
-        </dl>
-        <span class="badge">元の表記: 藤沢市オープンデータ利用規約</span>
-        <div class="attr">
-          <code>出典：藤沢市「食品営業許可施設情報」（https://www.city.fujisawa.kanagawa.jp/seiei/shokuhineisei/opendatabase.html）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：藤沢市「食品営業許可施設情報」（https://www.city.fujisawa.kanagawa.jp/seiei/shokuhineisei/opendatabase.html）を加工して作成">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-nara-pref">
-        <h3>奈良県<span class="dataset">食品営業許可施設一覧（奈良市を除く）</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://www.pref.nara.lg.jp/n086/52413.html" target="_blank" rel="noopener">https://www.pref.nara.lg.jp/n086/52413.html</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://www.pref.nara.lg.jp/n086/52413.html" target="_blank" rel="noopener">https://www.pref.nara.lg.jp/n086/52413.html</a></dd>
-        </dl>
-        <span class="badge">元の表記: 奈良県（出典明示・利用規約に従う）</span>
-        <div class="attr">
-          <code>出典：奈良県「食品営業許可施設一覧（奈良市を除く）」（https://www.pref.nara.lg.jp/n086/52413.html）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：奈良県「食品営業許可施設一覧（奈良市を除く）」（https://www.pref.nara.lg.jp/n086/52413.html）を加工して作成">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-kashiwa">
-        <h3>柏市<span class="dataset">食品営業許可一覧</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://www.city.kashiwa.lg.jp/databunseki/shiseijoho/jouhoukoukai/opendate/food.html" target="_blank" rel="noopener">https://www.city.kashiwa.lg.jp/databunseki/shiseijoho/jouhoukoukai/opendate/food.html</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://www.city.kashiwa.lg.jp/documents/24912/122173_food_business_all.csv" target="_blank" rel="noopener">https://www.city.kashiwa.lg.jp/documents/24912/122173_food_business_all…</a></dd>
-        </dl>
-        <span class="badge">元の表記: 柏市オープンデータ利用規約</span>
-        <div class="attr">
-          <code>出典：柏市「食品営業許可一覧」（https://www.city.kashiwa.lg.jp/databunseki/shiseijoho/jouhoukoukai/opendate/food.html）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：柏市「食品営業許可一覧」（https://www.city.kashiwa.lg.jp/databunseki/shiseijoho/jouhoukoukai/opendate/food.html）を加工して作成">コピー</button>
-        </div>
-      </article>
-    </section>
-    <section class="license" id="unconfirmed">
-      <h2>ライセンス表記が未確認 <span class="count">9 ソース</span></h2>
-      <p class="requirement">掲載ページでライセンスの明示が確認できなかったソースです。本 API では出典を明示したうえで収録しています。再利用にあたっては、各自治体の利用条件を必ずご自身でご確認ください。</p>
-      <article class="src" id="src-koriyama">
-        <h3>郡山市<span class="dataset">食品営業許可施設一覧</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://www.city.koriyama.lg.jp/soshiki/74/7244.html" target="_blank" rel="noopener">https://www.city.koriyama.lg.jp/soshiki/74/7244.html</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://www.city.koriyama.lg.jp/uploaded/attachment/120902.xls" target="_blank" rel="noopener">https://www.city.koriyama.lg.jp/uploaded/attachment/120902.xls</a></dd>
-        </dl>
-        <span class="badge">元の表記: 要確認</span>
-        <div class="attr">
-          <code>出典：郡山市「食品営業許可施設一覧」（https://www.city.koriyama.lg.jp/soshiki/74/7244.html）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：郡山市「食品営業許可施設一覧」（https://www.city.koriyama.lg.jp/soshiki/74/7244.html）を加工して作成">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-kofu">
-        <h3>甲府市<span class="dataset">食品営業許可施設一覧</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://www.city.kofu.yamanashi.jp/hokenjo/h31-shokuhin/2019-shokuhinkyokaitiran.html" target="_blank" rel="noopener">https://www.city.kofu.yamanashi.jp/hokenjo/h31-shokuhin/2019-shokuhinkyokaitiran.html</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://www.city.kofu.yamanashi.jp/hokenjo/h31-shokuhin/documents/download_20260430143717.zip" target="_blank" rel="noopener">https://www.city.kofu.yamanashi.jp/hokenjo/h31-shokuhin/documents/downl…</a></dd>
-        </dl>
-        <span class="badge">元の表記: 要確認</span>
-        <div class="attr">
-          <code>出典：甲府市「食品営業許可施設一覧」（https://www.city.kofu.yamanashi.jp/hokenjo/h31-shokuhin/2019-shokuhinkyokaitiran.html）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：甲府市「食品営業許可施設一覧」（https://www.city.kofu.yamanashi.jp/hokenjo/h31-shokuhin/2019-shokuhinkyokaitiran.html）を加工して作成">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-matsue">
-        <h3>松江市<span class="dataset">食品営業許可施設一覧</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://www.city.matsue.lg.jp/soshikikarasagasu/kenkofukushibu_hokeneiseika/hokeneisei/4/2226.html" target="_blank" rel="noopener">https://www.city.matsue.lg.jp/soshikikarasagasu/kenkofukushibu_hokeneiseika/hokeneisei/4/2226.html</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://www.city.matsue.lg.jp/material/files/group/50/202605_eigyoukyoka_zenken.xlsx" target="_blank" rel="noopener">https://www.city.matsue.lg.jp/material/files/group/50/202605_eigyoukyok…</a></dd>
-        </dl>
-        <span class="badge">元の表記: 要確認</span>
-        <div class="attr">
-          <code>出典：松江市「食品営業許可施設一覧」（https://www.city.matsue.lg.jp/soshikikarasagasu/kenkofukushibu_hokeneiseika/hokeneisei/4/2226.html）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：松江市「食品営業許可施設一覧」（https://www.city.matsue.lg.jp/soshikikarasagasu/kenkofukushibu_hokeneiseika/hokeneisei/4/2226.html）を加工して作成">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-sendai">
-        <h3>仙台市<span class="dataset">営業許可施設一覧</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://www.city.sendai.jp/sekatsuese-shokuhin/kyokalist/joho.html" target="_blank" rel="noopener">https://www.city.sendai.jp/sekatsuese-shokuhin/kyokalist/joho.html</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://www.city.sendai.jp/sekatsuese-shokuhin/kyokalist/documents/r7shokuhinichiran.zip" target="_blank" rel="noopener">https://www.city.sendai.jp/sekatsuese-shokuhin/kyokalist/documents/r7sh…</a></dd>
-        </dl>
-        <span class="badge">元の表記: 要確認</span>
-        <div class="attr">
-          <code>出典：仙台市「営業許可施設一覧」（https://www.city.sendai.jp/sekatsuese-shokuhin/kyokalist/joho.html）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：仙台市「営業許可施設一覧」（https://www.city.sendai.jp/sekatsuese-shokuhin/kyokalist/joho.html）を加工して作成">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-chiba-city">
-        <h3>千葉市<span class="dataset">食品営業許可施設一覧</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://www.city.chiba.jp/somu/somu/seisakuhomu/shisei/hokenjokankei.html" target="_blank" rel="noopener">https://www.city.chiba.jp/somu/somu/seisakuhomu/shisei/hokenjokankei.html</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://www.city.chiba.jp/somu/somu/seisakuhomu/shisei/documents/202605syokuhin.xlsx" target="_blank" rel="noopener">https://www.city.chiba.jp/somu/somu/seisakuhomu/shisei/documents/202605…</a></dd>
-        </dl>
-        <span class="badge">元の表記: 要確認</span>
-        <div class="attr">
-          <code>出典：千葉市「食品営業許可施設一覧」（https://www.city.chiba.jp/somu/somu/seisakuhomu/shisei/hokenjokankei.html）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：千葉市「食品営業許可施設一覧」（https://www.city.chiba.jp/somu/somu/seisakuhomu/shisei/hokenjokankei.html）を加工して作成">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-shimane-pref">
-        <h3>島根県<span class="dataset">食品営業許可一覧（松江市を除く）</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.html" target="_blank" rel="noopener">https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.html</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.data/R8_05all_02unnnann.xlsx" target="_blank" rel="noopener">https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashiset…</a><br><a href="https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.data/R8_05all_03izumo.xlsx" target="_blank" rel="noopener">https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashiset…</a><br><a href="https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.data/R8_05all_04kenou.xlsx" target="_blank" rel="noopener">https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashiset…</a><br><a href="https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.data/R8_05all_05hamada.xlsx" target="_blank" rel="noopener">https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashiset…</a><br><a href="https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.data/R8_05all_06masuda.xlsx" target="_blank" rel="noopener">https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashiset…</a><br><a href="https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.data/R8_05all_07oki.xlsx" target="_blank" rel="noopener">https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashiset…</a></dd>
-        </dl>
-        <span class="badge">元の表記: 要確認</span>
-        <div class="attr">
-          <code>出典：島根県「食品営業許可一覧（松江市を除く）」（https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.html）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：島根県「食品営業許可一覧（松江市を除く）」（https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.html）を加工して作成">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-itabashi-ku">
-        <h3>板橋区<span class="dataset">東京都板橋区食品営業許可施設一覧</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://www.city.itabashi.tokyo.jp/kenko/eisei/shokuhin/1051220.html" target="_blank" rel="noopener">https://www.city.itabashi.tokyo.jp/kenko/eisei/shokuhin/1051220.html</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://www.city.itabashi.tokyo.jp/_res/projects/default_project/_page_/001/051/220/r8.5_shokuhinkyokashisetsu.xlsx" target="_blank" rel="noopener">https://www.city.itabashi.tokyo.jp/_res/projects/default_project/_page_…</a></dd>
-        </dl>
-        <span class="badge">元の表記: 要確認</span>
-        <div class="attr">
-          <code>出典：板橋区「東京都板橋区食品営業許可施設一覧」（https://www.city.itabashi.tokyo.jp/kenko/eisei/shokuhin/1051220.html）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：板橋区「東京都板橋区食品営業許可施設一覧」（https://www.city.itabashi.tokyo.jp/kenko/eisei/shokuhin/1051220.html）を加工して作成">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-hyogo-pref">
-        <h3>兵庫県<span class="dataset">食品関係営業施設リスト（許可）</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://web.pref.hyogo.lg.jp/kf14/shokuhineigyoushisetsu_list.html" target="_blank" rel="noopener">https://web.pref.hyogo.lg.jp/kf14/shokuhineigyoushisetsu_list.html</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx" target="_blank" rel="noopener">https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisenc…</a></dd>
-        </dl>
-        <span class="badge">元の表記: 要確認</span>
-        <div class="attr">
-          <code>出典：兵庫県「食品関係営業施設リスト（許可）」（https://web.pref.hyogo.lg.jp/kf14/shokuhineigyoushisetsu_list.html）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：兵庫県「食品関係営業施設リスト（許可）」（https://web.pref.hyogo.lg.jp/kf14/shokuhineigyoushisetsu_list.html）を加工して作成">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-toyohashi">
-        <h3>豊橋市<span class="dataset">食品営業許可施設情報（新規）</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://www.city.toyohashi.lg.jp/13766.htm" target="_blank" rel="noopener">https://www.city.toyohashi.lg.jp/13766.htm</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://www.city.toyohashi.lg.jp/secure/18290/shokuhinshinki202605EXCEL.xlsx" target="_blank" rel="noopener">https://www.city.toyohashi.lg.jp/secure/18290/shokuhinshinki202605EXCEL…</a></dd>
-        </dl>
-        <span class="badge">元の表記: 要確認</span>
-        <div class="attr">
-          <code>出典：豊橋市「食品営業許可施設情報（新規）」（https://www.city.toyohashi.lg.jp/13766.htm）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：豊橋市「食品営業許可施設情報（新規）」（https://www.city.toyohashi.lg.jp/13766.htm）を加工して作成">コピー</button>
-        </div>
-      </article>
-    </section>
 
     <footer>
       <p>
-        このページは <a href="https://github.com/gl20percentclub/japan-facilities-api/blob/main/config/sources.yaml">config/sources.yaml</a> から
-        <a href="https://github.com/gl20percentclub/japan-facilities-api/blob/main/scripts/gen-attribution.js">scripts/gen-attribution.js</a> が自動生成しています。
-        誤りを見つけた場合は <a href="https://github.com/gl20percentclub/japan-facilities-api/issues">Issue</a> でお知らせください。
+        このページは <a href="https://github.com/gl20percentclub/japan-food-facilities/blob/main/config/sources.yaml">config/sources.yaml</a> から
+        <a href="https://github.com/gl20percentclub/japan-food-facilities/blob/main/scripts/gen-attribution.js">scripts/gen-attribution.js</a> が自動生成しています。
+        誤りを見つけた場合は <a href="https://github.com/gl20percentclub/japan-food-facilities/issues">Issue</a> でお知らせください。
       </p>
       <p>
         <a href="./">← トップへ戻る</a> · <a href="./map.html">プレビュー地図</a> ·
-        <a href="https://github.com/gl20percentclub/japan-facilities-api">GitHub リポジトリ</a>
+        <a href="https://github.com/gl20percentclub/japan-food-facilities">GitHub リポジトリ</a>
       </p>
     </footer>
   </div>


### PR DESCRIPTION
## 概要

`config/sources.yaml` からは既に除外済みだったライセンス未確定の16ソースが、`attribution.html` の再生成漏れにより出典ページに掲載され続けていた。実際には収録していないソースを「収録ソース」として表示している状態だったため、`npm run build:attribution` で再生成して現状のデータと一致させる。

## 変更内容

`attribution.html` を再生成（手書きの変更はなし）。

- 「ライセンス表記が未確認」9ソース（郡山市・千葉市・板橋区・豊橋市・兵庫県・松江市・仙台市・甲府市・島根県）のセクションを削除
- 「自治体独自の利用規約」7ソース（奈良県・柏市・藤沢市・石川県・長野県・滋賀県・広島県）のセクションを削除
- 収録ソース数を 98 → 82 に更新
- リポジトリ改名（Japan Facilities API → Japan Food Facilities）をタイトル・説明文・リンクに反映（生成元は改名済みで、再生成により自動で解消）

再生成後の内訳: CC BY 4.0 = 50 / CC BY 3.0 = 1 / CC BY 2.1 JP = 10 / CC BY 2.0 = 2 / CC BY（バージョン表記なし）= 17 / PDL1.0 = 2。

## 補足

除外した16ソースの利用規約確認と再収録は crawler リポジトリの issue #1 で追跡している。
https://github.com/gl20percentclub/japan-facilities-crawler/issues/1

規約を実調査して license を埋め直す `fix/attribution-licenses` ブランチが別途あるが、それは issue #1 の解決（再収録）にあたる。本 PR は「配信していないソースを出典ページに載せている」現状を先に解消するための暫定対応で、再収録はその後に行う。

## 確認

- `npm run test:unit` 通過（`gen-attribution` のテストを含む）