### PR TITLE
ci: 自動生成ファイルのドリフトを検知・自己修復する仕組みを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+# PR と main への push でユニットテストを走らせる。
+# ここで走る scripts/*.test.js には「attribution.html が config/sources.yaml と
+# 同期しているか」「llms.txt が README と同期しているか」の検査も含まれるため、
+# 生成物のコミット漏れ・古い生成物の混入は PR の時点で落ちる。
+# （テスト自体は前からあったが、実行するワークフローが無く機能していなかった）
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # 配信物（api/）を伴う統合テストはデータが無いと動かないため unit のみ。
+      - name: Run unit tests
+        run: npm run test:unit

--- a/.github/workflows/generated-docs.yml
+++ b/.github/workflows/generated-docs.yml
@@ -1,0 +1,83 @@
+name: Generated docs
+
+# main 上の自動生成ファイル（attribution.html / llms.txt / llms-full.txt）が
+# 生成元（config/sources.yaml・README.md・生成スクリプト）とずれていたら、
+# 再生成してそのままコミットする（自己修復）。
+#
+# 自己修復する理由: 生成物はこのリポジトリの外（週次クローラーの自動コミット等）
+# からも push されるため、古いスナップショットが混入すると旧リポジトリ名や
+# 除外済みソースが復活する。実際に一度発生している。
+# 配信されるページは pages.yml が配信前に再生成するので公開ページは常に正しいが、
+# リポジトリ上の内容もここで生成元に合わせて揃えておく。
+#
+# PR でのドリフト検査は ci.yml（npm run test:unit に同期テストが含まれる）が担う。
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'README.md'
+      - 'config/sources.yaml'
+      - 'scripts/gen-attribution.js'
+      - 'scripts/gen-llms.js'
+      # 生成物そのものへの push も対象にする（外部の自動コミットで古い内容が
+      # 入ったときに、その push で即座に巻き戻せるようにするため）。
+      # 自己修復コミットは GITHUB_TOKEN による push でワークフローを再発火しないため
+      # 無限ループにはならない。
+      - 'attribution.html'
+      - 'llms.txt'
+      - 'llms-full.txt'
+      - '.github/workflows/generated-docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+# 同じブランチへの多重実行を避ける（自己修復コミットの衝突防止）。
+concurrency:
+  group: generated-docs-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  regenerate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      # 生成スクリプトは js-yaml だけで動くため devDependencies は入れない。
+      - name: Install dependencies
+        run: npm ci --omit=dev
+
+      - name: Regenerate
+        run: |
+          npm run build:attribution
+          npm run build:llms
+
+      # 外部からの古い自動コミットを巻き戻すため、差分があれば黙って直す。
+      - name: Commit regenerated files
+        run: |
+          if git diff --quiet -- attribution.html llms.txt llms-full.txt; then
+            echo "自動生成ファイルは生成元と一致しています"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add attribution.html llms.txt llms-full.txt
+          git commit -m "chore: 自動生成ファイルを生成元から再生成"
+          # 実行中に main が進んでいることがあるため rebase してリトライする。
+          for i in 1 2 3; do
+            if git pull --rebase --autostash origin "${GITHUB_REF_NAME}" \
+              && git push origin "HEAD:${GITHUB_REF_NAME}"; then
+              exit 0
+            fi
+            echo "push retry $i..."
+            sleep 5
+          done
+          echo "::error::再生成した自動生成ファイルの push に失敗しました"
+          exit 1

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,6 +3,12 @@ name: Deploy Pages
 # 静的ページ（LP・プレビュー地図・出典表示）を main への push で gh-pages に反映する。
 # データ（api/）の生成は重いため crawl.yml 側で週次に行う。ここではページだけを
 # 上書きし、既存の api/ には触れない（keep_files: true）。
+#
+# 自動生成ページ（attribution.html / llms.txt / llms-full.txt）は配信前に必ず
+# 生成元（config/sources.yaml・README.md）から作り直す。リポジトリにコミット済みの
+# ファイルが古くても、配信されるページは常に main の生成元と一致する。
+# （過去に外部の自動コミットで古い attribution.html が main に入り、旧リポジトリ名と
+#  除外済みソースが公開ページへ巻き戻る事故があった）
 on:
   push:
     branches: [main]
@@ -14,6 +20,10 @@ on:
       - 'llms.txt'
       - 'llms-full.txt'
       - '_headers'
+      - 'README.md'
+      - 'config/sources.yaml'
+      - 'scripts/gen-attribution.js'
+      - 'scripts/gen-llms.js'
       - '.github/workflows/pages.yml'
   workflow_dispatch:
 
@@ -31,6 +41,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      # 生成スクリプトは js-yaml だけで動くため devDependencies は入れない。
+      - name: Install dependencies
+        run: npm ci --omit=dev
+
+      # 配信するページを生成元から作り直す（コミット済みの内容に依存させない）。
+      - name: Regenerate generated pages
+        run: |
+          npm run build:attribution
+          npm run build:llms
 
       # keep_files: true なので gh-pages 上の api/ は残したまま、ページだけ上書きされる。
       # 反面ファイル削除は反映されないため、リネームや削除の掃除は crawl.yml の

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,3 +77,20 @@ attribution.html        # 出典表示ページ（sources.yaml から自動生�
   gh-pages へ反映する
 - `crawl.yml` は gh-pages へデータを配信していた旧構成の名残で、現在は使っていない
   （停止・削除は別途対応）。設定は `scripts/workflows.test.js` で固定されている
+- `publish_dir: .` のため `.gitignore` を配信対象から除外しないと gh-pages 上の `api/` が
+  全消えする事故が起きる（過去に発生済み。workflows.test.js が再発を防いでいる）
+
+## 生成物の所有権（このリポジトリが単一の情報源）
+
+`config/sources.yaml` と、そこから作られる `attribution.html` / `llms.txt` / `llms-full.txt`
+は**このリポジトリが唯一の情報源**。クロールを実行する外部の基盤（private リポジトリ
+`gl20percentclub/japan-facilities-crawler` + Fargate）は、これらを生成・push してはならない。
+外部が渡してよいのは README の STATS ブロック（クロール結果の統計）だけ。
+
+- `pages.yml` は配信前に必ず生成物を作り直すため、公開ページは常に main の生成元と一致する
+- `generated-docs.yml` は main 上の生成物がずれていたら再生成してコミットする（自己修復）
+- `ci.yml` は PR でユニットテストを走らせる。生成物の同期テスト（`gen-attribution.test.js` 等）が
+  含まれるため、生成元だけ直して生成物を再生成し忘れた PR はここで落ちる
+- 過去の事故: クローラーが自リポジトリに持っていた古い `config/sources.yaml` の
+  スナップショットから `attribution.html` を生成して main に push し、旧リポジトリ名と
+  ライセンス未確定で除外したソースが公開ページに巻き戻った

--- a/scripts/workflows.test.js
+++ b/scripts/workflows.test.js
@@ -106,6 +106,59 @@ for (const page of pushPaths.filter((p) => p.endsWith('.html'))) {
   assert(fs.existsSync(path.join(ROOT, page)), `pages.yml: ${page} がリポジトリに存在する`);
 }
 
+// --- 自動生成ページは配信前に生成元から作り直す ---
+// コミット済みの attribution.html / llms*.txt が古くても（外部の自動コミット等）、
+// 公開ページは常に config/sources.yaml・README.md と一致させるための固定。
+const pagesRun = Object.values(pages.jobs ?? {})
+  .flatMap((job) => job.steps ?? [])
+  .map((step) => step.run ?? '')
+  .join('\n');
+assert(
+  pagesRun.includes('build:attribution') && pagesRun.includes('build:llms'),
+  'pages.yml: 配信前に attribution.html / llms*.txt を再生成する',
+);
+// 再生成が配信ステップより前にあること（順序が入れ替わると意味がない）。
+const pagesStepNames = Object.values(pages.jobs ?? {})
+  .flatMap((job) => job.steps ?? [])
+  .map((step) => (step.uses ?? '').startsWith('peaceiris/actions-gh-pages')
+    ? 'DEPLOY'
+    : (step.run ?? ''));
+assert(
+  pagesStepNames.findIndex((s) => s.includes('build:attribution'))
+    < pagesStepNames.indexOf('DEPLOY'),
+  'pages.yml: 再生成ステップが配信ステップより前にある',
+);
+// 生成元の変更だけでも配信が走る（生成物のコミット漏れで公開ページが古くならない）。
+for (const src of ['README.md', 'config/sources.yaml']) {
+  assert(pushPaths.includes(src), `pages.yml: ${src} の変更を配信対象にしている`);
+}
+
+// --- 生成物のドリフトを検知・自己修復するワークフロー ---
+const genDocs = loadWorkflow('generated-docs.yml');
+const genDocsPushPaths = genDocs.on?.push?.paths ?? [];
+assert(
+  genDocs.on?.push?.branches?.includes('main'),
+  'generated-docs.yml: main への push で動く',
+);
+// PR でのドリフト検査は ci.yml のユニットテスト（同期テストを含む）が担う。
+const ci = loadWorkflow('ci.yml');
+const ciRun = Object.values(ci.jobs ?? {})
+  .flatMap((job) => job.steps ?? [])
+  .map((step) => step.run ?? '')
+  .join('\n');
+assert(ci.on?.pull_request !== undefined, 'ci.yml: PR でテストが走る');
+assert(ciRun.includes('test:unit'), 'ci.yml: ユニットテスト（生成物の同期検査を含む）を実行する');
+for (const generated of ['attribution.html', 'llms.txt', 'llms-full.txt']) {
+  assert(
+    genDocsPushPaths.includes(generated),
+    `generated-docs.yml: ${generated} への push を検査対象にしている（外部の古い自動コミット対策）`,
+  );
+}
+assert(
+  genDocs.permissions?.contents === 'write',
+  'generated-docs.yml: 自己修復コミットのため contents: write を持つ',
+);
+
 console.log('');
 if (failures > 0) {
   console.error(`❌ ワークフロー設定テストに ${failures} 件の失敗`);


### PR DESCRIPTION
## 背景（起きた事故）

週次クローラー（private リポジトリ `japan-facilities-crawler` + Fargate）が、**自リポジトリに持っている古い `config/sources.yaml` のスナップショット**から `attribution.html` を生成し、公開リポの main へ push していた。その結果 main 上の `attribution.html` が

- 旧リポジトリ名・旧URL（「Japan Facilities API」/ `japan-facilities-api`）
- ライセンス未確定で除外したはずの16ソース（98ソース分の一覧）

に巻き戻っていた（コミット db9c437）。加えて、`attribution.html` の同期を検査するユニットテストは以前から存在したのに、**テストを実行するワークフローが無く**、main が壊れていることに誰も気づけなかった。

## 対策（このPR）

生成物の整合性を「人の運用」ではなくワークフローで担保する。

| ファイル | 内容 |
|---|---|
| `pages.yml` | 配信前に `attribution.html` / `llms.txt` / `llms-full.txt` を生成元から作り直す。コミット済みの内容が古くても、**公開ページは常に main の生成元と一致する**。生成元（`README.md` / `config/sources.yaml` / 生成スクリプト）の変更でも配信が走るよう paths を追加 |
| `generated-docs.yml`（新規） | main 上の生成物がずれていたら再生成してコミットする（自己修復）。生成物への push 自体もトリガーに含めるため、外部から古い内容が入っても即座に巻き戻る。自己修復コミットは GITHUB_TOKEN による push なのでワークフローを再発火せず、ループしない |
| `ci.yml`（新規） | PR と main への push で `npm run test:unit` を実行。生成物の同期テストが含まれるため、生成元だけ直して生成物を忘れた PR はここで落ちる |
| `scripts/workflows.test.js` | 上記の設定を固定するテストを追加（再生成が配信ステップより前にあること等） |
| `AGENTS.md` | 生成物の所有権を明記。`config/sources.yaml` とその生成物はこのリポジトリが唯一の情報源で、外部が渡してよいのは README の STATS ブロックだけ |

## クローラー側（別PR）

根本原因である「二重所有」は、クローラーリポジトリ側でも直す（別PR）。

- `attribution.html` の生成・push をやめる
- 自リポジトリの `config/sources.yaml` のコピーを廃止し、クロール時に clone した公開リポの `config/sources.yaml` を使う

## テスト

`npm run test:unit`: 全件合格

## 注意

このPRは #61 の上にスタックしている（base: `docs/data-usage-attribution`）。#61 のマージ後に base を main に切り替える。