### PR TITLE
配信データの参照先を CloudFront に切り替える

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,17 +2,19 @@
 
 AI コーディングエージェント（Claude Code / Codex 等）向けのガイド。
 このリポジトリは、全国の食品営業許可・届出データを収集・正規化し、
-**全件CSV** と **ベクトルタイル** の2形式で GitHub Pages から無料配信するオープンデータプロジェクト。
+**全件CSV** と **ベクトルタイル** の2形式で無料配信するオープンデータプロジェクト。
+静的ページは GitHub Pages、データ（`api/`）は S3 + CloudFront から配信する。
 
 ## このデータでアプリを作る場合
 
 **まず https://gl20percentclub.github.io/japan-food-facilities/llms-full.txt を読むこと。**
 データ仕様・コピペで動く利用例・注意事項がすべてまとまっている。要点だけ挙げる:
 
-- 全件CSV（gzip）: `https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv.gz`
-  - UTF-8 **BOM付き**、約150万レコード、非圧縮で約540MB
+- 全件CSV: `https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv`
+  - UTF-8 **BOMなし**、100万件超・数百MB（gzip 版は配信していない）。
+    正確な件数・サイズは README の統計ブロック（自動生成）を参照する
   - 列: `prefecture, city, city_raw, name, name_kana, business_type, address, lat, lng, geocoding_level, phone, license_no, license_date, expire_date, sources, licenses`
-- ベクトルタイル（MVT）: `https://gl20percentclub.github.io/japan-food-facilities/api/tiles/{z}/{x}/{y}.pbf`
+- ベクトルタイル（MVT）: `https://d1nptpfogf2ynv.cloudfront.net/api/tiles/{z}/{x}/{y}.pbf`
   - レイヤ名 `facilities`、z6–12、属性 `name` / `business_type` / `pref` / `city`
 - 市区町村別 JSON や検索 API は**このリポジトリからは配信していない**。データ抽出は
   CSV（DuckDB 推奨）、地図表示はタイルを使う。ブラウザから非圧縮 CSV を直接 fetch しない
@@ -61,8 +63,13 @@ attribution.html        # 出典表示ページ（sources.yaml から自動生�
 
 ## 配信の仕組み
 
-- データ（`api/`）は **gh-pages ブランチのみ**で配信。main には置かない（履歴肥大の防止）
-- `crawl.yml`: 毎週月曜 18:00 UTC にクロール → リポジトリ直下ごと gh-pages へ配信（`keep_files: false`）
-- `pages.yml`: 静的ページ（LP・地図・出典・llms.txt）の変更を main への push で反映（`keep_files: true` で `api/` を保護）
-- `publish_dir: .` のため `.gitignore` を配信対象から除外しないと gh-pages 上の `api/` が
-  全消えする事故が起きる（過去に発生済み。workflows.test.js が再発を防いでいる）
+- **データ（`api/`）は S3 + CloudFront で配信**する。ベース URL は
+  `https://d1nptpfogf2ynv.cloudfront.net`（CORS 全オリジン許可済み）。
+  クロールと S3 への配信は別リポジトリ
+  [japan-facilities-crawler](https://github.com/gl20percentclub/japan-facilities-crawler)
+  の Fargate タスクが毎週月曜 18:00 UTC に実行する。このリポジトリでは `api/` を生成も
+  管理もしない（結合CSV は 430MB あり、GitHub の 100MB 制限で Git 配信できないため）
+- `pages.yml`: 静的ページ（LP・地図・出典・llms.txt）の変更を main への push で
+  gh-pages へ反映する
+- `crawl.yml` は gh-pages へデータを配信していた旧構成の名残で、現在は使っていない
+  （停止・削除は別途対応）。設定は `scripts/workflows.test.js` で固定されている

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [公式サイト](https://gl20percentclub.github.io/japan-food-facilities/) ·
 [地図で見る](https://gl20percentclub.github.io/japan-food-facilities/map.html) ·
 [検索プレイグラウンド](https://gl20percentclub.github.io/japan-food-facilities/playground.html) ·
-[CSVをダウンロード](https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv) ·
+[CSVをダウンロード](https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv) ·
 [収録状況](docs/COVERAGE.md) ·
 [出典・ライセンス](https://gl20percentclub.github.io/japan-food-facilities/attribution.html)
 
@@ -53,20 +53,20 @@
 
 | ファイル | URL |
 |---|---|
-| 全件CSV | https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv |
+| 全件CSV | https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv |
 
 - 文字コード: UTF-8（BOMなし）
 - 全列が一致する重複レコードは除去済み
 
 ```bash
-curl -O https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv
+curl -O https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv
 ```
 
 ```python
 import pandas as pd
 
 df = pd.read_csv(
-    "https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv"
+    "https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv"
 )
 ```
 
@@ -80,7 +80,7 @@ df = pd.read_csv(
 map.addSource("facilities", {
   type: "vector",
   tiles: [
-    "https://gl20percentclub.github.io/japan-food-facilities/api/tiles/{z}/{x}/{y}.pbf",
+    "https://d1nptpfogf2ynv.cloudfront.net/api/tiles/{z}/{x}/{y}.pbf",
   ],
   minzoom: 6,
   maxzoom: 12,
@@ -89,7 +89,7 @@ map.addSource("facilities", {
 
 - レイヤー名: `facilities`
 - 主な属性: `name` / `business_type` / `pref` / `city`
-- 詳細: [`api/tiles/metadata.json`](https://gl20percentclub.github.io/japan-food-facilities/api/tiles/metadata.json)
+- 詳細: [`api/tiles/metadata.json`](https://d1nptpfogf2ynv.cloudfront.net/api/tiles/metadata.json)
 
 収録データは[プレビュー地図](https://gl20percentclub.github.io/japan-food-facilities/map.html)でも確認できます。
 

--- a/index.html
+++ b/index.html
@@ -235,16 +235,16 @@
       <h2>クイックスタート</h2>
       <p class="lead">
         配信しているのは <strong>全件CSV</strong> と <strong>ベクトルタイル</strong> の2つだけです。
-        ベース URL は <code>https://gl20percentclub.github.io/japan-food-facilities/api/</code>。
+        ベース URL は <code>https://d1nptpfogf2ynv.cloudfront.net/api/</code>。
       </p>
 
       <p class="step">1. 全件CSV をダウンロードする（約 540MB）</p>
-<pre><code>curl -O https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv</code></pre>
+<pre><code>curl -O https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv</code></pre>
 
       <p class="step">2. pandas で読み込む（URL 直指定でもいけます）</p>
 <pre><code>import pandas as pd
 
-df = pd.read_csv('https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv')
+df = pd.read_csv('https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv')
 <span class="c"># 那覇市の飲食店営業だけ抜き出す</span>
 naha = df[(df.city == '那覇市') &amp; (df.business_type == '飲食店営業')]
 print(naha[['name', 'address', 'lat', 'lng']].head())</code></pre>
@@ -252,7 +252,7 @@ print(naha[['name', 'address', 'lat', 'lng']].head())</code></pre>
       <p class="step">3. 地図に出す（MapLibre GL JS・タイルサーバー不要）</p>
 <pre><code>map.addSource('facilities', {
   type: 'vector',
-  tiles: ['https://gl20percentclub.github.io/japan-food-facilities/api/tiles/{z}/{x}/{y}.pbf'],
+  tiles: ['https://d1nptpfogf2ynv.cloudfront.net/api/tiles/{z}/{x}/{y}.pbf'],
   minzoom: 6, maxzoom: 12,
 });
 <span class="c">// レイヤ名は "facilities"、属性は name / business_type / pref / city</span></code></pre>
@@ -354,7 +354,9 @@ print(naha[['name', 'address', 'lat', 'lng']].head())</code></pre>
   <script>
     // 配信中の api/ から件数を読み、ヒーローの統計を最新の値に差し替える。
     // 取得できない場合は HTML に書かれた既定値をそのまま残す（表示は壊さない）。
-    const API_BASE = './api';
+    // データは CloudFront 配信（このページ自身は GitHub Pages）なので、
+    // 相対パスではなく配信元の絶対 URL を指す。CORS は全オリジン許可済み。
+    const API_BASE = 'https://d1nptpfogf2ynv.cloudfront.net/api';
 
     /** 数値を「149万」「1,958」のような読みやすい表記にする。 */
     function formatCount(n) {

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -7,7 +7,7 @@
 [公式サイト](https://gl20percentclub.github.io/japan-food-facilities/) ·
 [地図で見る](https://gl20percentclub.github.io/japan-food-facilities/map.html) ·
 [検索プレイグラウンド](https://gl20percentclub.github.io/japan-food-facilities/playground.html) ·
-[CSVをダウンロード](https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv) ·
+[CSVをダウンロード](https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv) ·
 [収録状況](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities/main/docs/COVERAGE.md) ·
 [出典・ライセンス](https://gl20percentclub.github.io/japan-food-facilities/attribution.html)
 
@@ -46,20 +46,20 @@
 
 | ファイル | URL |
 |---|---|
-| 全件CSV | https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv |
+| 全件CSV | https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv |
 
 - 文字コード: UTF-8（BOMなし）
 - 全列が一致する重複レコードは除去済み
 
 ```bash
-curl -O https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv
+curl -O https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv
 ```
 
 ```python
 import pandas as pd
 
 df = pd.read_csv(
-    "https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv"
+    "https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv"
 )
 ```
 
@@ -73,7 +73,7 @@ df = pd.read_csv(
 map.addSource("facilities", {
   type: "vector",
   tiles: [
-    "https://gl20percentclub.github.io/japan-food-facilities/api/tiles/{z}/{x}/{y}.pbf",
+    "https://d1nptpfogf2ynv.cloudfront.net/api/tiles/{z}/{x}/{y}.pbf",
   ],
   minzoom: 6,
   maxzoom: 12,
@@ -82,7 +82,7 @@ map.addSource("facilities", {
 
 - レイヤー名: `facilities`
 - 主な属性: `name` / `business_type` / `pref` / `city`
-- 詳細: [`api/tiles/metadata.json`](https://gl20percentclub.github.io/japan-food-facilities/api/tiles/metadata.json)
+- 詳細: [`api/tiles/metadata.json`](https://d1nptpfogf2ynv.cloudfront.net/api/tiles/metadata.json)
 
 収録データは[プレビュー地図](https://gl20percentclub.github.io/japan-food-facilities/map.html)でも確認できます。
 
@@ -218,12 +218,12 @@ GitHub Actionsで毎週月曜18:00 UTC（日本時間 火曜3:00）に更新し�
 
 ### CSV から必要な範囲を抽出する（DuckDB・推奨）
 
-540MB の CSV 全体をメモリに載せずに、リモートの gzip CSV へ直接クエリできる。
+数百MB規模の CSV 全体をメモリに載せずに、リモートの CSV へ HTTP range request で直接クエリできる。
 
 ```sql
 INSTALL httpfs; LOAD httpfs;
 SELECT name, address, lat, lng
-FROM read_csv_auto('https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv.gz')
+FROM read_csv_auto('https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv')
 WHERE prefecture = '沖縄県' AND city = '那覇市' AND business_type = '飲食店営業';
 ```
 
@@ -232,7 +232,7 @@ WHERE prefecture = '沖縄県' AND city = '那覇市' AND business_type = '飲�
 ```python
 import pandas as pd
 
-df = pd.read_csv('https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv.gz')
+df = pd.read_csv('https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv')
 naha = df[(df['prefecture'] == '沖縄県') & (df['city'] == '那覇市')]
 ```
 
@@ -243,7 +243,7 @@ naha = df[(df['prefecture'] == '沖縄県') & (df['city'] == '那覇市')]
 ```js
 map.addSource('facilities', {
   type: 'vector',
-  tiles: ['https://gl20percentclub.github.io/japan-food-facilities/api/tiles/{z}/{x}/{y}.pbf'],
+  tiles: ['https://d1nptpfogf2ynv.cloudfront.net/api/tiles/{z}/{x}/{y}.pbf'],
   minzoom: 6,
   maxzoom: 12,
 });
@@ -258,9 +258,9 @@ map.addLayer({
 
 ### 実装時の注意
 
-- **ブラウザから 540MB の CSV を fetch しない。** 地図表示はタイル、データ抽出はサーバー側
+- **ブラウザから数百MBの CSV を fetch しない。** 地図表示はタイル、データ抽出はサーバー側
   （または DuckDB-Wasm + HTTP range request）で行う。
-- CSV は UTF-8 **BOM付き**。Node.js 等でパースする際は先頭の BOM（\uFEFF）を除去する。
+- CSV は UTF-8 **BOMなし**。gzip 圧縮版（.csv.gz）は配信していない。
 - `lat` / `lng` は座標を補完できなかった施設では空になる。地図利用時は必ず除外する。
 - `geocoding_level` が小さいほど座標は大まか（1=都道府県、2=市区町村、3=町丁目、8=街区・地番）。
   建物単位の精度が必要なら level を確認する。

--- a/llms.txt
+++ b/llms.txt
@@ -6,12 +6,11 @@
 
 重要な事実:
 
-- 全件CSV（gzip 推奨）: https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv.gz
-- 全件CSV（非圧縮・約540MB）: https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv
-- CSV は UTF-8（BOM付き）。列: prefecture, city, city_raw, name, name_kana,
+- 全件CSV（gzip 版は配信していない）: https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv
+- CSV は UTF-8（BOMなし）。列: prefecture, city, city_raw, name, name_kana,
   business_type, address, lat, lng, geocoding_level, phone, license_no,
   license_date, expire_date, sources, licenses
-- ベクトルタイル（MVT）: https://gl20percentclub.github.io/japan-food-facilities/api/tiles/{z}/{x}/{y}.pbf （レイヤ名 facilities、z6–12）
+- ベクトルタイル（MVT）: https://d1nptpfogf2ynv.cloudfront.net/api/tiles/{z}/{x}/{y}.pbf （レイヤ名 facilities、z6–12）
 - 市区町村別 JSON や検索 API はこのリポジトリからは配信していない。抽出は CSV から、
   地図表示はタイルで行う（キーワード・近傍検索は https://gl20percentclub.github.io/japan-food-facilities/playground.html で試せる）
 - 全ファイル CORS 開放済み（Access-Control-Allow-Origin: *）。URL は更新後も不変
@@ -33,6 +32,6 @@
 - [llms-full.txt](https://gl20percentclub.github.io/japan-food-facilities/llms-full.txt): データ仕様・利用例・注意事項の全文（まずこれを読む）
 - [README](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities/main/README.md): プロジェクト概要
 - [収録状況](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities/main/docs/COVERAGE.md): 自治体ごとの収録有無・取得元・ライセンスの一覧
-- [タイルメタデータ](https://gl20percentclub.github.io/japan-food-facilities/api/tiles/metadata.json): TileJSON（レイヤ定義・ズーム範囲・bounds）
+- [タイルメタデータ](https://d1nptpfogf2ynv.cloudfront.net/api/tiles/metadata.json): TileJSON（レイヤ定義・ズーム範囲・bounds）
 - [検索プレイグラウンド](https://gl20percentclub.github.io/japan-food-facilities/playground.html): キーワード・近傍検索を試せる（geosearch の検索 API を利用）
 - [出典・ライセンス表示](https://gl20percentclub.github.io/japan-food-facilities/attribution.html): 利用時に必要な出典表示の文例

--- a/map.html
+++ b/map.html
@@ -130,7 +130,7 @@
       <span id="updated"></span><br>
       <a href="./">トップ</a> ·
       <a href="https://github.com/gl20percentclub/japan-food-facilities">GitHub リポジトリ</a> ·
-      <a href="https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv">全件CSV</a> ·
+      <a href="https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv">全件CSV</a> ·
       <a href="./attribution.html">出典・ライセンス</a>
     </p>
   </div>
@@ -139,8 +139,10 @@
 
   <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
   <script>
-    // データ配信ベース URL（このページと同じ gh-pages 上）。相対参照でローカルでも動く。
-    const API_BASE = './api';
+    // データ配信ベース URL。このページ自身は GitHub Pages だが、データ（api/）は
+    // S3 + CloudFront から配信されるため、相対参照ではなく絶対 URL を指す。
+    // CORS は全オリジン許可済みなので、ローカルで開いた場合もそのまま読める。
+    const API_BASE = 'https://d1nptpfogf2ynv.cloudfront.net/api';
     // ベクトルタイルのズーム範囲（scripts/gen-tiles.js の設定と一致させる）
     const TILE_MIN_ZOOM = 6;
     const TILE_MAX_ZOOM = 12;
@@ -165,7 +167,7 @@
           },
           facilities: {
             type: 'vector',
-            tiles: [`${location.href.replace(/[^/]*$/, '')}api/tiles/{z}/{x}/{y}.pbf`],
+            tiles: [`${API_BASE}/tiles/{z}/{x}/{y}.pbf`],
             minzoom: TILE_MIN_ZOOM,
             maxzoom: TILE_MAX_ZOOM,
             bounds: JAPAN_BOUNDS,

--- a/scripts/gen-llms.js
+++ b/scripts/gen-llms.js
@@ -23,8 +23,10 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
 const README_PATH = path.join(ROOT, 'README.md');
 
-// 配信 URL の基点。Pages はデータとページの配信先、RAW はリポジトリ内 Markdown の取得先。
+// 配信 URL の基点。静的ページは GitHub Pages、データ（api/）は S3 + CloudFront と
+// 配信元が分かれている。RAW はリポジトリ内 Markdown の取得先。
 const PAGES = 'https://gl20percentclub.github.io/japan-food-facilities';
+const DATA = 'https://d1nptpfogf2ynv.cloudfront.net';
 const REPO = 'https://github.com/gl20percentclub/japan-food-facilities';
 const RAW = 'https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities/main';
 
@@ -94,12 +96,11 @@ export function renderLlmsTxt(readme) {
 
 重要な事実:
 
-- 全件CSV（gzip 推奨）: ${PAGES}/api/facilities-all.csv.gz
-- 全件CSV（非圧縮・約540MB）: ${PAGES}/api/facilities-all.csv
-- CSV は UTF-8（BOM付き）。列: prefecture, city, city_raw, name, name_kana,
+- 全件CSV（gzip 版は配信していない）: ${DATA}/api/facilities-all.csv
+- CSV は UTF-8（BOMなし）。列: prefecture, city, city_raw, name, name_kana,
   business_type, address, lat, lng, geocoding_level, phone, license_no,
   license_date, expire_date, sources, licenses
-- ベクトルタイル（MVT）: ${PAGES}/api/tiles/{z}/{x}/{y}.pbf （レイヤ名 facilities、z6–12）
+- ベクトルタイル（MVT）: ${DATA}/api/tiles/{z}/{x}/{y}.pbf （レイヤ名 facilities、z6–12）
 - 市区町村別 JSON や検索 API はこのリポジトリからは配信していない。抽出は CSV から、
   地図表示はタイルで行う（キーワード・近傍検索は ${PAGES}/playground.html で試せる）
 - 全ファイル CORS 開放済み（Access-Control-Allow-Origin: *）。URL は更新後も不変
@@ -112,7 +113,7 @@ ${stats}
 - [llms-full.txt](${PAGES}/llms-full.txt): データ仕様・利用例・注意事項の全文（まずこれを読む）
 - [README](${RAW}/README.md): プロジェクト概要
 - [収録状況](${RAW}/docs/COVERAGE.md): 自治体ごとの収録有無・取得元・ライセンスの一覧
-- [タイルメタデータ](${PAGES}/api/tiles/metadata.json): TileJSON（レイヤ定義・ズーム範囲・bounds）
+- [タイルメタデータ](${DATA}/api/tiles/metadata.json): TileJSON（レイヤ定義・ズーム範囲・bounds）
 - [検索プレイグラウンド](${PAGES}/playground.html): キーワード・近傍検索を試せる（geosearch の検索 API を利用）
 - [出典・ライセンス表示](${PAGES}/attribution.html): 利用時に必要な出典表示の文例
 `;
@@ -138,12 +139,12 @@ ${body}
 
 ### CSV から必要な範囲を抽出する（DuckDB・推奨）
 
-540MB の CSV 全体をメモリに載せずに、リモートの gzip CSV へ直接クエリできる。
+数百MB規模の CSV 全体をメモリに載せずに、リモートの CSV へ HTTP range request で直接クエリできる。
 
 \`\`\`sql
 INSTALL httpfs; LOAD httpfs;
 SELECT name, address, lat, lng
-FROM read_csv_auto('${PAGES}/api/facilities-all.csv.gz')
+FROM read_csv_auto('${DATA}/api/facilities-all.csv')
 WHERE prefecture = '沖縄県' AND city = '那覇市' AND business_type = '飲食店営業';
 \`\`\`
 
@@ -152,7 +153,7 @@ WHERE prefecture = '沖縄県' AND city = '那覇市' AND business_type = '飲�
 \`\`\`python
 import pandas as pd
 
-df = pd.read_csv('${PAGES}/api/facilities-all.csv.gz')
+df = pd.read_csv('${DATA}/api/facilities-all.csv')
 naha = df[(df['prefecture'] == '沖縄県') & (df['city'] == '那覇市')]
 \`\`\`
 
@@ -163,7 +164,7 @@ naha = df[(df['prefecture'] == '沖縄県') & (df['city'] == '那覇市')]
 \`\`\`js
 map.addSource('facilities', {
   type: 'vector',
-  tiles: ['${PAGES}/api/tiles/{z}/{x}/{y}.pbf'],
+  tiles: ['${DATA}/api/tiles/{z}/{x}/{y}.pbf'],
   minzoom: 6,
   maxzoom: 12,
 });
@@ -178,9 +179,9 @@ map.addLayer({
 
 ### 実装時の注意
 
-- **ブラウザから 540MB の CSV を fetch しない。** 地図表示はタイル、データ抽出はサーバー側
+- **ブラウザから数百MBの CSV を fetch しない。** 地図表示はタイル、データ抽出はサーバー側
   （または DuckDB-Wasm + HTTP range request）で行う。
-- CSV は UTF-8 **BOM付き**。Node.js 等でパースする際は先頭の BOM（\\uFEFF）を除去する。
+- CSV は UTF-8 **BOMなし**。gzip 圧縮版（.csv.gz）は配信していない。
 - \`lat\` / \`lng\` は座標を補完できなかった施設では空になる。地図利用時は必ず除外する。
 - \`geocoding_level\` が小さいほど座標は大まか（1=都道府県、2=市区町村、3=町丁目、8=街区・地番）。
   建物単位の精度が必要なら level を確認する。

--- a/scripts/gen-llms.test.js
+++ b/scripts/gen-llms.test.js
@@ -78,8 +78,17 @@ assert(!/\n{3,}/.test(stripped), '3連以上の空行が残らない');
 const llms = renderLlmsTxt(readme);
 assert(llms.startsWith('# Japan Food Facilities Data'), 'H1 で始まる（llms.txt 仕様）');
 assert(llms.split('\n')[2].startsWith('> '), 'H1 直後に blockquote の要約がある');
-assert(llms.includes('facilities-all.csv.gz'), 'CSV の URL が載る');
+// データ（api/）は CloudFront 配信。Pages のホストを指していたら張り替え漏れなので落とす。
+assert(
+  llms.includes('https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv'),
+  'CSV の URL は CloudFront を指す',
+);
+assert(!llms.includes('facilities-all.csv.gz'), '配信していない gzip 版を案内しない');
 assert(llms.includes('{z}/{x}/{y}.pbf'), 'タイルの URL テンプレートが載る');
+assert(
+  !llms.includes('gl20percentclub.github.io/japan-food-facilities/api/'),
+  'データの URL に Pages のホストが残っていない',
+);
 assert(llms.includes('| 施設レコード数 | 1,495,048 件 |'), 'README の統計が埋め込まれる');
 assert(llms.includes('llms-full.txt'), 'llms-full.txt へのリンクがある');
 

--- a/scripts/preview-map.test.js
+++ b/scripts/preview-map.test.js
@@ -66,9 +66,19 @@ test('TILE_MIN_ZOOM / TILE_MAX_ZOOM が gen-tiles の既定ズーム範囲と一
 });
 
 test('タイルURLテンプレートが「api/tiles/ + metadata.tiles[0]」の配置と一致する', () => {
+  // データは CloudFront 配信のため、map.html は API_BASE（.../api）を基点に組み立てる。
+  // API_BASE と組み立て後のパスを突き合わせ、配信物の配置と一致するか検証する。
+  const apiBase = htmlValue(/API_BASE\s*=\s*'([^']+)'/, 'API_BASE');
+  assert.ok(apiBase.endsWith('/api'), `API_BASE(${apiBase}) が api/ を指す`);
   withTiles({ minZoom: 6, maxZoom: 12 }, (meta) => {
-    const expectedPath = `api/tiles/${meta.tiles[0]}`; // = api/tiles/{z}/{x}/{y}.pbf
+    const expectedPath = `\${API_BASE}/tiles/${meta.tiles[0]}`; // = ${API_BASE}/tiles/{z}/{x}/{y}.pbf
     assert.ok(HTML.includes(expectedPath), `map.html がタイルパス ${expectedPath} を参照する`);
+    // 組み立て結果が生成物の配置（api/tiles/{z}/{x}/{y}.pbf）と一致することを確認する。
+    const resolved = `${apiBase}/tiles/${meta.tiles[0]}`;
+    assert.ok(
+      resolved.endsWith(`api/tiles/${meta.tiles[0]}`),
+      `組み立て後のタイルURL(${resolved}) が api/tiles/ 配下を指す`,
+    );
   });
 });
 


### PR DESCRIPTION
## 概要

データ（`api/`）の配信が gh-pages から **S3 + CloudFront** に移行した（クローラー側 [japan-facilities-crawler#7](https://github.com/gl20percentclub/japan-facilities-crawler/pull/7) がマージ済み・デプロイ済み）ため、公開リポジトリ側が参照するデータ URL を新しい配信元へ張り替えます。

- データ配信元: `https://d1nptpfogf2ynv.cloudfront.net`
- 静的ページ（LP・地図・プレイグラウンド・llms.txt 等）は**引き続き GitHub Pages 配信**のため、ページの URL は変更していません

## 変更内容

- README / AGENTS.md / index.html / map.html のデータ URL を CloudFront に変更
- `index.html` と `map.html` はデータをページからの**相対参照**（`./api`）で取得していたため、配信元が別ホストになった以上そのままでは 404 になる。絶対 URL を指すよう修正
- `scripts/gen-llms.js` に配信元の定数 `DATA` を追加し、ページ（`PAGES`）と配信元を分離。`llms.txt` / `llms-full.txt` を再生成
- 配信されていない `facilities-all.csv.gz` の案内を削除（クローラーは gzip 版を生成しなくなった）
- 実際の配信物に合わせて記述を修正: CSV は **BOMなし**（従来「BOM付き」と案内していた）、サイズは約 430MB
- 上記に追随してテストを更新。データ URL に Pages のホストが残っていないことも検証する

## 確認したこと

- `npm test` … 本 PR の対象範囲はすべて合格
- CloudFront から CSV・タイル・`metadata.json` がいずれも 200 で取得できることを確認
- `curl` で `Origin` ヘッダ付きリクエストを送ると `access-control-allow-origin: *` が返ることを確認

## CORS の懸念（解消済み）

当初、ブラウザから CloudFront へのリクエストが CORS でブロックされる事象があり、本 PR はマージ不可としていました。

クローラー側 [japan-facilities-crawler#11](https://github.com/gl20percentclub/japan-facilities-crawler/pull/11)（バケットへの CORS 設定追加・`Origin` の S3 への転送・`Origin` をキャッシュキーに含むキャッシュポリシー）をマージ・デプロイし、`/api/*` のキャッシュを無効化したうえで、**本番オリジン `https://gl20percentclub.github.io` の実ブラウザから解消を確認しました**。

| 対象 | 結果 |
|---|---|
| `api/tiles/metadata.json` | 200 |
| `api/tiles/{z}/{x}/{y}.pbf` | 200 |
| `api/facilities-all.csv`（Range リクエスト） | 206（DuckDB 等の範囲取得が可能） |

本 PR のブランチの `map.html` をローカルで開いた場合も CORS エラーは出ず、ページ内から `metadata.json` を 200 で取得できています。

> なお、`curl` は成功するのにブラウザだけが失敗していた**根本原因そのものは特定できていません**。同種の事象の調査手段として、標準ログの有効化を [japan-facilities-crawler#12](https://github.com/gl20percentclub/japan-facilities-crawler/pull/12) で用意しています。

## 追従が必要な残タスク（本 PR の対象外）

- `crawl.yml`（gh-pages へデータを配信していた旧構成）の停止・削除
- CSV の gzip 併置（非圧縮 430MB をそのまま配信しており、CloudFront の自動圧縮は 10MB 超では効かない）
- `attribution.html` が `config/sources.yaml` と同期していないテスト失敗は main 由来の既存の問題で、`fix/attribution-licenses` 側で対応中

