### PR TITLE
各自治体の利用規約を確認しライセンス表記を正確化

### DIFF
--- a/attribution.html
+++ b/attribution.html
@@ -7,8 +7,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>出典・ライセンス表示 — Japan Facilities API</title>
-  <meta name="description" content="Japan Facilities API が収録する全データソースの出典URL・ライセンスと、各データの出典表示形式に沿った表示文の一覧です。">
+  <title>出典・ライセンス表示 — Japan Food Facilities</title>
+  <meta name="description" content="Japan Food Facilities が収録する全データソースの出典URL・ライセンスと、各データの出典表示形式に沿った表示文の一覧です。">
   <style>
     :root {
       --accent: #e8563f;
@@ -136,9 +136,9 @@
   <div class="wrap">
     <h1>出典・ライセンス表示（Attribution）</h1>
     <p class="lead">
-      <a href="https://gl20percentclub.github.io/japan-facilities-api/">Japan Facilities API</a> は、各自治体・省庁が公開する食品営業許可・届出のオープンデータを
+      <a href="https://gl20percentclub.github.io/japan-food-facilities/">Japan Food Facilities</a> は、各自治体・省庁が公開する食品営業許可・届出のオープンデータを
       取得し、全国共通フォーマットへの正規化と緯度経度の付与を行って配信しています。
-      本ページは収録している全 98 ソースの出典 URL とライセンス、および
+      本ページは収録している全 82 ソースの出典 URL とライセンス、および
       各データが求める出典表示形式に沿った表示文の一覧です。
     </p>
 
@@ -149,7 +149,7 @@
     </p>
     <p>全国データをまとめて利用する場合は、次の一括表記でも構いません（個別ソースの一覧として本ページを参照させてください）。</p>
     <div class="callout">
-      <code>出典：Japan Facilities API（各自治体・厚生労働省が公開する食品営業許可オープンデータを加工して作成）<br>https://gl20percentclub.github.io/japan-facilities-api/attribution.html</code>
+      <code>出典：Japan Food Facilities（各自治体・厚生労働省が公開する食品営業許可オープンデータを加工して作成）<br>https://gl20percentclub.github.io/japan-food-facilities/attribution.html</code>
     </div>
     <p class="lead" style="margin-top:12px">
       緯度経度は本サービスが住所からジオコーディングして独自に付与した参考情報であり、各自治体が提供しているものではありません。
@@ -159,19 +159,18 @@
     <nav class="toc" aria-label="ライセンス別の目次">
       <strong>ライセンス別の一覧</strong>
       <ul>
-      <li><a href="#cc-by-4-0">CC BY 4.0</a> <span class="count">50</span></li>
+      <li><a href="#cc-by-4-0">CC BY 4.0</a> <span class="count">60</span></li>
       <li><a href="#cc-by-3-0">CC BY 3.0</a> <span class="count">1</span></li>
-      <li><a href="#cc-by-2-1-jp">CC BY 2.1 JP</a> <span class="count">10</span></li>
+      <li><a href="#cc-by-2-1-jp">CC BY 2.1 JP</a> <span class="count">13</span></li>
       <li><a href="#cc-by-2-0">CC BY 2.0</a> <span class="count">2</span></li>
-      <li><a href="#cc-by">CC BY（バージョン表記なし）</a> <span class="count">17</span></li>
-      <li><a href="#pdl-1-0">公共データ利用規約（第1.0版・PDL1.0）</a> <span class="count">2</span></li>
-      <li><a href="#local-terms">自治体独自の利用規約</a> <span class="count">7</span></li>
-      <li><a href="#unconfirmed">ライセンス表記が未確認</a> <span class="count">9</span></li>
+      <li><a href="#cc-by">CC BY（バージョン表記なし）</a> <span class="count">1</span></li>
+      <li><a href="#pdl-1-0">公共データ利用規約（第1.0版・PDL1.0）</a> <span class="count">4</span></li>
+      <li><a href="#cc0-1-0">CC0 1.0</a> <span class="count">1</span></li>
       </ul>
     </nav>
 
     <section class="license" id="cc-by-4-0">
-      <h2>CC BY 4.0 <span class="count">50 ソース</span></h2>
+      <h2>CC BY 4.0 <span class="count">60 ソース</span></h2>
       <p class="requirement">出典（提供者名・データセット名・出典 URL）の明示と、改変した旨の表示が必要です。本 API は正規化・緯度経度付与などの加工を行っているため、「加工して作成」の旨を必ず含めてください。 — <a href="https://creativecommons.org/licenses/by/4.0/deed.ja" target="_blank" rel="noopener">ライセンス本文</a></p>
       <article class="src" id="src-iwaki">
         <h3>いわき市<span class="dataset">食品営業許可施設一覧</span></h3>
@@ -255,6 +254,20 @@
         <div class="attr">
           <code>出典：沖縄県「食品営業許可・届出」（https://data.bodik.jp/dataset/90559956-0f04-42cf-9e96-91598a527d03）を加工して作成（CC BY 4.0）</code>
           <button type="button" class="copy" data-copy="出典：沖縄県「食品営業許可・届出」（https://data.bodik.jp/dataset/90559956-0f04-42cf-9e96-91598a527d03）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-shimonoseki">
+        <h3>下関市<span class="dataset">食品営業許可施設一覧（マップ用）</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://yamaguchi-opendata.jp/ckan/dataset/50c21bfa-4ee1-4553-b166-8ed2e625a6f5" target="_blank" rel="noopener">https://yamaguchi-opendata.jp/ckan/dataset/50c21bfa-4ee1-4553-b166-8ed2e625a6f5</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://yamaguchi-opendata.jp/ckan/dataset/50c21bfa-4ee1-4553-b166-8ed2e625a6f5/resource/f61a61f9-a9ca-448f-8e48-38f647fd2539/download/352012_food_business_map.csv" target="_blank" rel="noopener">https://yamaguchi-opendata.jp/ckan/dataset/50c21bfa-4ee1-4553-b166-8ed2…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：下関市「食品営業許可施設一覧（マップ用）」（https://yamaguchi-opendata.jp/ckan/dataset/50c21bfa-4ee1-4553-b166-8ed2e625a6f5）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：下関市「食品営業許可施設一覧（マップ用）」（https://yamaguchi-opendata.jp/ckan/dataset/50c21bfa-4ee1-4553-b166-8ed2e625a6f5）を加工して作成（CC BY 4.0）">コピー</button>
         </div>
       </article>
       <article class="src" id="src-chigasaki">
@@ -355,6 +368,20 @@
           <button type="button" class="copy" data-copy="出典：高崎市「食品営業許可施設一覧」（https://www.city.takasaki.gunma.jp/page/4527.html）を加工して作成（CC BY 4.0）">コピー</button>
         </div>
       </article>
+      <article class="src" id="src-takamatsu">
+        <h3>高松市<span class="dataset">食品等営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://opendata.smartcity-takamatsu.jp/ckan/dataset/licensed_food_business_facility_list" target="_blank" rel="noopener">https://opendata.smartcity-takamatsu.jp/ckan/dataset/licensed_food_business_facility_list</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://opendata.takamatsu-fact.com/licensed_food_business_facility_list/data.csv" target="_blank" rel="noopener">https://opendata.takamatsu-fact.com/licensed_food_business_facility_lis…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：高松市「食品等営業許可施設一覧」（https://opendata.smartcity-takamatsu.jp/ckan/dataset/licensed_food_business_facility_list）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：高松市「食品等営業許可施設一覧」（https://opendata.smartcity-takamatsu.jp/ckan/dataset/licensed_food_business_facility_list）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
       <article class="src" id="src-bodik-571df2fc">
         <h3>佐世保市<span class="dataset">［佐世保市］食品営業許可施設一覧</span></h3>
         <dl>
@@ -423,6 +450,20 @@
         <div class="attr">
           <code>出典：山形市「食品営業許可・届出施設一覧」（https://www.city.yamagata-yamagata.lg.jp/kenkofukushi/eisei/1006555/1006558/1012802.html）を加工して作成（CC BY 4.0）</code>
           <button type="button" class="copy" data-copy="出典：山形市「食品営業許可・届出施設一覧」（https://www.city.yamagata-yamagata.lg.jp/kenkofukushi/eisei/1006555/1006558/1012802.html）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-yamaguchi-pref">
+        <h3>山口県<span class="dataset">食品営業許可施設情報一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://yamaguchi-opendata.jp/ckan/dataset/9d0d2325-62b4-447c-8817-a381c968a5cd" target="_blank" rel="noopener">https://yamaguchi-opendata.jp/ckan/dataset/9d0d2325-62b4-447c-8817-a381c968a5cd</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://yamaguchi-opendata.jp/ckan/dataset/9d0d2325-62b4-447c-8817-a381c968a5cd/resource/44efb857-48c7-4a2e-9e99-61bf38f6f125/download/350001_food_business_all.csv" target="_blank" rel="noopener">https://yamaguchi-opendata.jp/ckan/dataset/9d0d2325-62b4-447c-8817-a381…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：山口県「食品営業許可施設情報一覧」（https://yamaguchi-opendata.jp/ckan/dataset/9d0d2325-62b4-447c-8817-a381c968a5cd）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：山口県「食品営業許可施設情報一覧」（https://yamaguchi-opendata.jp/ckan/dataset/9d0d2325-62b4-447c-8817-a381c968a5cd）を加工して作成（CC BY 4.0）">コピー</button>
         </div>
       </article>
       <article class="src" id="src-bodik-e5809d89">
@@ -495,6 +536,20 @@
           <button type="button" class="copy" data-copy="出典：渋谷区「東京都渋谷区食品等営業許可・届出一覧」（https://city-shibuya-data.opendata.arcgis.com/items/e68f41ebfa5f4ea490ca9af701d44e02）を加工して作成（CC BY 4.0）">コピー</button>
         </div>
       </article>
+      <article class="src" id="src-matsuyama">
+        <h3>松山市<span class="dataset">食品営業許可全施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.html" target="_blank" rel="noopener">https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.files/382019_food_business_all_2026031.csv" target="_blank" rel="noopener">https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.f…</a><br><a href="https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.files/382019_food_business_all_2026032.csv" target="_blank" rel="noopener">https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.f…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：松山市「食品営業許可全施設一覧」（https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.html）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：松山市「食品営業許可全施設一覧」（https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.html）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
       <article class="src" id="src-shinjuku-ku">
         <h3>新宿区<span class="dataset">東京都新宿区食品等営業許可・届出一覧</span></h3>
         <dl>
@@ -563,6 +618,20 @@
         <div class="attr">
           <code>出典：青森市「食品営業許可施設一覧」（https://www.city.aomori.aomori.jp/shisei/jouhokoukai/opendata/1006170/1006184.html）を加工して作成（CC BY 4.0）</code>
           <button type="button" class="copy" data-copy="出典：青森市「食品営業許可施設一覧」（https://www.city.aomori.aomori.jp/shisei/jouhokoukai/opendata/1006170/1006184.html）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-bodik-86a8d652">
+        <h3>静岡市<span class="dataset">食品衛生関係営業許可台帳</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.bodik.jp/dataset/86a8d652-beb2-41b7-8da6-f9245e04217d" target="_blank" rel="noopener">https://data.bodik.jp/dataset/86a8d652-beb2-41b7-8da6-f9245e04217d</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=76e0c6d1-2332-4ca9-afd5-1ef442733eff" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=76e0c6d1-2332-4ca9-…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：静岡市「食品衛生関係営業許可台帳」（https://data.bodik.jp/dataset/86a8d652-beb2-41b7-8da6-f9245e04217d）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：静岡市「食品衛生関係営業許可台帳」（https://data.bodik.jp/dataset/86a8d652-beb2-41b7-8da6-f9245e04217d）を加工して作成（CC BY 4.0）">コピー</button>
         </div>
       </article>
       <article class="src" id="src-kawasaki">
@@ -775,6 +844,20 @@
           <button type="button" class="copy" data-copy="出典：東大阪市「食品等営業許可一覧」（https://data.bodik.jp/dataset/272272_15）を加工して作成（CC BY 4.0）">コピー</button>
         </div>
       </article>
+      <article class="src" id="src-tokushima-pref">
+        <h3>徳島県<span class="dataset">食品等営業許可・届出一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://opendata.pref.tokushima.lg.jp/dataset/4615.html" target="_blank" rel="noopener">https://opendata.pref.tokushima.lg.jp/dataset/4615.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://opendata.pref.tokushima.lg.jp/dataset/4615/resource/14084/36000_food_business_all.csv" target="_blank" rel="noopener">https://opendata.pref.tokushima.lg.jp/dataset/4615/resource/14084/36000…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：徳島県「食品等営業許可・届出一覧」（https://opendata.pref.tokushima.lg.jp/dataset/4615.html）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：徳島県「食品等営業許可・届出一覧」（https://opendata.pref.tokushima.lg.jp/dataset/4615.html）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
       <article class="src" id="src-bodik-cbd20a26">
         <h3>那覇市<span class="dataset">（継続）食品営業許可施設</span></h3>
         <dl>
@@ -817,6 +900,48 @@
           <button type="button" class="copy" data-copy="出典：品川区「東京都品川区食品衛生許可施設」（https://www.city.shinagawa.tokyo.jp/PC/kenkou/kenkou-eisei/kenkou-eisei-syokuhin/opendate.html）を加工して作成（CC BY 4.0）">コピー</button>
         </div>
       </article>
+      <article class="src" id="src-hamamatsu">
+        <h3>浜松市<span class="dataset">食品衛生台帳（新規）</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://opendata.pref.shizuoka.jp/dataset/11921.html" target="_blank" rel="noopener">https://opendata.pref.shizuoka.jp/dataset/11921.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://static.hamamatsu.odpf.net/opendata/v01/syokuhineiseidaityou202401/syokuhineiseidaityou202401.csv" target="_blank" rel="noopener">https://static.hamamatsu.odpf.net/opendata/v01/syokuhineiseidaityou2024…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：浜松市「食品衛生台帳（新規）」（https://opendata.pref.shizuoka.jp/dataset/11921.html）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：浜松市「食品衛生台帳（新規）」（https://opendata.pref.shizuoka.jp/dataset/11921.html）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-toyama-city">
+        <h3>富山市<span class="dataset">食品営業許可施設</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://opdt.city.toyama.lg.jp/dataset/fb1198c6-3ac2-42fc-ae99-81ea5ba09a2d" target="_blank" rel="noopener">https://opdt.city.toyama.lg.jp/dataset/fb1198c6-3ac2-42fc-ae99-81ea5ba09a2d</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://opdt.city.toyama.lg.jp/dataset/fb1198c6-3ac2-42fc-ae99-81ea5ba09a2d/resource/fa38003f-accd-4690-b71b-96b1d78e1c45/download/syokuhin.xlsx" target="_blank" rel="noopener">https://opdt.city.toyama.lg.jp/dataset/fb1198c6-3ac2-42fc-ae99-81ea5ba0…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：富山市「食品営業許可施設」（https://opdt.city.toyama.lg.jp/dataset/fb1198c6-3ac2-42fc-ae99-81ea5ba09a2d）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：富山市「食品営業許可施設」（https://opdt.city.toyama.lg.jp/dataset/fb1198c6-3ac2-42fc-ae99-81ea5ba09a2d）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-bodik-5925a9fb">
+        <h3>福岡市<span class="dataset">福岡市　飲食店営業等営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.bodik.jp/dataset/5925a9fb-3326-4499-9acd-7b18c03d5e32" target="_blank" rel="noopener">https://data.bodik.jp/dataset/5925a9fb-3326-4499-9acd-7b18c03d5e32</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=70d22acf-2353-4bc1-b45d-f12d45da5216" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=70d22acf-2353-4bc1-…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：福岡市「福岡市　飲食店営業等営業許可施設一覧」（https://data.bodik.jp/dataset/5925a9fb-3326-4499-9acd-7b18c03d5e32）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：福岡市「福岡市　飲食店営業等営業許可施設一覧」（https://data.bodik.jp/dataset/5925a9fb-3326-4499-9acd-7b18c03d5e32）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
       <article class="src" id="src-bodik-2d6870cc">
         <h3>豊中市<span class="dataset">食品等営業許可一覧（豊中市）</span></h3>
         <dl>
@@ -843,6 +968,20 @@
         <div class="attr">
           <code>出典：豊田市「食品営業許可施設一覧（2026年5月31日現在）」（https://data.bodik.jp/dataset/385d18b1-7493-4a82-8b0d-b00d2996da69）を加工して作成（CC BY 4.0）</code>
           <button type="button" class="copy" data-copy="出典：豊田市「食品営業許可施設一覧（2026年5月31日現在）」（https://data.bodik.jp/dataset/385d18b1-7493-4a82-8b0d-b00d2996da69）を加工して作成（CC BY 4.0）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-bodik-822fb681">
+        <h3>北九州市<span class="dataset">北九州市　食品衛生法等許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.bodik.jp/dataset/822fb681-346a-444e-b482-33c67b50cac3" target="_blank" rel="noopener">https://data.bodik.jp/dataset/822fb681-346a-444e-b482-33c67b50cac3</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=dab2c5a1-393e-4bd2-9bab-7350296a05da" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=dab2c5a1-393e-4bd2-…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：北九州市「北九州市　食品衛生法等許可施設一覧」（https://data.bodik.jp/dataset/822fb681-346a-444e-b482-33c67b50cac3）を加工して作成（CC BY 4.0）</code>
+          <button type="button" class="copy" data-copy="出典：北九州市「北九州市　食品衛生法等許可施設一覧」（https://data.bodik.jp/dataset/822fb681-346a-444e-b482-33c67b50cac3）を加工して作成（CC BY 4.0）">コピー</button>
         </div>
       </article>
       <article class="src" id="src-bodik-979f325a">
@@ -893,7 +1032,7 @@
       </article>
     </section>
     <section class="license" id="cc-by-2-1-jp">
-      <h2>CC BY 2.1 JP <span class="count">10 ソース</span></h2>
+      <h2>CC BY 2.1 JP <span class="count">13 ソース</span></h2>
       <p class="requirement">出典の明示と、改変した旨の表示が必要です。 — <a href="https://creativecommons.org/licenses/by/2.1/jp/" target="_blank" rel="noopener">ライセンス本文</a></p>
       <article class="src" id="src-aichi-pref">
         <h3>愛知県<span class="dataset">食品営業者台帳（新規許可）</span></h3>
@@ -907,6 +1046,20 @@
         <div class="attr">
           <code>出典：愛知県「食品営業者台帳（新規許可）」（https://www.pref.aichi.jp/opendata/）を加工して作成（CC BY 2.1 JP）</code>
           <button type="button" class="copy" data-copy="出典：愛知県「食品営業者台帳（新規許可）」（https://www.pref.aichi.jp/opendata/）を加工して作成（CC BY 2.1 JP）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-bodik-f85dc2fb">
+        <h3>久留米市<span class="dataset">久留米市新規食品営業許可施設一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://data.bodik.jp/dataset/f85dc2fb-b148-4ed8-a00e-51a51e953793" target="_blank" rel="noopener">https://data.bodik.jp/dataset/f85dc2fb-b148-4ed8-a00e-51a51e953793</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=c1769ec0-e049-4256-a8c0-c0afd319843d" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=c1769ec0-e049-4256-…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：久留米市「久留米市新規食品営業許可施設一覧」（https://data.bodik.jp/dataset/f85dc2fb-b148-4ed8-a00e-51a51e953793）を加工して作成（CC BY 2.1 JP）</code>
+          <button type="button" class="copy" data-copy="出典：久留米市「久留米市新規食品営業許可施設一覧」（https://data.bodik.jp/dataset/f85dc2fb-b148-4ed8-a00e-51a51e953793）を加工して作成（CC BY 2.1 JP）">コピー</button>
         </div>
       </article>
       <article class="src" id="src-yamanashi-pref">
@@ -965,6 +1118,20 @@
           <button type="button" class="copy" data-copy="出典：大分市「食品営業許可・届出施設一覧」（https://www.city.oita.oita.jp/o095/kenko/hoken/20220908.html）を加工して作成（CC BY 2.1 JP）">コピー</button>
         </div>
       </article>
+      <article class="src" id="src-tottori-city">
+        <h3>鳥取市<span class="dataset">食品等営業許可・届出一覧</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://odp-pref-tottori.tori-info.co.jp/dataset/1858.html" target="_blank" rel="noopener">https://odp-pref-tottori.tori-info.co.jp/dataset/1858.html</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://odp-pref-tottori.tori-info.co.jp/dataset/1858/resource/9560/312011_food_business_all.csv" target="_blank" rel="noopener">https://odp-pref-tottori.tori-info.co.jp/dataset/1858/resource/9560/312…</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：鳥取市「食品等営業許可・届出一覧」（https://odp-pref-tottori.tori-info.co.jp/dataset/1858.html）を加工して作成（CC BY 2.1 JP）</code>
+          <button type="button" class="copy" data-copy="出典：鳥取市「食品等営業許可・届出一覧」（https://odp-pref-tottori.tori-info.co.jp/dataset/1858.html）を加工して作成（CC BY 2.1 JP）">コピー</button>
+        </div>
+      </article>
       <article class="src" id="src-nara-city">
         <h3>奈良市<span class="dataset">食品営業許可施設</span></h3>
         <dl>
@@ -977,6 +1144,20 @@
         <div class="attr">
           <code>出典：奈良市「食品営業許可施設」（https://www.city.nara.lg.jp/soshiki/97/10411.html）を加工して作成（CC BY 2.1 JP）</code>
           <button type="button" class="copy" data-copy="出典：奈良市「食品営業許可施設」（https://www.city.nara.lg.jp/soshiki/97/10411.html）を加工して作成（CC BY 2.1 JP）">コピー</button>
+        </div>
+      </article>
+      <article class="src" id="src-fukui-pref">
+        <h3>福井県<span class="dataset">食品営業許可取得施設</span></h3>
+        <dl>
+          <dt>出典ページ</dt>
+          <dd><a href="https://ckan.odp.jig.jp/dataset/jp-fukui-776-odp" target="_blank" rel="noopener">https://ckan.odp.jig.jp/dataset/jp-fukui-776-odp</a></dd>
+          <dt>取得URL</dt>
+          <dd><a href="https://data.odp.jig.jp/viewcsv/jp/fukui/776.csv" target="_blank" rel="noopener">https://data.odp.jig.jp/viewcsv/jp/fukui/776.csv</a><br><a href="https://data.odp.jig.jp/viewcsv/jp/fukui/777.csv" target="_blank" rel="noopener">https://data.odp.jig.jp/viewcsv/jp/fukui/777.csv</a></dd>
+        </dl>
+        
+        <div class="attr">
+          <code>出典：福井県「食品営業許可取得施設」（https://ckan.odp.jig.jp/dataset/jp-fukui-776-odp）を加工して作成（CC BY 2.1 JP）</code>
+          <button type="button" class="copy" data-copy="出典：福井県「食品営業許可取得施設」（https://ckan.odp.jig.jp/dataset/jp-fukui-776-odp）を加工して作成（CC BY 2.1 JP）">コピー</button>
         </div>
       </article>
       <article class="src" id="src-fukui-city">
@@ -1069,36 +1250,8 @@
       </article>
     </section>
     <section class="license" id="cc-by">
-      <h2>CC BY（バージョン表記なし） <span class="count">17 ソース</span></h2>
+      <h2>CC BY（バージョン表記なし） <span class="count">1 ソース</span></h2>
       <p class="requirement">掲載ページに「CC BY」とのみ記載されており、バージョンが特定できないソースです。CC BY 共通の要件である出典の明示と改変した旨の表示を行ってください（元の表記は各行に併記しています）。 — <a href="https://creativecommons.org/licenses/by/4.0/deed.ja" target="_blank" rel="noopener">ライセンス本文</a></p>
-      <article class="src" id="src-shimonoseki">
-        <h3>下関市<span class="dataset">食品営業許可施設一覧（マップ用）</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://yamaguchi-opendata.jp/ckan/dataset/50c21bfa-4ee1-4553-b166-8ed2e625a6f5" target="_blank" rel="noopener">https://yamaguchi-opendata.jp/ckan/dataset/50c21bfa-4ee1-4553-b166-8ed2e625a6f5</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://yamaguchi-opendata.jp/ckan/dataset/50c21bfa-4ee1-4553-b166-8ed2e625a6f5/resource/f61a61f9-a9ca-448f-8e48-38f647fd2539/download/352012_food_business_map.csv" target="_blank" rel="noopener">https://yamaguchi-opendata.jp/ckan/dataset/50c21bfa-4ee1-4553-b166-8ed2…</a></dd>
-        </dl>
-        <span class="badge">元の表記: CC BY</span>
-        <div class="attr">
-          <code>出典：下関市「食品営業許可施設一覧（マップ用）」（https://yamaguchi-opendata.jp/ckan/dataset/50c21bfa-4ee1-4553-b166-8ed2e625a6f5）を加工して作成（CC BY（バージョン表記なし））</code>
-          <button type="button" class="copy" data-copy="出典：下関市「食品営業許可施設一覧（マップ用）」（https://yamaguchi-opendata.jp/ckan/dataset/50c21bfa-4ee1-4553-b166-8ed2e625a6f5）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-bodik-f85dc2fb">
-        <h3>久留米市<span class="dataset">久留米市新規食品営業許可施設一覧</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://data.bodik.jp/dataset/f85dc2fb-b148-4ed8-a00e-51a51e953793" target="_blank" rel="noopener">https://data.bodik.jp/dataset/f85dc2fb-b148-4ed8-a00e-51a51e953793</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=c1769ec0-e049-4256-a8c0-c0afd319843d" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=c1769ec0-e049-4256-…</a></dd>
-        </dl>
-        <span class="badge">元の表記: Creative Commons Attribution</span>
-        <div class="attr">
-          <code>出典：久留米市「久留米市新規食品営業許可施設一覧」（https://data.bodik.jp/dataset/f85dc2fb-b148-4ed8-a00e-51a51e953793）を加工して作成（CC BY（バージョン表記なし））</code>
-          <button type="button" class="copy" data-copy="出典：久留米市「久留米市新規食品営業許可施設一覧」（https://data.bodik.jp/dataset/f85dc2fb-b148-4ed8-a00e-51a51e953793）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
-        </div>
-      </article>
       <article class="src" id="src-kanazawa">
         <h3>金沢市<span class="dataset">食品衛生関係営業許可施設一覧</span></h3>
         <dl>
@@ -1113,205 +1266,9 @@
           <button type="button" class="copy" data-copy="出典：金沢市「食品衛生関係営業許可施設一覧」（https://catalog-data.city.kanazawa.ishikawa.jp/dataset/172014-syokuhineisei-kyokashisetsu）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
         </div>
       </article>
-      <article class="src" id="src-takamatsu">
-        <h3>高松市<span class="dataset">食品等営業許可施設一覧</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://opendata.smartcity-takamatsu.jp/ckan/dataset/licensed_food_business_facility_list" target="_blank" rel="noopener">https://opendata.smartcity-takamatsu.jp/ckan/dataset/licensed_food_business_facility_list</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://opendata.takamatsu-fact.com/licensed_food_business_facility_list/data.csv" target="_blank" rel="noopener">https://opendata.takamatsu-fact.com/licensed_food_business_facility_lis…</a></dd>
-        </dl>
-        <span class="badge">元の表記: CC BY</span>
-        <div class="attr">
-          <code>出典：高松市「食品等営業許可施設一覧」（https://opendata.smartcity-takamatsu.jp/ckan/dataset/licensed_food_business_facility_list）を加工して作成（CC BY（バージョン表記なし））</code>
-          <button type="button" class="copy" data-copy="出典：高松市「食品等営業許可施設一覧」（https://opendata.smartcity-takamatsu.jp/ckan/dataset/licensed_food_business_facility_list）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-yamaguchi-pref">
-        <h3>山口県<span class="dataset">食品営業許可施設情報一覧</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://yamaguchi-opendata.jp/ckan/dataset/9d0d2325-62b4-447c-8817-a381c968a5cd" target="_blank" rel="noopener">https://yamaguchi-opendata.jp/ckan/dataset/9d0d2325-62b4-447c-8817-a381c968a5cd</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://yamaguchi-opendata.jp/ckan/dataset/9d0d2325-62b4-447c-8817-a381c968a5cd/resource/44efb857-48c7-4a2e-9e99-61bf38f6f125/download/350001_food_business_all.csv" target="_blank" rel="noopener">https://yamaguchi-opendata.jp/ckan/dataset/9d0d2325-62b4-447c-8817-a381…</a></dd>
-        </dl>
-        <span class="badge">元の表記: CC BY</span>
-        <div class="attr">
-          <code>出典：山口県「食品営業許可施設情報一覧」（https://yamaguchi-opendata.jp/ckan/dataset/9d0d2325-62b4-447c-8817-a381c968a5cd）を加工して作成（CC BY（バージョン表記なし））</code>
-          <button type="button" class="copy" data-copy="出典：山口県「食品営業許可施設情報一覧」（https://yamaguchi-opendata.jp/ckan/dataset/9d0d2325-62b4-447c-8817-a381c968a5cd）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-matsuyama">
-        <h3>松山市<span class="dataset">食品営業許可全施設一覧</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.html" target="_blank" rel="noopener">https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.html</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.files/382019_food_business_all_2026031.csv" target="_blank" rel="noopener">https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.f…</a><br><a href="https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.files/382019_food_business_all_2026032.csv" target="_blank" rel="noopener">https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.f…</a></dd>
-        </dl>
-        <span class="badge">元の表記: CC BY</span>
-        <div class="attr">
-          <code>出典：松山市「食品営業許可全施設一覧」（https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.html）を加工して作成（CC BY（バージョン表記なし））</code>
-          <button type="button" class="copy" data-copy="出典：松山市「食品営業許可全施設一覧」（https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.html）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-nishinomiya">
-        <h3>西宮市<span class="dataset">食品営業許可施設一覧</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="http://opendata.nishi.or.jp/opendata/ResultDetail.php?id=9" target="_blank" rel="noopener">http://opendata.nishi.or.jp/opendata/ResultDetail.php?id=9</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="http://opendata.nishi.or.jp/opendata/ResultDetail.php?id=9" target="_blank" rel="noopener">http://opendata.nishi.or.jp/opendata/ResultDetail.php?id=9</a></dd>
-        </dl>
-        <span class="badge">元の表記: CC BY相当</span>
-        <div class="attr">
-          <code>出典：西宮市「食品営業許可施設一覧」（http://opendata.nishi.or.jp/opendata/ResultDetail.php?id=9）を加工して作成（CC BY（バージョン表記なし））</code>
-          <button type="button" class="copy" data-copy="出典：西宮市「食品営業許可施設一覧」（http://opendata.nishi.or.jp/opendata/ResultDetail.php?id=9）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-bodik-86a8d652">
-        <h3>静岡市<span class="dataset">食品衛生関係営業許可台帳</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://data.bodik.jp/dataset/86a8d652-beb2-41b7-8da6-f9245e04217d" target="_blank" rel="noopener">https://data.bodik.jp/dataset/86a8d652-beb2-41b7-8da6-f9245e04217d</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=76e0c6d1-2332-4ca9-afd5-1ef442733eff" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=76e0c6d1-2332-4ca9-…</a></dd>
-        </dl>
-        <span class="badge">元の表記: Creative Commons Attribution</span>
-        <div class="attr">
-          <code>出典：静岡市「食品衛生関係営業許可台帳」（https://data.bodik.jp/dataset/86a8d652-beb2-41b7-8da6-f9245e04217d）を加工して作成（CC BY（バージョン表記なし））</code>
-          <button type="button" class="copy" data-copy="出典：静岡市「食品衛生関係営業許可台帳」（https://data.bodik.jp/dataset/86a8d652-beb2-41b7-8da6-f9245e04217d）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-tottori-city">
-        <h3>鳥取市<span class="dataset">食品等営業許可・届出一覧</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://odp-pref-tottori.tori-info.co.jp/dataset/1858" target="_blank" rel="noopener">https://odp-pref-tottori.tori-info.co.jp/dataset/1858</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://odp-pref-tottori.tori-info.co.jp/dataset/1858/resource/9560/312011_food_business_all.csv" target="_blank" rel="noopener">https://odp-pref-tottori.tori-info.co.jp/dataset/1858/resource/9560/312…</a></dd>
-        </dl>
-        <span class="badge">元の表記: CC BY</span>
-        <div class="attr">
-          <code>出典：鳥取市「食品等営業許可・届出一覧」（https://odp-pref-tottori.tori-info.co.jp/dataset/1858）を加工して作成（CC BY（バージョン表記なし））</code>
-          <button type="button" class="copy" data-copy="出典：鳥取市「食品等営業許可・届出一覧」（https://odp-pref-tottori.tori-info.co.jp/dataset/1858）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-tokushima-pref">
-        <h3>徳島県<span class="dataset">食品等営業許可・届出一覧</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://opendata.pref.tokushima.lg.jp/dataset/4615" target="_blank" rel="noopener">https://opendata.pref.tokushima.lg.jp/dataset/4615</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://opendata.pref.tokushima.lg.jp/dataset/4615/resource/14084/36000_food_business_all.csv" target="_blank" rel="noopener">https://opendata.pref.tokushima.lg.jp/dataset/4615/resource/14084/36000…</a></dd>
-        </dl>
-        <span class="badge">元の表記: CC BY</span>
-        <div class="attr">
-          <code>出典：徳島県「食品等営業許可・届出一覧」（https://opendata.pref.tokushima.lg.jp/dataset/4615）を加工して作成（CC BY（バージョン表記なし））</code>
-          <button type="button" class="copy" data-copy="出典：徳島県「食品等営業許可・届出一覧」（https://opendata.pref.tokushima.lg.jp/dataset/4615）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-hamamatsu">
-        <h3>浜松市<span class="dataset">食品衛生台帳（新規）</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://opendata.pref.shizuoka.jp/dataset/11921.html" target="_blank" rel="noopener">https://opendata.pref.shizuoka.jp/dataset/11921.html</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://static.hamamatsu.odpf.net/opendata/v01/syokuhineiseidaityou202401/syokuhineiseidaityou202401.csv" target="_blank" rel="noopener">https://static.hamamatsu.odpf.net/opendata/v01/syokuhineiseidaityou2024…</a></dd>
-        </dl>
-        <span class="badge">元の表記: CC BY</span>
-        <div class="attr">
-          <code>出典：浜松市「食品衛生台帳（新規）」（https://opendata.pref.shizuoka.jp/dataset/11921.html）を加工して作成（CC BY（バージョン表記なし））</code>
-          <button type="button" class="copy" data-copy="出典：浜松市「食品衛生台帳（新規）」（https://opendata.pref.shizuoka.jp/dataset/11921.html）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-toyama-pref">
-        <h3>富山県<span class="dataset">食品営業許可施設一覧</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://opendata.pref.toyama.jp/dataset/syokuhin" target="_blank" rel="noopener">https://opendata.pref.toyama.jp/dataset/syokuhin</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://toyama-pref.box.com/shared/static/1t6074lluawpua1u5jhx1yeaynb48rle.csv" target="_blank" rel="noopener">https://toyama-pref.box.com/shared/static/1t6074lluawpua1u5jhx1yeaynb48…</a></dd>
-        </dl>
-        <span class="badge">元の表記: CC BY</span>
-        <div class="attr">
-          <code>出典：富山県「食品営業許可施設一覧」（https://opendata.pref.toyama.jp/dataset/syokuhin）を加工して作成（CC BY（バージョン表記なし））</code>
-          <button type="button" class="copy" data-copy="出典：富山県「食品営業許可施設一覧」（https://opendata.pref.toyama.jp/dataset/syokuhin）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-toyama-city">
-        <h3>富山市<span class="dataset">食品営業許可施設</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://opdt.city.toyama.lg.jp/dataset/fb1198c6-3ac2-42fc-ae99-81ea5ba09a2d" target="_blank" rel="noopener">https://opdt.city.toyama.lg.jp/dataset/fb1198c6-3ac2-42fc-ae99-81ea5ba09a2d</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://opdt.city.toyama.lg.jp/dataset/fb1198c6-3ac2-42fc-ae99-81ea5ba09a2d/resource/fa38003f-accd-4690-b71b-96b1d78e1c45/download/syokuhin.xlsx" target="_blank" rel="noopener">https://opdt.city.toyama.lg.jp/dataset/fb1198c6-3ac2-42fc-ae99-81ea5ba0…</a></dd>
-        </dl>
-        <span class="badge">元の表記: CC BY</span>
-        <div class="attr">
-          <code>出典：富山市「食品営業許可施設」（https://opdt.city.toyama.lg.jp/dataset/fb1198c6-3ac2-42fc-ae99-81ea5ba09a2d）を加工して作成（CC BY（バージョン表記なし））</code>
-          <button type="button" class="copy" data-copy="出典：富山市「食品営業許可施設」（https://opdt.city.toyama.lg.jp/dataset/fb1198c6-3ac2-42fc-ae99-81ea5ba09a2d）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-fukui-pref">
-        <h3>福井県<span class="dataset">食品営業許可取得施設</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://ckan.odp.jig.jp/dataset/jp-fukui-776-odp" target="_blank" rel="noopener">https://ckan.odp.jig.jp/dataset/jp-fukui-776-odp</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://data.odp.jig.jp/viewcsv/jp/fukui/776.csv" target="_blank" rel="noopener">https://data.odp.jig.jp/viewcsv/jp/fukui/776.csv</a><br><a href="https://data.odp.jig.jp/viewcsv/jp/fukui/777.csv" target="_blank" rel="noopener">https://data.odp.jig.jp/viewcsv/jp/fukui/777.csv</a></dd>
-        </dl>
-        <span class="badge">元の表記: CC BY</span>
-        <div class="attr">
-          <code>出典：福井県「食品営業許可取得施設」（https://ckan.odp.jig.jp/dataset/jp-fukui-776-odp）を加工して作成（CC BY（バージョン表記なし））</code>
-          <button type="button" class="copy" data-copy="出典：福井県「食品営業許可取得施設」（https://ckan.odp.jig.jp/dataset/jp-fukui-776-odp）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-bodik-5925a9fb">
-        <h3>福岡市<span class="dataset">福岡市　飲食店営業等営業許可施設一覧</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://data.bodik.jp/dataset/5925a9fb-3326-4499-9acd-7b18c03d5e32" target="_blank" rel="noopener">https://data.bodik.jp/dataset/5925a9fb-3326-4499-9acd-7b18c03d5e32</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=70d22acf-2353-4bc1-b45d-f12d45da5216" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=70d22acf-2353-4bc1-…</a></dd>
-        </dl>
-        <span class="badge">元の表記: Creative Commons Attribution</span>
-        <div class="attr">
-          <code>出典：福岡市「福岡市　飲食店営業等営業許可施設一覧」（https://data.bodik.jp/dataset/5925a9fb-3326-4499-9acd-7b18c03d5e32）を加工して作成（CC BY（バージョン表記なし））</code>
-          <button type="button" class="copy" data-copy="出典：福岡市「福岡市　飲食店営業等営業許可施設一覧」（https://data.bodik.jp/dataset/5925a9fb-3326-4499-9acd-7b18c03d5e32）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-fukuyama">
-        <h3>福山市<span class="dataset">営業許認可等施設一覧</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://data.city.fukuyama.hiroshima.jp/dataset/61f415c5-88f7-46d0-8ada-4bb8855685a0" target="_blank" rel="noopener">https://data.city.fukuyama.hiroshima.jp/dataset/61f415c5-88f7-46d0-8ada-4bb8855685a0</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://data.city.fukuyama.hiroshima.jp/dataset/61f415c5-88f7-46d0-8ada-4bb8855685a0/resource/21fec913-dc08-4344-94d1-ffb0068ab147/download/2026_3all.csv" target="_blank" rel="noopener">https://data.city.fukuyama.hiroshima.jp/dataset/61f415c5-88f7-46d0-8ada…</a></dd>
-        </dl>
-        <span class="badge">元の表記: CC BY</span>
-        <div class="attr">
-          <code>出典：福山市「営業許認可等施設一覧」（https://data.city.fukuyama.hiroshima.jp/dataset/61f415c5-88f7-46d0-8ada-4bb8855685a0）を加工して作成（CC BY（バージョン表記なし））</code>
-          <button type="button" class="copy" data-copy="出典：福山市「営業許認可等施設一覧」（https://data.city.fukuyama.hiroshima.jp/dataset/61f415c5-88f7-46d0-8ada-4bb8855685a0）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-bodik-822fb681">
-        <h3>北九州市<span class="dataset">北九州市　食品衛生法等許可施設一覧</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://data.bodik.jp/dataset/822fb681-346a-444e-b482-33c67b50cac3" target="_blank" rel="noopener">https://data.bodik.jp/dataset/822fb681-346a-444e-b482-33c67b50cac3</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=dab2c5a1-393e-4bd2-9bab-7350296a05da" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=dab2c5a1-393e-4bd2-…</a></dd>
-        </dl>
-        <span class="badge">元の表記: Creative Commons Attribution</span>
-        <div class="attr">
-          <code>出典：北九州市「北九州市　食品衛生法等許可施設一覧」（https://data.bodik.jp/dataset/822fb681-346a-444e-b482-33c67b50cac3）を加工して作成（CC BY（バージョン表記なし））</code>
-          <button type="button" class="copy" data-copy="出典：北九州市「北九州市　食品衛生法等許可施設一覧」（https://data.bodik.jp/dataset/822fb681-346a-444e-b482-33c67b50cac3）を加工して作成（CC BY（バージョン表記なし））">コピー</button>
-        </div>
-      </article>
     </section>
     <section class="license" id="pdl-1-0">
-      <h2>公共データ利用規約（第1.0版・PDL1.0） <span class="count">2 ソース</span></h2>
+      <h2>公共データ利用規約（第1.0版・PDL1.0） <span class="count">4 ソース</span></h2>
       <p class="requirement">出典の明示が必要です（商用利用を含めて再利用可・CC BY 4.0 互換）。編集・加工した情報を提供する場合は、加工した旨も併記してください。 — <a href="https://www.digital.go.jp/resources/open_data/public_data_license_v1.0" target="_blank" rel="noopener">ライセンス本文</a></p>
       <article class="src" id="src-kumamoto-city">
         <h3>熊本市<span class="dataset">飲食店営業許可施設一覧</span></h3>
@@ -1341,249 +1298,63 @@
           <button type="button" class="copy" data-copy="出典：厚生労働省「食品衛生申請等システム（オープンデータ）」（https://i2fas.mhlw.go.jp/faspub/IO_S010303.do）を加工して作成（公共データ利用規約（第1.0版・PDL1.0））">コピー</button>
         </div>
       </article>
-    </section>
-    <section class="license" id="local-terms">
-      <h2>自治体独自の利用規約 <span class="count">7 ソース</span></h2>
-      <p class="requirement">各自治体が定める独自の利用規約に従ってください（いずれも出典の明示が必要です）。規約の内容は各行の出典ページから確認できます。</p>
-      <article class="src" id="src-hiroshima-pref">
-        <h3>広島県<span class="dataset">食品営業許可施設一覧</span></h3>
+      <article class="src" id="src-nishinomiya">
+        <h3>西宮市<span class="dataset">食品営業許可施設一覧</span></h3>
         <dl>
           <dt>出典ページ</dt>
-          <dd><a href="https://www.pref.hiroshima.lg.jp/soshiki/172/eigyoukyokaninnteisisetuitirann.html" target="_blank" rel="noopener">https://www.pref.hiroshima.lg.jp/soshiki/172/eigyoukyokaninnteisisetuitirann.html</a></dd>
+          <dd><a href="http://opendata.nishi.or.jp/opendata/ResultDetail.php?id=9" target="_blank" rel="noopener">http://opendata.nishi.or.jp/opendata/ResultDetail.php?id=9</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://www.pref.hiroshima.lg.jp/uploaded/attachment/664836.xlsx" target="_blank" rel="noopener">https://www.pref.hiroshima.lg.jp/uploaded/attachment/664836.xlsx</a></dd>
+          <dd><a href="http://opendata.nishi.or.jp/opendata/ResultDetail.php?id=9" target="_blank" rel="noopener">http://opendata.nishi.or.jp/opendata/ResultDetail.php?id=9</a></dd>
         </dl>
-        <span class="badge">元の表記: 広島県利用規約</span>
+        <span class="badge">元の表記: 公共データ利用規約（第1.0版, PDL1.0）</span>
         <div class="attr">
-          <code>出典：広島県「食品営業許可施設一覧」（https://www.pref.hiroshima.lg.jp/soshiki/172/eigyoukyokaninnteisisetuitirann.html）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：広島県「食品営業許可施設一覧」（https://www.pref.hiroshima.lg.jp/soshiki/172/eigyoukyokaninnteisisetuitirann.html）を加工して作成">コピー</button>
+          <code>出典：西宮市「食品営業許可施設一覧」（http://opendata.nishi.or.jp/opendata/ResultDetail.php?id=9）を加工して作成（公共データ利用規約（第1.0版・PDL1.0））</code>
+          <button type="button" class="copy" data-copy="出典：西宮市「食品営業許可施設一覧」（http://opendata.nishi.or.jp/opendata/ResultDetail.php?id=9）を加工して作成（公共データ利用規約（第1.0版・PDL1.0））">コピー</button>
         </div>
       </article>
-      <article class="src" id="src-shiga-pref">
-        <h3>滋賀県<span class="dataset">食品営業許可施設一覧</span></h3>
+      <article class="src" id="src-fukuyama">
+        <h3>福山市<span class="dataset">営業許認可等施設一覧</span></h3>
         <dl>
           <dt>出典ページ</dt>
-          <dd><a href="https://www.pref.shiga.lg.jp/ippan/kurashi/syokunoanzen/300273.html" target="_blank" rel="noopener">https://www.pref.shiga.lg.jp/ippan/kurashi/syokunoanzen/300273.html</a></dd>
+          <dd><a href="https://data.city.fukuyama.hiroshima.jp/dataset/61f415c5-88f7-46d0-8ada-4bb8855685a0" target="_blank" rel="noopener">https://data.city.fukuyama.hiroshima.jp/dataset/61f415c5-88f7-46d0-8ada-4bb8855685a0</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://www.pref.shiga.lg.jp/ippan/kurashi/syokunoanzen/300273.html" target="_blank" rel="noopener">https://www.pref.shiga.lg.jp/ippan/kurashi/syokunoanzen/300273.html</a></dd>
+          <dd><a href="https://data.city.fukuyama.hiroshima.jp/dataset/61f415c5-88f7-46d0-8ada-4bb8855685a0/resource/21fec913-dc08-4344-94d1-ffb0068ab147/download/2026_3all.csv" target="_blank" rel="noopener">https://data.city.fukuyama.hiroshima.jp/dataset/61f415c5-88f7-46d0-8ada…</a></dd>
         </dl>
-        <span class="badge">元の表記: 滋賀県OD利用規約</span>
+        <span class="badge">元の表記: 公共データ利用規約（第1.0版, PDL1.0）</span>
         <div class="attr">
-          <code>出典：滋賀県「食品営業許可施設一覧」（https://www.pref.shiga.lg.jp/ippan/kurashi/syokunoanzen/300273.html）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：滋賀県「食品営業許可施設一覧」（https://www.pref.shiga.lg.jp/ippan/kurashi/syokunoanzen/300273.html）を加工して作成">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-ishikawa-pref">
-        <h3>石川県<span class="dataset">営業許可施設一覧</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://www.pref.ishikawa.lg.jp/yakuji/syokuhin/opendate.html" target="_blank" rel="noopener">https://www.pref.ishikawa.lg.jp/yakuji/syokuhin/opendate.html</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://www.pref.ishikawa.lg.jp/yakuji/syokuhin/documents/nendor7.xlsx" target="_blank" rel="noopener">https://www.pref.ishikawa.lg.jp/yakuji/syokuhin/documents/nendor7.xlsx</a></dd>
-        </dl>
-        <span class="badge">元の表記: 石川県利用規約</span>
-        <div class="attr">
-          <code>出典：石川県「営業許可施設一覧」（https://www.pref.ishikawa.lg.jp/yakuji/syokuhin/opendate.html）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：石川県「営業許可施設一覧」（https://www.pref.ishikawa.lg.jp/yakuji/syokuhin/opendate.html）を加工して作成">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-nagano-pref">
-        <h3>長野県<span class="dataset">食品営業許可施設</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/opendata.html" target="_blank" rel="noopener">https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/opendata.html</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/documents/food_20260531_csv.csv" target="_blank" rel="noopener">https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/document…</a></dd>
-        </dl>
-        <span class="badge">元の表記: 長野県オープンデータ利用規約</span>
-        <div class="attr">
-          <code>出典：長野県「食品営業許可施設」（https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/opendata.html）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：長野県「食品営業許可施設」（https://www.pref.nagano.lg.jp/shokusei/kenko/shokuhin/seikatsu/opendata.html）を加工して作成">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-fujisawa">
-        <h3>藤沢市<span class="dataset">食品営業許可施設情報</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://www.city.fujisawa.kanagawa.jp/seiei/shokuhineisei/opendatabase.html" target="_blank" rel="noopener">https://www.city.fujisawa.kanagawa.jp/seiei/shokuhineisei/opendatabase.html</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://www.city.fujisawa.kanagawa.jp/seiei/shokuhineisei/opendatabase.html" target="_blank" rel="noopener">https://www.city.fujisawa.kanagawa.jp/seiei/shokuhineisei/opendatabase.…</a></dd>
-        </dl>
-        <span class="badge">元の表記: 藤沢市オープンデータ利用規約</span>
-        <div class="attr">
-          <code>出典：藤沢市「食品営業許可施設情報」（https://www.city.fujisawa.kanagawa.jp/seiei/shokuhineisei/opendatabase.html）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：藤沢市「食品営業許可施設情報」（https://www.city.fujisawa.kanagawa.jp/seiei/shokuhineisei/opendatabase.html）を加工して作成">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-nara-pref">
-        <h3>奈良県<span class="dataset">食品営業許可施設一覧（奈良市を除く）</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://www.pref.nara.lg.jp/n086/52413.html" target="_blank" rel="noopener">https://www.pref.nara.lg.jp/n086/52413.html</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://www.pref.nara.lg.jp/n086/52413.html" target="_blank" rel="noopener">https://www.pref.nara.lg.jp/n086/52413.html</a></dd>
-        </dl>
-        <span class="badge">元の表記: 奈良県（出典明示・利用規約に従う）</span>
-        <div class="attr">
-          <code>出典：奈良県「食品営業許可施設一覧（奈良市を除く）」（https://www.pref.nara.lg.jp/n086/52413.html）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：奈良県「食品営業許可施設一覧（奈良市を除く）」（https://www.pref.nara.lg.jp/n086/52413.html）を加工して作成">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-kashiwa">
-        <h3>柏市<span class="dataset">食品営業許可一覧</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://www.city.kashiwa.lg.jp/databunseki/shiseijoho/jouhoukoukai/opendate/food.html" target="_blank" rel="noopener">https://www.city.kashiwa.lg.jp/databunseki/shiseijoho/jouhoukoukai/opendate/food.html</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://www.city.kashiwa.lg.jp/documents/24912/122173_food_business_all.csv" target="_blank" rel="noopener">https://www.city.kashiwa.lg.jp/documents/24912/122173_food_business_all…</a></dd>
-        </dl>
-        <span class="badge">元の表記: 柏市オープンデータ利用規約</span>
-        <div class="attr">
-          <code>出典：柏市「食品営業許可一覧」（https://www.city.kashiwa.lg.jp/databunseki/shiseijoho/jouhoukoukai/opendate/food.html）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：柏市「食品営業許可一覧」（https://www.city.kashiwa.lg.jp/databunseki/shiseijoho/jouhoukoukai/opendate/food.html）を加工して作成">コピー</button>
+          <code>出典：福山市「営業許認可等施設一覧」（https://data.city.fukuyama.hiroshima.jp/dataset/61f415c5-88f7-46d0-8ada-4bb8855685a0）を加工して作成（公共データ利用規約（第1.0版・PDL1.0））</code>
+          <button type="button" class="copy" data-copy="出典：福山市「営業許認可等施設一覧」（https://data.city.fukuyama.hiroshima.jp/dataset/61f415c5-88f7-46d0-8ada-4bb8855685a0）を加工して作成（公共データ利用規約（第1.0版・PDL1.0））">コピー</button>
         </div>
       </article>
     </section>
-    <section class="license" id="unconfirmed">
-      <h2>ライセンス表記が未確認 <span class="count">9 ソース</span></h2>
-      <p class="requirement">掲載ページでライセンスの明示が確認できなかったソースです。本 API では出典を明示したうえで収録しています。再利用にあたっては、各自治体の利用条件を必ずご自身でご確認ください。</p>
-      <article class="src" id="src-koriyama">
-        <h3>郡山市<span class="dataset">食品営業許可施設一覧</span></h3>
+    <section class="license" id="cc0-1-0">
+      <h2>CC0 1.0 <span class="count">1 ソース</span></h2>
+      <p class="requirement">CC0（パブリックドメイン提供）のため出典表示は法的には不要ですが、本 API ではデータの来歴を示すため出典を明示しています（表示例も同形式で掲載します）。 — <a href="https://creativecommons.org/publicdomain/zero/1.0/deed.ja" target="_blank" rel="noopener">ライセンス本文</a></p>
+      <article class="src" id="src-toyama-pref">
+        <h3>富山県<span class="dataset">食品営業許可施設一覧</span></h3>
         <dl>
           <dt>出典ページ</dt>
-          <dd><a href="https://www.city.koriyama.lg.jp/soshiki/74/7244.html" target="_blank" rel="noopener">https://www.city.koriyama.lg.jp/soshiki/74/7244.html</a></dd>
+          <dd><a href="https://ckan-front.tdcp.pref.toyama.jp/dataset/syokuhin" target="_blank" rel="noopener">https://ckan-front.tdcp.pref.toyama.jp/dataset/syokuhin</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://www.city.koriyama.lg.jp/uploaded/attachment/120902.xls" target="_blank" rel="noopener">https://www.city.koriyama.lg.jp/uploaded/attachment/120902.xls</a></dd>
+          <dd><a href="https://toyama-pref.box.com/shared/static/1t6074lluawpua1u5jhx1yeaynb48rle.csv" target="_blank" rel="noopener">https://toyama-pref.box.com/shared/static/1t6074lluawpua1u5jhx1yeaynb48…</a></dd>
         </dl>
-        <span class="badge">元の表記: 要確認</span>
+        
         <div class="attr">
-          <code>出典：郡山市「食品営業許可施設一覧」（https://www.city.koriyama.lg.jp/soshiki/74/7244.html）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：郡山市「食品営業許可施設一覧」（https://www.city.koriyama.lg.jp/soshiki/74/7244.html）を加工して作成">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-kofu">
-        <h3>甲府市<span class="dataset">食品営業許可施設一覧</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://www.city.kofu.yamanashi.jp/hokenjo/h31-shokuhin/2019-shokuhinkyokaitiran.html" target="_blank" rel="noopener">https://www.city.kofu.yamanashi.jp/hokenjo/h31-shokuhin/2019-shokuhinkyokaitiran.html</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://www.city.kofu.yamanashi.jp/hokenjo/h31-shokuhin/documents/download_20260430143717.zip" target="_blank" rel="noopener">https://www.city.kofu.yamanashi.jp/hokenjo/h31-shokuhin/documents/downl…</a></dd>
-        </dl>
-        <span class="badge">元の表記: 要確認</span>
-        <div class="attr">
-          <code>出典：甲府市「食品営業許可施設一覧」（https://www.city.kofu.yamanashi.jp/hokenjo/h31-shokuhin/2019-shokuhinkyokaitiran.html）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：甲府市「食品営業許可施設一覧」（https://www.city.kofu.yamanashi.jp/hokenjo/h31-shokuhin/2019-shokuhinkyokaitiran.html）を加工して作成">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-matsue">
-        <h3>松江市<span class="dataset">食品営業許可施設一覧</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://www.city.matsue.lg.jp/soshikikarasagasu/kenkofukushibu_hokeneiseika/hokeneisei/4/2226.html" target="_blank" rel="noopener">https://www.city.matsue.lg.jp/soshikikarasagasu/kenkofukushibu_hokeneiseika/hokeneisei/4/2226.html</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://www.city.matsue.lg.jp/material/files/group/50/202605_eigyoukyoka_zenken.xlsx" target="_blank" rel="noopener">https://www.city.matsue.lg.jp/material/files/group/50/202605_eigyoukyok…</a></dd>
-        </dl>
-        <span class="badge">元の表記: 要確認</span>
-        <div class="attr">
-          <code>出典：松江市「食品営業許可施設一覧」（https://www.city.matsue.lg.jp/soshikikarasagasu/kenkofukushibu_hokeneiseika/hokeneisei/4/2226.html）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：松江市「食品営業許可施設一覧」（https://www.city.matsue.lg.jp/soshikikarasagasu/kenkofukushibu_hokeneiseika/hokeneisei/4/2226.html）を加工して作成">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-sendai">
-        <h3>仙台市<span class="dataset">営業許可施設一覧</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://www.city.sendai.jp/sekatsuese-shokuhin/kyokalist/joho.html" target="_blank" rel="noopener">https://www.city.sendai.jp/sekatsuese-shokuhin/kyokalist/joho.html</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://www.city.sendai.jp/sekatsuese-shokuhin/kyokalist/documents/r7shokuhinichiran.zip" target="_blank" rel="noopener">https://www.city.sendai.jp/sekatsuese-shokuhin/kyokalist/documents/r7sh…</a></dd>
-        </dl>
-        <span class="badge">元の表記: 要確認</span>
-        <div class="attr">
-          <code>出典：仙台市「営業許可施設一覧」（https://www.city.sendai.jp/sekatsuese-shokuhin/kyokalist/joho.html）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：仙台市「営業許可施設一覧」（https://www.city.sendai.jp/sekatsuese-shokuhin/kyokalist/joho.html）を加工して作成">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-chiba-city">
-        <h3>千葉市<span class="dataset">食品営業許可施設一覧</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://www.city.chiba.jp/somu/somu/seisakuhomu/shisei/hokenjokankei.html" target="_blank" rel="noopener">https://www.city.chiba.jp/somu/somu/seisakuhomu/shisei/hokenjokankei.html</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://www.city.chiba.jp/somu/somu/seisakuhomu/shisei/documents/202605syokuhin.xlsx" target="_blank" rel="noopener">https://www.city.chiba.jp/somu/somu/seisakuhomu/shisei/documents/202605…</a></dd>
-        </dl>
-        <span class="badge">元の表記: 要確認</span>
-        <div class="attr">
-          <code>出典：千葉市「食品営業許可施設一覧」（https://www.city.chiba.jp/somu/somu/seisakuhomu/shisei/hokenjokankei.html）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：千葉市「食品営業許可施設一覧」（https://www.city.chiba.jp/somu/somu/seisakuhomu/shisei/hokenjokankei.html）を加工して作成">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-shimane-pref">
-        <h3>島根県<span class="dataset">食品営業許可一覧（松江市を除く）</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.html" target="_blank" rel="noopener">https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.html</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.data/R8_05all_02unnnann.xlsx" target="_blank" rel="noopener">https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashiset…</a><br><a href="https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.data/R8_05all_03izumo.xlsx" target="_blank" rel="noopener">https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashiset…</a><br><a href="https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.data/R8_05all_04kenou.xlsx" target="_blank" rel="noopener">https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashiset…</a><br><a href="https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.data/R8_05all_05hamada.xlsx" target="_blank" rel="noopener">https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashiset…</a><br><a href="https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.data/R8_05all_06masuda.xlsx" target="_blank" rel="noopener">https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashiset…</a><br><a href="https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.data/R8_05all_07oki.xlsx" target="_blank" rel="noopener">https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashiset…</a></dd>
-        </dl>
-        <span class="badge">元の表記: 要確認</span>
-        <div class="attr">
-          <code>出典：島根県「食品営業許可一覧（松江市を除く）」（https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.html）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：島根県「食品営業許可一覧（松江市を除く）」（https://www.pref.shimane.lg.jp/life/syoku/anzen/eisei/eigyoukyokashisetu.html）を加工して作成">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-itabashi-ku">
-        <h3>板橋区<span class="dataset">東京都板橋区食品営業許可施設一覧</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://www.city.itabashi.tokyo.jp/kenko/eisei/shokuhin/1051220.html" target="_blank" rel="noopener">https://www.city.itabashi.tokyo.jp/kenko/eisei/shokuhin/1051220.html</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://www.city.itabashi.tokyo.jp/_res/projects/default_project/_page_/001/051/220/r8.5_shokuhinkyokashisetsu.xlsx" target="_blank" rel="noopener">https://www.city.itabashi.tokyo.jp/_res/projects/default_project/_page_…</a></dd>
-        </dl>
-        <span class="badge">元の表記: 要確認</span>
-        <div class="attr">
-          <code>出典：板橋区「東京都板橋区食品営業許可施設一覧」（https://www.city.itabashi.tokyo.jp/kenko/eisei/shokuhin/1051220.html）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：板橋区「東京都板橋区食品営業許可施設一覧」（https://www.city.itabashi.tokyo.jp/kenko/eisei/shokuhin/1051220.html）を加工して作成">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-hyogo-pref">
-        <h3>兵庫県<span class="dataset">食品関係営業施設リスト（許可）</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://web.pref.hyogo.lg.jp/kf14/shokuhineigyoushisetsu_list.html" target="_blank" rel="noopener">https://web.pref.hyogo.lg.jp/kf14/shokuhineigyoushisetsu_list.html</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisence_all.xlsx" target="_blank" rel="noopener">https://web.pref.hyogo.lg.jp/kf14/documents/000028_food_business_lisenc…</a></dd>
-        </dl>
-        <span class="badge">元の表記: 要確認</span>
-        <div class="attr">
-          <code>出典：兵庫県「食品関係営業施設リスト（許可）」（https://web.pref.hyogo.lg.jp/kf14/shokuhineigyoushisetsu_list.html）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：兵庫県「食品関係営業施設リスト（許可）」（https://web.pref.hyogo.lg.jp/kf14/shokuhineigyoushisetsu_list.html）を加工して作成">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-toyohashi">
-        <h3>豊橋市<span class="dataset">食品営業許可施設情報（新規）</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://www.city.toyohashi.lg.jp/13766.htm" target="_blank" rel="noopener">https://www.city.toyohashi.lg.jp/13766.htm</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://www.city.toyohashi.lg.jp/secure/18290/shokuhinshinki202605EXCEL.xlsx" target="_blank" rel="noopener">https://www.city.toyohashi.lg.jp/secure/18290/shokuhinshinki202605EXCEL…</a></dd>
-        </dl>
-        <span class="badge">元の表記: 要確認</span>
-        <div class="attr">
-          <code>出典：豊橋市「食品営業許可施設情報（新規）」（https://www.city.toyohashi.lg.jp/13766.htm）を加工して作成</code>
-          <button type="button" class="copy" data-copy="出典：豊橋市「食品営業許可施設情報（新規）」（https://www.city.toyohashi.lg.jp/13766.htm）を加工して作成">コピー</button>
+          <code>出典：富山県「食品営業許可施設一覧」（https://ckan-front.tdcp.pref.toyama.jp/dataset/syokuhin）を加工して作成（CC0 1.0）</code>
+          <button type="button" class="copy" data-copy="出典：富山県「食品営業許可施設一覧」（https://ckan-front.tdcp.pref.toyama.jp/dataset/syokuhin）を加工して作成（CC0 1.0）">コピー</button>
         </div>
       </article>
     </section>
 
     <footer>
       <p>
-        このページは <a href="https://github.com/gl20percentclub/japan-facilities-api/blob/main/config/sources.yaml">config/sources.yaml</a> から
-        <a href="https://github.com/gl20percentclub/japan-facilities-api/blob/main/scripts/gen-attribution.js">scripts/gen-attribution.js</a> が自動生成しています。
-        誤りを見つけた場合は <a href="https://github.com/gl20percentclub/japan-facilities-api/issues">Issue</a> でお知らせください。
+        このページは <a href="https://github.com/gl20percentclub/japan-food-facilities/blob/main/config/sources.yaml">config/sources.yaml</a> から
+        <a href="https://github.com/gl20percentclub/japan-food-facilities/blob/main/scripts/gen-attribution.js">scripts/gen-attribution.js</a> が自動生成しています。
+        誤りを見つけた場合は <a href="https://github.com/gl20percentclub/japan-food-facilities/issues">Issue</a> でお知らせください。
       </p>
       <p>
         <a href="./">← トップへ戻る</a> · <a href="./map.html">プレビュー地図</a> ·
-        <a href="https://github.com/gl20percentclub/japan-facilities-api">GitHub リポジトリ</a>
+        <a href="https://github.com/gl20percentclub/japan-food-facilities">GitHub リポジトリ</a>
       </p>
     </footer>
   </div>

--- a/config/sources.yaml
+++ b/config/sources.yaml
@@ -268,7 +268,8 @@ sources:
       resourceId: c1769ec0-e049-4256-a8c0-c0afd319843d
     source: 久留米市 久留米市新規食品営業許可施設一覧
     sourceUrl: https://data.bodik.jp/dataset/f85dc2fb-b148-4ed8-a00e-51a51e953793
-    license: Creative Commons Attribution
+    # 久留米市オープンデータ利用規約（https://odcs.bodik.jp/402036/tos/）が表示2.1日本を指定
+    license: CC BY 2.1 JP
   - key: bodik-5a58e9d4
     acquire:
       type: ckan
@@ -336,7 +337,8 @@ sources:
       resourceId: 76e0c6d1-2332-4ca9-afd5-1ef442733eff
     source: 静岡市 食品衛生関係営業許可台帳
     sourceUrl: https://data.bodik.jp/dataset/86a8d652-beb2-41b7-8da6-f9245e04217d
-    license: Creative Commons Attribution
+    # 静岡市オープンデータ利用規約（https://odcs.bodik.jp/221007/tos/）が表示4.0国際を指定
+    license: CC BY 4.0
   - key: bodik-be0e8464
     acquire:
       type: ckan
@@ -392,7 +394,8 @@ sources:
       resourceId: 70d22acf-2353-4bc1-b45d-f12d45da5216
     source: 福岡市 福岡市　飲食店営業等営業許可施設一覧
     sourceUrl: https://data.bodik.jp/dataset/5925a9fb-3326-4499-9acd-7b18c03d5e32
-    license: Creative Commons Attribution
+    # 福岡市オープンデータサイト利用規約（https://odcs.bodik.jp/401307/tos/）が表示4.0国際を指定
+    license: CC BY 4.0
   - key: bodik-2d6870cc
     acquire:
       type: ckan
@@ -416,7 +419,8 @@ sources:
       resourceId: dab2c5a1-393e-4bd2-9bab-7350296a05da
     source: 北九州市 北九州市　食品衛生法等許可施設一覧
     sourceUrl: https://data.bodik.jp/dataset/822fb681-346a-444e-b482-33c67b50cac3
-    license: Creative Commons Attribution
+    # 北九州市オープンデータ利用規約（https://odcs.bodik.jp/401005/tos/）が表示4.0国際を指定
+    license: CC BY 4.0
   - key: bodik-979f325a
     acquire:
       type: ckan
@@ -678,8 +682,9 @@ sources:
       format: csv
       encoding: shift_jis
     source: 富山県食品営業許可施設一覧
-    sourceUrl: https://opendata.pref.toyama.jp/dataset/syokuhin
-    license: CC BY
+    # 旧ポータル閉鎖（2026-05-29）に伴い富山データ連携基盤へ移転。CKAN の license_id は cc-zero
+    sourceUrl: https://ckan-front.tdcp.pref.toyama.jp/dataset/syokuhin
+    license: CC0 1.0
     defaultPref: 富山県
   - key: toyama-city
     acquire:
@@ -688,7 +693,8 @@ sources:
       format: xlsx
     source: 富山市食品営業許可施設
     sourceUrl: https://opdt.city.toyama.lg.jp/dataset/fb1198c6-3ac2-42fc-ae99-81ea5ba09a2d
-    license: CC BY
+    # 富山市オープンデータ利用規約（https://opdt.city.toyama.lg.jp/pages/terms）が表示4.0国際を指定
+    license: CC BY 4.0
     defaultPref: 富山県
     defaultCity: 富山市
   - key: kanazawa
@@ -712,7 +718,8 @@ sources:
       encoding: utf-8
     source: 福井県食品営業許可取得施設
     sourceUrl: https://ckan.odp.jig.jp/dataset/jp-fukui-776-odp
-    license: CC BY
+    # データセットページの追加情報に「CC-BY-2.1」表記あり
+    license: CC BY 2.1 JP
     defaultPref: 福井県
   - key: fukui-city
     acquire:
@@ -789,7 +796,8 @@ sources:
       encoding: shift_jis
     source: 浜松市食品衛生台帳（新規）
     sourceUrl: https://opendata.pref.shizuoka.jp/dataset/11921.html
-    license: CC BY
+    # 静岡県オープンデータポータル利用規約（https://opendata.pref.shizuoka.jp/privacy.html）が表示4.0国際を指定
+    license: CC BY 4.0
     defaultPref: 静岡県
     defaultCity: 浜松市
   - key: aichi-pref
@@ -876,7 +884,8 @@ sources:
       format: xlsx
     source: 西宮市食品営業許可施設一覧
     sourceUrl: http://opendata.nishi.or.jp/opendata/ResultDetail.php?id=9
-    license: CC BY相当
+    # 西宮市オープンデータ利用規約 第2.0版（https://opendata.nishi.or.jp/opendata/kiyaku.pdf）が PDL1.0 を適用
+    license: 公共データ利用規約（第1.0版, PDL1.0）
     defaultPref: 兵庫県
     defaultCity: 西宮市
   - key: nara-city
@@ -897,8 +906,9 @@ sources:
       format: csv
       encoding: utf-8
     source: 鳥取市食品等営業許可・届出一覧
-    sourceUrl: https://odp-pref-tottori.tori-info.co.jp/dataset/1858
-    license: CC BY
+    sourceUrl: https://odp-pref-tottori.tori-info.co.jp/dataset/1858.html
+    # 鳥取県オープンデータポータル利用規約（https://odp-pref-tottori.tori-info.co.jp/agreement.html）が表示2.1日本を指定
+    license: CC BY 2.1 JP
     defaultPref: 鳥取県
     defaultCity: 鳥取市
   - key: fukuyama
@@ -909,7 +919,8 @@ sources:
       encoding: auto
     source: 福山市営業許認可等施設一覧
     sourceUrl: https://data.city.fukuyama.hiroshima.jp/dataset/61f415c5-88f7-46d0-8ada-4bb8855685a0
-    license: CC BY
+    # 福山市オープンデータカタログサイト利用規約（https://data.city.fukuyama.hiroshima.jp/terms）が PDL1.0 を適用
+    license: 公共データ利用規約（第1.0版, PDL1.0）
     defaultPref: 広島県
     defaultCity: 福山市
   - key: yamaguchi-pref
@@ -920,7 +931,8 @@ sources:
       encoding: utf-8
     source: 山口県食品営業許可施設情報一覧
     sourceUrl: https://yamaguchi-opendata.jp/ckan/dataset/9d0d2325-62b4-447c-8817-a381c968a5cd
-    license: CC BY
+    # 山口県オープンデータカタログサイト利用規約（https://yamaguchi-opendata.jp/www/terms.html）が CC BY 4.0 での利用を許諾
+    license: CC BY 4.0
     defaultPref: 山口県
   - key: shimonoseki
     acquire:
@@ -930,7 +942,8 @@ sources:
       encoding: utf-8
     source: 下関市食品営業許可施設一覧（マップ用）
     sourceUrl: https://yamaguchi-opendata.jp/ckan/dataset/50c21bfa-4ee1-4553-b166-8ed2e625a6f5
-    license: CC BY
+    # 山口県オープンデータカタログサイト利用規約（https://yamaguchi-opendata.jp/www/terms.html）が CC BY 4.0 での利用を許諾
+    license: CC BY 4.0
     defaultPref: 山口県
     defaultCity: 下関市
   - key: tokushima-pref
@@ -940,8 +953,9 @@ sources:
       format: csv
       encoding: utf-8
     source: 徳島県食品等営業許可・届出一覧
-    sourceUrl: https://opendata.pref.tokushima.lg.jp/dataset/4615
-    license: CC BY
+    sourceUrl: https://opendata.pref.tokushima.lg.jp/dataset/4615.html
+    # ポータル説明ページ（https://opendata.pref.tokushima.lg.jp/about.html）が表示4.0国際を明記
+    license: CC BY 4.0
     defaultPref: 徳島県
   - key: takamatsu
     acquire:
@@ -951,7 +965,8 @@ sources:
       encoding: utf-8
     source: 高松市食品等営業許可施設一覧
     sourceUrl: https://opendata.smartcity-takamatsu.jp/ckan/dataset/licensed_food_business_facility_list
-    license: CC BY
+    # スマートシティたかまつポータル利用規約（https://opendata.smartcity-takamatsu.jp/odp/tos/）が表示4.0国際を指定
+    license: CC BY 4.0
     defaultPref: 香川県
     defaultCity: 高松市
   - key: matsuyama
@@ -964,7 +979,8 @@ sources:
       encoding: utf-8
     source: 松山市食品営業許可全施設一覧
     sourceUrl: https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.html
-    license: CC BY
+    # 松山市オープンデータサイト（https://www.city.matsuyama.ehime.jp/shisei/opendata/top.html）が表示4.0国際を明記
+    license: CC BY 4.0
     defaultPref: 愛媛県
     defaultCity: 松山市
   - key: kumamoto-city

--- a/scripts/gen-attribution.js
+++ b/scripts/gen-attribution.js
@@ -106,6 +106,16 @@ const LICENSE_GROUPS = [
     noteModified: true,
   },
   {
+    id: 'cc0-1-0',
+    label: 'CC0 1.0',
+    url: 'https://creativecommons.org/publicdomain/zero/1.0/deed.ja',
+    match: ['CC0 1.0', 'CC0', 'Creative Commons CCZero'],
+    requirement:
+      'CC0（パブリックドメイン提供）のため出典表示は法的には不要ですが、'
+      + '本 API ではデータの来歴を示すため出典を明示しています（表示例も同形式で掲載します）。',
+    noteModified: true,
+  },
+  {
     id: 'local-terms',
     label: '自治体独自の利用規約',
     url: null,


### PR DESCRIPTION
## 背景

出典表示ページ（attribution.html）で「CC BY（バージョン表記なし）」に分類されていたソースが17件あった。CKAN カタログのライセンスバッジが Open Definition の汎用 `cc-by`（バージョン無指定）にリンクしているだけで、実際のバージョンはポータル側の利用規約で定められているケースがほとんどだったため、17件すべての利用規約を確認してバージョンを確定した。

## ライセンス表記の修正

| 修正後 | 対象 |
|---|---|
| CC BY 4.0 | 下関市・山口県・静岡市・浜松市・高松市・松山市・富山市・福岡市・北九州市・徳島県 |
| CC BY 2.1 JP | 久留米市・鳥取市・福井県 |
| 公共データ利用規約（第1.0版・PDL1.0） | 西宮市・福山市 |
| CC0 1.0 | 富山県 |

金沢市のみ、利用規約（[opendata_rule.pdf](https://portal-data.city.kanazawa.ishikawa.jp/pdf/opendata_rule.pdf)）が「各データに付されているライセンスの内容に従ってください」としか定めておらずバージョンを指定していないため、「CC BY（バージョン表記なし）」のまま据え置いた。

この結果、当該区分は 17件 → 1件（金沢市のみ）になった。

## リンク切れ・移転の修正

- **富山県**: 旧ポータル `opendata.pref.toyama.jp` が 2026-05-29 に閉鎖され、富山データ連携基盤へ統合されていた（[閉鎖告知](https://www.pref.toyama.jp/140521/kensei/kenseiunei/jouhouka/kj00020546/opendata-togo.html)）。移転先のデータセットは CKAN の `license_id` が `cc-zero` になっていたため、`gen-attribution.js` に CC0 1.0 の区分を追加したうえで出典 URL を差し替えた。取得 URL 自体は移転後も同一のため、クロール処理への影響はない。
- **鳥取市・徳島県**: データセット URL が末尾 `.html` 付きに変更されており、旧 URL は 404 になっていたため更新した。

## 補足

- 各エントリのライセンス判断の根拠（利用規約の URL）は `config/sources.yaml` にコメントとして残した。
- 今回の変更はいずれも CC BY 4.0 での再配信を妨げない。CC BY 2.1 JP は翻案物を後続バージョンでライセンスでき、PDL1.0 は CC BY 4.0 互換、CC0 は制約なしのため。
- `npm run test:unit` 通過済み。