### PR TITLE
全件CSVをReleaseアセットで配信する（100MB上限によるデータ配信停止の修正）

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -72,6 +72,35 @@ jobs:
       - name: Validate
         run: npm test
 
+      # 全件CSV（約400MB）を Release アセットとして配信する。
+      # gh-pages では配信できない: GitHub は 1ファイル 100MB を上限とし、
+      # これを超えるファイルを含む push は拒否される（GH001）。Release アセットは
+      # 上限 2GB のため全件CSV をそのまま置ける。
+      #
+      # タグ data-latest を固定で使い回し、ダウンロード URL を不変に保つ
+      # （--clobber で同名アセットを毎週上書きする）。
+      - name: Publish merged CSV to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # 初回のみリリースを作成する（2回目以降は既存のものを使う）。
+          if ! gh release view data-latest >/dev/null 2>&1; then
+            gh release create data-latest \
+              --title '全件CSV（最新）' \
+              --notes '毎週のクロールで更新される全件CSV。詳細は README を参照。'
+          fi
+          # アセットを上書きアップロード（URL は常に同じ）。
+          gh release upload data-latest api/facilities-all.csv --clobber
+          # 更新日と件数を本文に反映して、いつ時点のデータか分かるようにする。
+          gh release edit data-latest --notes "$(printf '%s\n' \
+            "毎週のクロールで更新される全件CSV（BOM なし UTF-8）。" \
+            "" \
+            "- 更新: $(date -u '+%Y-%m-%d %H:%M UTC')" \
+            "- ダウンロード: https://github.com/${GITHUB_REPOSITORY}/releases/download/data-latest/facilities-all.csv" \
+            "" \
+            "列の定義・ライセンス・利用例は README / llms-full.txt を参照。")"
+
       # README の統計（件数・サイズ）・出典表示ページ・llms.txt だけを main に反映する。
       # 生成物 api/ は Git 管理せず（.gitignore）、配信は gh-pages のみで行う（履歴肥大を避けるため）。
       # クロール中に他の push で main が進むことがあるため、rebase してリトライする。
@@ -92,14 +121,17 @@ jobs:
           done
           echo "::warning::README stats の push に失敗（gh-pages への配信は別ステップで実施）"
 
-      # 生成した api/ を gh-pages へ配信する（データの唯一の配信先）。
+      # 生成した api/ のうち、ベクトルタイルを gh-pages へ配信する。
       # publish_dir が . なので .gitignore も配信対象に含まれてしまう。gh-pages 側では
       # actions-gh-pages が git add --all するため、api/ を無視する .gitignore が
       # 配信先に置かれると生成物が一切コミットされない。必ず除外する。
+      #
+      # 全件CSV は 100MB 上限を超えるため必ず除外する（含めると push 全体が
+      # GH001 で失敗し、タイルもろとも配信されない）。配信は Release アセットで行う。
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: .
           publish_branch: gh-pages
-          exclude_assets: 'node_modules,.cache,scripts,.github,.gitignore'
+          exclude_assets: 'node_modules,.cache,scripts,.github,.gitignore,api/facilities-all.csv'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,8 @@ AI コーディングエージェント（Claude Code / Codex 等）向けのガ
 **まず https://gl20percentclub.github.io/japan-food-facilities/llms-full.txt を読むこと。**
 データ仕様・コピペで動く利用例・注意事項がすべてまとまっている。要点だけ挙げる:
 
-- 全件CSV（gzip）: `https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv.gz`
-  - UTF-8 **BOM付き**、約150万レコード、非圧縮で約540MB
+- 全件CSV: `https://github.com/gl20percentclub/japan-food-facilities/releases/download/data-latest/facilities-all.csv`
+  - **BOM なし** UTF-8、約150万レコード、約400MB（GitHub Release アセットとして配信）
   - 列: `prefecture, city, city_raw, name, name_kana, business_type, address, lat, lng, geocoding_level, phone, license_no, license_date, expire_date, sources, licenses`
 - ベクトルタイル（MVT）: `https://gl20percentclub.github.io/japan-food-facilities/api/tiles/{z}/{x}/{y}.pbf`
   - レイヤ名 `facilities`、z6–12、属性 `name` / `business_type` / `pref` / `city`

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [公式サイト](https://gl20percentclub.github.io/japan-food-facilities/) ·
 [地図で見る](https://gl20percentclub.github.io/japan-food-facilities/map.html) ·
 [検索プレイグラウンド](https://gl20percentclub.github.io/japan-food-facilities/playground.html) ·
-[CSVをダウンロード](https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv) ·
+[CSVをダウンロード](https://github.com/gl20percentclub/japan-food-facilities/releases/download/data-latest/facilities-all.csv) ·
 [収録状況](docs/COVERAGE.md) ·
 [出典・ライセンス](https://gl20percentclub.github.io/japan-food-facilities/attribution.html)
 
@@ -53,20 +53,23 @@
 
 | ファイル | URL |
 |---|---|
-| 全件CSV | https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv |
+| 全件CSV | https://github.com/gl20percentclub/japan-food-facilities/releases/download/data-latest/facilities-all.csv |
 
 - 文字コード: UTF-8（BOMなし）
 - 全列が一致する重複レコードは除去済み
+- 配信は GitHub Release アセット（タグ `data-latest`）。約400MBあり、GitHub Pages の
+  1ファイル100MB制限を超えるためこの形式で配信しています。URLは更新後も変わりません
+- リダイレクトを経由するため、`curl` には `-L` を付けてください
 
 ```bash
-curl -O https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv
+curl -LO https://github.com/gl20percentclub/japan-food-facilities/releases/download/data-latest/facilities-all.csv
 ```
 
 ```python
 import pandas as pd
 
 df = pd.read_csv(
-    "https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv"
+    "https://github.com/gl20percentclub/japan-food-facilities/releases/download/data-latest/facilities-all.csv"
 )
 ```
 

--- a/index.html
+++ b/index.html
@@ -235,16 +235,17 @@
       <h2>クイックスタート</h2>
       <p class="lead">
         配信しているのは <strong>全件CSV</strong> と <strong>ベクトルタイル</strong> の2つだけです。
-        ベース URL は <code>https://gl20percentclub.github.io/japan-food-facilities/api/</code>。
+        CSV は GitHub Release アセット、タイルは
+        <code>https://gl20percentclub.github.io/japan-food-facilities/api/</code> 配下で配信しています。
       </p>
 
-      <p class="step">1. 全件CSV をダウンロードする（約 540MB）</p>
-<pre><code>curl -O https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv</code></pre>
+      <p class="step">1. 全件CSV をダウンロードする（約 400MB・リダイレクトを辿るので <code>-L</code> が必要）</p>
+<pre><code>curl -LO https://github.com/gl20percentclub/japan-food-facilities/releases/download/data-latest/facilities-all.csv</code></pre>
 
       <p class="step">2. pandas で読み込む（URL 直指定でもいけます）</p>
 <pre><code>import pandas as pd
 
-df = pd.read_csv('https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv')
+df = pd.read_csv('https://github.com/gl20percentclub/japan-food-facilities/releases/download/data-latest/facilities-all.csv')
 <span class="c"># 那覇市の飲食店営業だけ抜き出す</span>
 naha = df[(df.city == '那覇市') &amp; (df.business_type == '飲食店営業')]
 print(naha[['name', 'address', 'lat', 'lng']].head())</code></pre>
@@ -271,7 +272,7 @@ print(naha[['name', 'address', 'lat', 'lng']].head())</code></pre>
   <section id="formats">
     <div class="wrap">
       <h2>配信している形式</h2>
-      <p class="lead">用途に合わせて2つから選べます。どちらも同じベース URL 配下の静的ファイルです。</p>
+      <p class="lead">用途に合わせて2つから選べます。どちらも登録不要で直接取得できる静的ファイルです。</p>
       <div class="table-scroll">
         <table class="formats">
           <thead>
@@ -280,7 +281,7 @@ print(naha[['name', 'address', 'lat', 'lng']].head())</code></pre>
           <tbody>
             <tr>
               <td>全件 CSV</td>
-              <td><code>api/facilities-all.csv</code>（約 540MB）</td>
+              <td><code>releases/download/data-latest/facilities-all.csv</code>（約 400MB）</td>
               <td>pandas・BI ツール・DB 取り込みで分析する。全項目入り・BOM なし UTF-8 です。</td>
             </tr>
             <tr>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -7,7 +7,7 @@
 [公式サイト](https://gl20percentclub.github.io/japan-food-facilities/) ·
 [地図で見る](https://gl20percentclub.github.io/japan-food-facilities/map.html) ·
 [検索プレイグラウンド](https://gl20percentclub.github.io/japan-food-facilities/playground.html) ·
-[CSVをダウンロード](https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv) ·
+[CSVをダウンロード](https://github.com/gl20percentclub/japan-food-facilities/releases/download/data-latest/facilities-all.csv) ·
 [収録状況](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities/main/docs/COVERAGE.md) ·
 [出典・ライセンス](https://gl20percentclub.github.io/japan-food-facilities/attribution.html)
 
@@ -24,12 +24,12 @@
 - 毎週自動更新
 
 <!-- STATS:START -->
-> **最終更新: 2026-07-31**
+> **最終更新: 2026-08-01**
 >
 > | 項目 | 値 |
 > |---|---|
 > | 施設レコード数 | 1,488,756 件 |
-> | 座標を持つ施設 | 1,359,323 件 |
+> | 座標を持つ施設 | 1,359,322 件 |
 > | 都道府県 | 48 |
 > | 市区町村 | 1,796 |
 > | 結合CSV | 約 430.3 MB |
@@ -46,20 +46,23 @@
 
 | ファイル | URL |
 |---|---|
-| 全件CSV | https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv |
+| 全件CSV | https://github.com/gl20percentclub/japan-food-facilities/releases/download/data-latest/facilities-all.csv |
 
 - 文字コード: UTF-8（BOMなし）
 - 全列が一致する重複レコードは除去済み
+- 配信は GitHub Release アセット（タグ `data-latest`）。約400MBあり、GitHub Pages の
+  1ファイル100MB制限を超えるためこの形式で配信しています。URLは更新後も変わりません
+- リダイレクトを経由するため、`curl` には `-L` を付けてください
 
 ```bash
-curl -O https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv
+curl -LO https://github.com/gl20percentclub/japan-food-facilities/releases/download/data-latest/facilities-all.csv
 ```
 
 ```python
 import pandas as pd
 
 df = pd.read_csv(
-    "https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv"
+    "https://github.com/gl20percentclub/japan-food-facilities/releases/download/data-latest/facilities-all.csv"
 )
 ```
 
@@ -218,12 +221,12 @@ GitHub Actionsで毎週月曜18:00 UTC（日本時間 火曜3:00）に更新し�
 
 ### CSV から必要な範囲を抽出する（DuckDB・推奨）
 
-540MB の CSV 全体をメモリに載せずに、リモートの gzip CSV へ直接クエリできる。
+400MB の CSV 全体をメモリに載せずに、リモートの CSV へ直接クエリできる。
 
 ```sql
 INSTALL httpfs; LOAD httpfs;
 SELECT name, address, lat, lng
-FROM read_csv_auto('https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv.gz')
+FROM read_csv_auto('https://github.com/gl20percentclub/japan-food-facilities/releases/download/data-latest/facilities-all.csv')
 WHERE prefecture = '沖縄県' AND city = '那覇市' AND business_type = '飲食店営業';
 ```
 
@@ -232,7 +235,7 @@ WHERE prefecture = '沖縄県' AND city = '那覇市' AND business_type = '飲�
 ```python
 import pandas as pd
 
-df = pd.read_csv('https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv.gz')
+df = pd.read_csv('https://github.com/gl20percentclub/japan-food-facilities/releases/download/data-latest/facilities-all.csv')
 naha = df[(df['prefecture'] == '沖縄県') & (df['city'] == '那覇市')]
 ```
 

--- a/llms.txt
+++ b/llms.txt
@@ -6,23 +6,23 @@
 
 重要な事実:
 
-- 全件CSV（gzip 推奨）: https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv.gz
-- 全件CSV（非圧縮・約540MB）: https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv
-- CSV は UTF-8（BOM付き）。列: prefecture, city, city_raw, name, name_kana,
+- 全件CSV（約400MB）: https://github.com/gl20percentclub/japan-food-facilities/releases/download/data-latest/facilities-all.csv
+  （Release アセットとして配信。Pages の 1ファイル 100MB 上限を超えるため）
+- CSV は BOM なし UTF-8。列: prefecture, city, city_raw, name, name_kana,
   business_type, address, lat, lng, geocoding_level, phone, license_no,
   license_date, expire_date, sources, licenses
 - ベクトルタイル（MVT）: https://gl20percentclub.github.io/japan-food-facilities/api/tiles/{z}/{x}/{y}.pbf （レイヤ名 facilities、z6–12）
 - 市区町村別 JSON や検索 API はこのリポジトリからは配信していない。抽出は CSV から、
   地図表示はタイルで行う（キーワード・近傍検索は https://gl20percentclub.github.io/japan-food-facilities/playground.html で試せる）
-- 全ファイル CORS 開放済み（Access-Control-Allow-Origin: *）。URL は更新後も不変
+- タイルは CORS 開放済み（Access-Control-Allow-Origin: *）。URL は更新後も不変
 - 毎週月曜 18:00 UTC（JST 火曜 3:00）に自動更新
 
-**最終更新: 2026-07-31**
+**最終更新: 2026-08-01**
 
 | 項目 | 値 |
 |---|---|
 | 施設レコード数 | 1,488,756 件 |
-| 座標を持つ施設 | 1,359,323 件 |
+| 座標を持つ施設 | 1,359,322 件 |
 | 都道府県 | 48 |
 | 市区町村 | 1,796 |
 | 結合CSV | 約 430.3 MB |

--- a/map.html
+++ b/map.html
@@ -130,7 +130,7 @@
       <span id="updated"></span><br>
       <a href="./">トップ</a> ·
       <a href="https://github.com/gl20percentclub/japan-food-facilities">GitHub リポジトリ</a> ·
-      <a href="https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv">全件CSV</a> ·
+      <a href="https://github.com/gl20percentclub/japan-food-facilities/releases/download/data-latest/facilities-all.csv">全件CSV</a> ·
       <a href="./attribution.html">出典・ライセンス</a>
     </p>
   </div>

--- a/scripts/gen-llms.js
+++ b/scripts/gen-llms.js
@@ -27,6 +27,9 @@ const README_PATH = path.join(ROOT, 'README.md');
 const PAGES = 'https://gl20percentclub.github.io/japan-food-facilities';
 const REPO = 'https://github.com/gl20percentclub/japan-food-facilities';
 const RAW = 'https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities/main';
+// 全件CSV は Pages ではなく Release アセットで配信する（Pages は 1ファイル 100MB 上限、
+// CSV は約400MB）。タグ data-latest は毎週上書きされ、URL は不変。
+const CSV_URL = `${REPO}/releases/download/data-latest/facilities-all.csv`;
 
 const STATS_START = '<!-- STATS:START -->';
 const STATS_END = '<!-- STATS:END -->';
@@ -94,15 +97,15 @@ export function renderLlmsTxt(readme) {
 
 重要な事実:
 
-- 全件CSV（gzip 推奨）: ${PAGES}/api/facilities-all.csv.gz
-- 全件CSV（非圧縮・約540MB）: ${PAGES}/api/facilities-all.csv
-- CSV は UTF-8（BOM付き）。列: prefecture, city, city_raw, name, name_kana,
+- 全件CSV（約400MB）: ${CSV_URL}
+  （Release アセットとして配信。Pages の 1ファイル 100MB 上限を超えるため）
+- CSV は BOM なし UTF-8。列: prefecture, city, city_raw, name, name_kana,
   business_type, address, lat, lng, geocoding_level, phone, license_no,
   license_date, expire_date, sources, licenses
 - ベクトルタイル（MVT）: ${PAGES}/api/tiles/{z}/{x}/{y}.pbf （レイヤ名 facilities、z6–12）
 - 市区町村別 JSON や検索 API はこのリポジトリからは配信していない。抽出は CSV から、
   地図表示はタイルで行う（キーワード・近傍検索は ${PAGES}/playground.html で試せる）
-- 全ファイル CORS 開放済み（Access-Control-Allow-Origin: *）。URL は更新後も不変
+- タイルは CORS 開放済み（Access-Control-Allow-Origin: *）。URL は更新後も不変
 - 毎週月曜 18:00 UTC（JST 火曜 3:00）に自動更新
 
 ${stats}
@@ -138,12 +141,12 @@ ${body}
 
 ### CSV から必要な範囲を抽出する（DuckDB・推奨）
 
-540MB の CSV 全体をメモリに載せずに、リモートの gzip CSV へ直接クエリできる。
+400MB の CSV 全体をメモリに載せずに、リモートの CSV へ直接クエリできる。
 
 \`\`\`sql
 INSTALL httpfs; LOAD httpfs;
 SELECT name, address, lat, lng
-FROM read_csv_auto('${PAGES}/api/facilities-all.csv.gz')
+FROM read_csv_auto('${CSV_URL}')
 WHERE prefecture = '沖縄県' AND city = '那覇市' AND business_type = '飲食店営業';
 \`\`\`
 
@@ -152,7 +155,7 @@ WHERE prefecture = '沖縄県' AND city = '那覇市' AND business_type = '飲�
 \`\`\`python
 import pandas as pd
 
-df = pd.read_csv('${PAGES}/api/facilities-all.csv.gz')
+df = pd.read_csv('${CSV_URL}')
 naha = df[(df['prefecture'] == '沖縄県') & (df['city'] == '那覇市')]
 \`\`\`
 

--- a/scripts/gen-llms.test.js
+++ b/scripts/gen-llms.test.js
@@ -78,7 +78,11 @@ assert(!/\n{3,}/.test(stripped), '3連以上の空行が残らない');
 const llms = renderLlmsTxt(readme);
 assert(llms.startsWith('# Japan Food Facilities Data'), 'H1 で始まる（llms.txt 仕様）');
 assert(llms.split('\n')[2].startsWith('> '), 'H1 直後に blockquote の要約がある');
-assert(llms.includes('facilities-all.csv.gz'), 'CSV の URL が載る');
+// CSV は Release アセットで配信するため、Pages ではなく releases/download の URL が載る。
+assert(
+  llms.includes('/releases/download/data-latest/facilities-all.csv'),
+  'CSV の URL（Release アセット）が載る',
+);
 assert(llms.includes('{z}/{x}/{y}.pbf'), 'タイルの URL テンプレートが載る');
 assert(llms.includes('| 施設レコード数 | 1,495,048 件 |'), 'README の統計が埋め込まれる');
 assert(llms.includes('llms-full.txt'), 'llms-full.txt へのリンクがある');

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,7 +1,8 @@
 // 生成した配信物が正しいことを確認するバリデーションスクリプト。
 //
 // 検証対象は配信する2形式だけ:
-//   api/facilities-all.csv[.gz]   全件の結合CSV
+//   api/facilities-all.csv        全件の結合CSV（配信は Release アセット。
+//                                 gh-pages には載せない = 100MB 上限を超えるため）
 //   api/tiles/{z}/{x}/{y}.pbf     ベクトルタイル + metadata.json（TileJSON）
 //
 //   node scripts/test.js

--- a/scripts/workflows.test.js
+++ b/scripts/workflows.test.js
@@ -89,6 +89,33 @@ assert(
   'pages.yml: keep_files が true（既存の api/ を消さない）',
 );
 
+// --- 全件CSV は gh-pages に載せず Release で配信する ---
+// GitHub は 1ファイル 100MB を上限とし、超えるファイルを含む push は GH001 で
+// 拒否される。約400MB の全件CSV を配信対象に含めると push 全体が失敗し、
+// タイルもろとも配信されなくなる（実際に発生した）。除外を固定する。
+const crawlExcluded = String(crawlDeploy.exclude_assets ?? '')
+  .split(',')
+  .map((s) => s.trim());
+assert(
+  crawlExcluded.includes('api/facilities-all.csv'),
+  'crawl.yml: 全件CSV を gh-pages 配信から除外している（100MB 上限による push 失敗の防止）',
+);
+
+// 除外しただけでは配信されないため、Release へのアップロードが必要。
+// タグは固定（data-latest）で、ダウンロード URL を不変に保つ。
+const crawlRun = Object.values(crawl.jobs ?? {})
+  .flatMap((job) => job.steps ?? [])
+  .map((step) => step.run ?? '')
+  .join('\n');
+assert(
+  /gh release upload\s+data-latest[^\n]*api\/facilities-all\.csv/.test(crawlRun),
+  'crawl.yml: 全件CSV を Release（タグ data-latest）へアップロードしている',
+);
+assert(
+  crawlRun.includes('--clobber'),
+  'crawl.yml: Release アセットを上書きする（--clobber で URL を不変に保つ）',
+);
+
 // --- gh-pages への同時 push を避ける ---
 assert(
   crawl.concurrency?.group != null && crawl.concurrency?.group === pages.concurrency?.group,


### PR DESCRIPTION
## 概要

**gh-pages 上の `api/` が消えており、全件CSV・ベクトルタイルの配信が停止しています。** その原因を修正します。

結合CSVが約400MBまで育ち、GitHub の「1ファイル100MB」上限を超えました。crawl.yml は `publish_dir: .` で `api/` を gh-pages に push しているため、この1ファイルのせいで **push 全体が GH001 で拒否**され、CSV だけでなくタイルも配信されない状態になっていました。

```
remote: error: File api/facilities-all.csv is 397.14 MB; this exceeds GitHub's file size limit of 100.00 MB
remote: error: GH001: Large files detected.
```

gzip版を廃止した dc86f3d 以降、この状態が続いています（`api/` は gh-pages のツリーに存在しません）。

## 変更内容

- **`.github/workflows/crawl.yml`**
  - 全件CSVを **Release アセット（上限2GB）** としてアップロードするステップを追加。タグは `data-latest` 固定・`--clobber` で毎週上書きするため、**ダウンロードURLは不変**
  - リリース本文に更新日時とダウンロードURLを反映
  - gh-pages 配信の `exclude_assets` に `api/facilities-all.csv` を追加（**これが無いとタイルもろとも配信が止まる**）
- **`scripts/workflows.test.js`** — 「CSVをPages配信から除外」「CSVをReleaseへアップロード」「`--clobber`で上書き」の3点をテストで固定。同じ壊れ方の再発防止
- **`scripts/gen-llms.js`** — CSVのURLをReleaseアセットに変更。あわせて dc86f3d 以降の記述ずれも修正（`.gz` への参照が残っていた、`BOM付き`→`BOMなし`、`540MB`→`400MB`）
- **`README.md` / `index.html` / `map.html` / `AGENTS.md`** — 配信URLと注意書き（リダイレクトを辿るため `curl -L` が必要）を更新
- **`llms.txt` / `llms-full.txt`** — 再生成
- **`scripts/test.js`** — 冒頭コメントを実態に合わせて更新（検証は従来どおりローカル生成物に対して行う）

## テスト計画

- [x] `npm run test:unit` が全件パス（追加した workflows テスト3件を含む）
- [x] `npm run build:llms` で llms.txt / llms-full.txt が新URLで再生成されることを確認
- [ ] マージ後に `Crawl Facilities` を手動実行し、(1) Release `data-latest` にCSVが上がる (2) gh-pages への push が成功して `api/tiles/` が復活する ことを確認

## 破壊的変更

**全件CSVのURLが変わります。**

| | URL |
|---|---|
| 旧 | `https://gl20percentclub.github.io/japan-food-facilities/api/facilities-all.csv` |
| 新 | `https://github.com/gl20percentclub/japan-food-facilities/releases/download/data-latest/facilities-all.csv` |

旧URLは現在404（配信自体が停止しているため）なので、実質的に「動いていたものを壊す」変更ではありません。ベクトルタイルのURLは変更なしです。

## 補足（本PRの対象外）

- 今回の手動crawlでは取得元の一部が404で落ち、レコード数が 1,481,280 → 1,345,338 に減っていました（`--allow-empty-sources` で継続）。データソース側の追従は別途検討が必要です
- タイルは毎週約430MB分のblobがgh-pagesの履歴に積まれます。長期的には履歴の肥大化対策（orphan commitでの配信等）を検討する余地があります
