### PR TITLE
地図ページを統計表示と検索窓だけの最小構成にする

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,10 +18,10 @@ AI コーディングエージェント（Claude Code / Codex 等）向けのガ
   - レイヤ名 `facilities`、z6–12、属性 `name` / `business_type` / `pref` / `city`
 - 市区町村別 JSON や検索 API は**このリポジトリからは配信していない**。データ抽出は
   CSV（DuckDB 推奨）、地図表示はタイルを使う。ブラウザから非圧縮 CSV を直接 fetch しない
-- キーワード・近傍検索は [geosearch](https://github.com/naogify/geosearch) の検索 API を
-  使った `map.html`（地図・検索ページ）で試せる。API のエンドポイントは
-  `map.html` の `DEFAULT_API_URL`（または `?api=` パラメータ）で設定する。
-  旧 `playground.html` は `map.html` へのリダイレクトだけを残した薄いページ
+- `map.html` は統計表示と検索窓だけの最小構成のプレビュー地図。検索窓は
+  [geosearch](https://github.com/naogify/geosearch) の検索 API を呼ぶが、
+  エンドポイント（`DEFAULT_API_URL`）は未設定で現状は無効。旧 `playground.html` は
+  `map.html` へのリダイレクトだけを残した薄いページ
 - 商用・非商用を問わず利用可だが出典表示が必要。ライセンスは元データの提供元ごとに異なる
   （単一ライセンスではないので「CC BY 4.0」と一括で書かない）。出典表示:
   「出典：Japan Food Facilities（各自治体・厚生労働省が公開する食品営業許可オープンデータを加工して作成）」

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Weekly Crawl](https://img.shields.io/badge/更新-毎週自動-blue)](#更新頻度)
 
 [公式サイト](https://gl20percentclub.github.io/japan-food-facilities/) ·
-[地図で見る・検索する](https://gl20percentclub.github.io/japan-food-facilities/map.html) ·
+[地図で見る](https://gl20percentclub.github.io/japan-food-facilities/map.html) ·
 [CSVをダウンロード](https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv) ·
 [収録状況](docs/COVERAGE.md) ·
 [出典・ライセンス](https://gl20percentclub.github.io/japan-food-facilities/attribution.html)
@@ -95,14 +95,6 @@ map.addSource("facilities", {
 - 詳細: [`api/tiles/metadata.json`](https://d1nptpfogf2ynv.cloudfront.net/api/tiles/metadata.json)
 
 収録データは[地図ページ](https://gl20percentclub.github.io/japan-food-facilities/map.html)でも確認できます。
-
-### 地図から検索する
-
-キーワード検索・近傍検索（「東京駅の近くのカフェ」等）も、同じ[地図ページ](https://gl20percentclub.github.io/japan-food-facilities/map.html)から試せます。検索バックエンドには [geosearch](https://github.com/naogify/geosearch)（本データを SQLite in Lambda の検索APIに変換するIaC）を利用しており、実行された GET リクエストの URL がそのまま画面に表示されるため、アプリへの組み込み方も確認できます。
-
-- キーワード: 名称・カナ・住所・市区町村を横断検索（`q`）
-- 範囲: 地図の表示範囲内（`bbox`）、中心から近い順（`center` + `radius`）
-- 結果は一覧・地図表示・CSVダウンロードで確認可能
 
 ### AIエージェントから使う
 

--- a/attribution.html
+++ b/attribution.html
@@ -1358,7 +1358,7 @@
         誤りを見つけた場合は <a href="https://github.com/gl20percentclub/japan-food-facilities/issues">Issue</a> でお知らせください。
       </p>
       <p>
-        <a href="./">← トップへ戻る</a> · <a href="./map.html">地図・検索</a> ·
+        <a href="./">← トップへ戻る</a> · <a href="./map.html">プレビュー地図</a> ·
         <a href="https://github.com/gl20percentclub/japan-food-facilities">GitHub リポジトリ</a>
       </p>
     </footer>

--- a/index.html
+++ b/index.html
@@ -172,7 +172,7 @@
       </p>
       <div class="cta">
         <a class="btn primary" href="#quickstart">クイックスタート</a>
-        <a class="btn ghost" href="./map.html">地図で見る・検索する</a>
+        <a class="btn ghost" href="./map.html">地図で見てみる</a>
         <a class="btn ghost" href="https://github.com/gl20percentclub/japan-food-facilities">GitHub</a>
       </div>
 
@@ -295,7 +295,7 @@ print(naha[['name', 'address', 'lat', 'lng']].head())</code></pre>
         </table>
       </div>
       <p class="lead" style="margin:20px 0 0">
-        キーワード・近傍検索は<a href="./map.html">地図ページ</a>で試せます。
+        収録データは<a href="./map.html">地図ページ</a>でも確認できます。
         地域や業種を絞りたい場合は、CSV をダウンロードしてフィルタしてください。
         各列の詳細は <a href="https://github.com/gl20percentclub/japan-food-facilities#どんなデータか">README</a>、
         自治体ごとの収録状況は <a href="https://github.com/gl20percentclub/japan-food-facilities/blob/main/docs/COVERAGE.md">収録状況一覧</a> を参照してください。
@@ -355,7 +355,7 @@ print(naha[['name', 'address', 'lat', 'lng']].head())</code></pre>
   <footer>
     <div class="wrap">
       <p>
-        <a href="./map.html">地図・検索</a> ·
+        <a href="./map.html">地図</a> ·
         <a href="./attribution.html">出典・ライセンス</a> ·
         <a href="https://github.com/gl20percentclub/japan-food-facilities">GitHub</a> ·
         <a href="https://github.com/gl20percentclub/japan-food-facilities/issues">Issues</a>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5,7 +5,7 @@
 **全国の食品営業許可・届出データを、共通形式で無料配信するオープンデータプロジェクト**
 
 [公式サイト](https://gl20percentclub.github.io/japan-food-facilities/) ·
-[地図で見る・検索する](https://gl20percentclub.github.io/japan-food-facilities/map.html) ·
+[地図で見る](https://gl20percentclub.github.io/japan-food-facilities/map.html) ·
 [CSVをダウンロード](https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv) ·
 [収録状況](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities/main/docs/COVERAGE.md) ·
 [出典・ライセンス](https://gl20percentclub.github.io/japan-food-facilities/attribution.html)
@@ -88,14 +88,6 @@ map.addSource("facilities", {
 - 詳細: [`api/tiles/metadata.json`](https://d1nptpfogf2ynv.cloudfront.net/api/tiles/metadata.json)
 
 収録データは[地図ページ](https://gl20percentclub.github.io/japan-food-facilities/map.html)でも確認できます。
-
-### 地図から検索する
-
-キーワード検索・近傍検索（「東京駅の近くのカフェ」等）も、同じ[地図ページ](https://gl20percentclub.github.io/japan-food-facilities/map.html)から試せます。検索バックエンドには [geosearch](https://github.com/naogify/geosearch)（本データを SQLite in Lambda の検索APIに変換するIaC）を利用しており、実行された GET リクエストの URL がそのまま画面に表示されるため、アプリへの組み込み方も確認できます。
-
-- キーワード: 名称・カナ・住所・市区町村を横断検索（`q`）
-- 範囲: 地図の表示範囲内（`bbox`）、中心から近い順（`center` + `radius`）
-- 結果は一覧・地図表示・CSVダウンロードで確認可能
 
 ### AIエージェントから使う
 

--- a/llms.txt
+++ b/llms.txt
@@ -12,7 +12,7 @@
   license_date, expire_date, sources, licenses
 - ベクトルタイル（MVT）: https://d1nptpfogf2ynv.cloudfront.net/api/tiles/{z}/{x}/{y}.pbf （レイヤ名 facilities、z6–12）
 - 市区町村別 JSON や検索 API はこのリポジトリからは配信していない。抽出は CSV から、
-  地図表示はタイルで行う（キーワード・近傍検索は https://gl20percentclub.github.io/japan-food-facilities/map.html で試せる）
+  地図表示はタイルで行う
 - 全ファイル CORS 開放済み（Access-Control-Allow-Origin: *）。URL は更新後も不変
 - 毎週月曜 18:00 UTC（JST 火曜 3:00）に自動更新
 
@@ -33,5 +33,5 @@
 - [README](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities/main/README.md): プロジェクト概要
 - [収録状況](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities/main/docs/COVERAGE.md): 自治体ごとの収録有無・取得元・ライセンスの一覧
 - [タイルメタデータ](https://d1nptpfogf2ynv.cloudfront.net/api/tiles/metadata.json): TileJSON（レイヤ定義・ズーム範囲・bounds）
-- [地図・検索ページ](https://gl20percentclub.github.io/japan-food-facilities/map.html): 全件をタイルで表示し、キーワード・近傍検索も試せる（geosearch の検索 API を利用）
+- [地図ページ](https://gl20percentclub.github.io/japan-food-facilities/map.html): 収録データをベクトルタイルで表示するプレビュー地図
 - [出典・ライセンス表示](https://gl20percentclub.github.io/japan-food-facilities/attribution.html): 利用時に必要な出典表示の文例

--- a/map.html
+++ b/map.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>🍽️ Japan Food Facilities — 地図と検索</title>
-  <meta name="description" content="日本全国の飲食施設オープンデータ（食品営業許可・届出）を、地図で眺めながらキーワード・近傍検索できるページです。登録不要。">
+  <title>🍽️ Japan Food Facilities — 地図</title>
+  <meta name="description" content="日本全国の飲食施設オープンデータ（食品営業許可・届出）を地図で見て、名称や住所で検索できます。">
 
   <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css">
   <style>
@@ -18,9 +18,6 @@
       --field-bg: #ffffff;
       --soft: #f7f8fa;
       --border: rgba(31, 41, 51, 0.12);
-      --code-bg: #1f2933;
-      --code-ink: #e4e7eb;
-      --ok: #1a7f37;
       --err: #c0392b;
     }
     * { box-sizing: border-box; }
@@ -37,8 +34,8 @@
       top: 12px;
       left: 12px;
       z-index: 2;
-      width: min(360px, calc(100vw - 24px));
-      /* 画面からはみ出さないよう、パネル全体の高さに上限を設ける */
+      width: min(340px, calc(100vw - 24px));
+      /* 画面からはみ出さないよう上限を設け、超えた分はパネル内でスクロールさせる */
       max-height: calc(100% - 24px);
       display: flex;
       flex-direction: column;
@@ -47,7 +44,6 @@
       border: 1px solid var(--border);
       border-radius: 12px;
       box-shadow: 0 4px 20px rgba(0, 0, 0, 0.12);
-      /* 上限を超えたときにフッターのリンクが切れないよう、パネル自体もスクロールさせる */
       overflow-x: hidden;
       overflow-y: auto;
     }
@@ -87,7 +83,7 @@
     }
     .stat .lbl { font-size: 10px; color: #616e7c; }
 
-    /* --- 検索フォーム --- */
+    /* --- 検索窓 --- */
     .search-row { display: flex; gap: 8px; }
     .search-row input {
       flex: 1;
@@ -99,22 +95,6 @@
       border: 1px solid var(--border);
       border-radius: 8px;
       padding: 8px 10px;
-    }
-    .opts {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      gap: 8px;
-      margin-top: 8px;
-    }
-    .opts select {
-      width: 100%;
-      font-size: 12.5px;
-      font-family: inherit;
-      color: var(--sub);
-      background: var(--field-bg);
-      border: 1px solid var(--border);
-      border-radius: 8px;
-      padding: 6px 8px;
     }
     .btn {
       font-size: 14px;
@@ -130,36 +110,12 @@
     }
     .btn:hover { opacity: 0.85; }
     .btn:disabled { opacity: 0.4; cursor: not-allowed; }
-    .btn.ghost { background: transparent; color: var(--accent); }
-    .btn.small { font-size: 11.5px; padding: 4px 10px; }
 
-    /* --- 検索APIが未設定のときの案内 --- */
-    .notice {
-      display: none;
-      border: 1px solid var(--border);
-      border-left: 3px solid var(--accent);
-      background: var(--soft);
-      border-radius: 8px;
-      padding: 8px 10px;
-      font-size: 11.5px;
-      line-height: 1.6;
-      color: var(--sub);
-      margin-top: 10px;
-    }
-    .notice.visible { display: block; }
-
-    /* --- 結果 --- */
-    .result-head {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 8px;
-      margin-top: 12px;
-    }
-    #status { font-size: 12px; color: var(--sub); margin: 0; }
-    #status.ok { color: var(--ok); }
+    /* --- 検索結果 --- */
+    #status { font-size: 12px; color: var(--sub); margin: 8px 0 0; }
     #status.err { color: var(--err); }
-    /* 結果リストだけをスクロールさせ、検索フォームは常に見えるようにする */
+    #status:empty { display: none; }
+    /* 結果リストだけをスクロールさせ、検索窓は常に見えるようにする */
     #results {
       overflow-y: auto;
       margin: 8px 0 0;
@@ -177,24 +133,6 @@
     #results .r-name { font-weight: 600; display: block; }
     #results .r-meta { color: var(--muted); font-size: 11.5px; }
 
-    /* --- API リクエスト表示（折りたたみ） --- */
-    details.api { font-size: 11.5px; margin-top: 4px; }
-    details.api summary { cursor: pointer; color: var(--sub); }
-    details.api code#request-url {
-      display: block;
-      margin-top: 6px;
-      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      font-size: 11px;
-      line-height: 1.6;
-      color: var(--code-ink);
-      background: var(--code-bg);
-      border-radius: 8px;
-      padding: 8px 10px;
-      word-break: break-all;
-      white-space: pre-wrap;
-    }
-    details.api p { margin: 6px 0 0; color: var(--muted); line-height: 1.6; }
-
     /* --- フッターのリンク --- */
     .meta-line {
       font-size: 11px;
@@ -208,13 +146,12 @@
       display: inline-block;
       width: 9px; height: 9px;
       border-radius: 50%;
+      background: var(--accent);
       border: 1.5px solid #fff;
       box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.15);
       vertical-align: middle;
       margin-right: 4px;
     }
-    .legend-dot.all { background: var(--accent); }
-    .legend-dot.hit { background: var(--hit); margin-left: 8px; }
 
     /* --- ズームヒント（下中央） --- */
     .hint {
@@ -246,7 +183,7 @@
     .fac-row { font-size: 12px; color: #52606d; margin: 2px 0; }
     .fac-row .k { color: #9aa5b1; margin-right: 6px; }
 
-    /* 画面が低いときは統計を隠し、検索フォームと結果を優先する */
+    /* 画面が低いときは統計を隠し、検索窓と結果を優先する */
     @media (max-height: 640px) {
       .stats { display: none; }
     }
@@ -260,11 +197,11 @@
 <body>
   <div id="map"></div>
 
-  <!-- ================= 操作パネル（地図・検索を1画面に統合） ================= -->
+  <!-- ================= 操作パネル（統計と検索窓だけの最小構成） ================= -->
   <div class="panel">
     <div class="body">
       <h1>🍽️ Japan Food Facilities</h1>
-      <p class="sub">全国の飲食施設オープンデータ（食品営業許可・届出）を地図で見て、その場で検索できます。</p>
+      <p class="sub">全国の飲食施設オープンデータ（食品営業許可・届出）のプレビュー地図です。</p>
 
       <div class="stats">
         <div class="stat"><span class="num" id="stat-pref">–</span><span class="lbl">都道府県</span></div>
@@ -273,58 +210,18 @@
       </div>
 
       <div class="search-row">
-        <input id="keyword" type="text" placeholder="例: 渋谷 ラーメン" aria-label="キーワード（名称・カナ・住所・市区町村）">
+        <input id="keyword" type="text" placeholder="名称・住所で検索" aria-label="名称・住所で検索">
         <button class="btn" id="search" disabled>検索</button>
       </div>
-      <div class="opts">
-        <select id="scope" aria-label="検索範囲">
-          <option value="all">全国から検索</option>
-          <option value="bbox">地図の表示範囲内</option>
-          <option value="center">地図の中心から近い順</option>
-        </select>
-        <select id="limit" aria-label="上限件数">
-          <option value="50">上限 50件</option>
-          <option value="100">上限 100件</option>
-          <option value="200">上限 200件</option>
-        </select>
-        <select id="radius" aria-label="半径" hidden>
-          <option value="1000">半径 1km</option>
-          <option value="5000">半径 5km</option>
-          <option value="10000" selected>半径 10km</option>
-          <option value="50000">半径 50km</option>
-        </select>
-      </div>
-
-      <!-- 検索APIのエンドポイントが未設定のときだけ出す案内 -->
-      <div class="notice" id="notice-no-api">
-        <strong>検索APIのエンドポイントが未設定です。</strong>
-        URL に <code>?api=&lt;検索APIのURL&gt;</code> を付けるか、<code>map.html</code> の
-        <code>DEFAULT_API_URL</code> を設定すると検索できます。地図の閲覧はそのまま使えます。
-      </div>
-
-      <div class="result-head">
-        <p id="status">キーワードを入れて検索できます。</p>
-        <button class="btn ghost small" id="download" disabled>CSV</button>
-      </div>
+      <p id="status"></p>
     </div>
 
     <!-- 検索結果（クリックでその施設へ移動する） -->
     <ul id="results"></ul>
 
     <div class="body" style="padding-top:8px">
-      <details class="api">
-        <summary>API リクエストを見る</summary>
-        <code id="request-url">—</code>
-        <p>
-          この GET リクエストがそのまま検索 API の使い方です。レスポンスは
-          <code>{ count, results: [{ name, name_kana, prefecture, city, address, business_type,
-          lat, lng, level }] }</code> の JSON です。
-        </p>
-      </details>
-
       <p class="meta-line">
-        <span class="legend-dot all"></span>全施設
-        <span class="legend-dot hit"></span>検索結果
+        <span class="legend-dot"></span>各点＝1施設
         <span id="updated"></span><br>
         <a href="./">トップ</a> ·
         <a href="https://github.com/gl20percentclub/japan-food-facilities">GitHub</a> ·
@@ -350,19 +247,15 @@
     const JAPAN_BOUNDS = [122, 20, 154, 46];
 
     // 検索 API（geosearch: SQLite FTS5 + R*Tree in Lambda）のエンドポイント。
-    // デプロイの CDK 出力 SearchApiUrl を設定する。URL の ?api= で上書きもできる
-    // （例: map.html?api=https://xxxx.execute-api.ap-northeast-1.amazonaws.com/）。
+    // 未設定のあいだ検索窓は無効で、地図の閲覧だけができる。デプロイの CDK 出力
+    // SearchApiUrl を設定すると有効になる（URL の ?api= でも上書きできる）。
     const DEFAULT_API_URL = '';
     const API_URL = new URLSearchParams(location.search).get('api') || DEFAULT_API_URL;
-
-    // CSV ダウンロードに出す列（検索 API のレスポンス results[] のフィールド）。
-    const RESULT_FIELDS = [
-      'name', 'business_type', 'prefecture', 'city', 'address',
-      'name_kana', 'lat', 'lng', 'level',
-    ];
+    // 検索結果の取得件数の上限（一覧が長くなりすぎない程度に抑える）。
+    const SEARCH_LIMIT = 50;
 
     // ================= 状態 =================
-    let lastRows = []; // 直近の検索結果（結果リスト・地図・CSV で共有する）
+    let lastRows = []; // 直近の検索結果（結果リストと地図で共有する）
 
     const $ = (id) => document.getElementById(id);
     /** HTML 埋め込み用のエスケープ。 */
@@ -466,9 +359,6 @@
     map.on('zoom', updateHint);
     map.on('load', updateHint);
 
-    // 地図が動いたら、範囲を使う検索モードのリクエスト URL 表示を追随させる。
-    map.on('moveend', updateRequestUrl);
-
     // ================= ポップアップ =================
     /**
      * 施設のポップアップを表示する。`info` は { name, business_type, place, address } で、
@@ -511,56 +401,25 @@
       map.on('mouseleave', layer, () => { map.getCanvas().style.cursor = ''; });
     }
 
-    // ================= リクエスト組み立て =================
-    /** ステータス行を更新する。kind は '' | 'ok' | 'err'。 */
+    // ================= 検索 =================
+    /** ステータス行を更新する。kind は '' | 'err'。 */
     function setStatus(msg, kind = '') {
       const el = $('status');
       el.textContent = msg;
       el.className = kind;
     }
 
-    /** 小数を URL 用に丸める（座標は5桁 ≒ 1m 精度で十分）。 */
-    const r5 = (n) => Math.round(n * 1e5) / 1e5;
-
-    /**
-     * フォームと地図の状態から検索 API のクエリパラメータを組み立てる。
-     * scope=bbox は地図の表示範囲、scope=center は地図中心 + 半径を使う。
-     */
-    function buildParams() {
-      const params = new URLSearchParams();
-      const q = $('keyword').value.trim();
-      if (q) params.set('q', q);
-
-      const scope = $('scope').value;
-      if (scope === 'bbox') {
-        const b = map.getBounds();
-        params.set('bbox', [r5(b.getWest()), r5(b.getSouth()), r5(b.getEast()), r5(b.getNorth())].join(','));
-      } else if (scope === 'center') {
-        const c = map.getCenter();
-        params.set('center', `${r5(c.lng)},${r5(c.lat)}`);
-        params.set('radius', $('radius').value);
-      }
-
-      params.set('limit', $('limit').value);
-      return params;
-    }
-
-    /** 現在のフォーム内容で実行される GET リクエストの URL 表示を更新する。 */
-    function updateRequestUrl() {
-      const base = API_URL || '<検索APIのURL>';
-      $('request-url').textContent = `GET ${base}?${buildParams().toString()}`;
-    }
-
-    // ================= 検索実行 =================
-    /** 検索 API を呼び、結果リスト・地図・CSV ボタンを更新する。 */
+    /** 検索 API をキーワードで呼び、結果リストと地図を更新する。 */
     async function run() {
-      if (!API_URL) return;
+      const q = $('keyword').value.trim();
+      if (!API_URL || !q) return;
       $('search').disabled = true;
       try {
         setStatus('検索中…');
-        const t0 = performance.now();
-        const res = await fetch(`${API_URL}?${buildParams().toString()}`);
-        const ms = Math.round(performance.now() - t0);
+        const params = new URLSearchParams();
+        params.set('q', q);
+        params.set('limit', String(SEARCH_LIMIT));
+        const res = await fetch(`${API_URL}?${params.toString()}`);
         const body = await res.json();
         // 400 はクエリ起因のエラー。API が返す error メッセージをそのまま見せる。
         if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`);
@@ -568,8 +427,9 @@
         lastRows = body.results || [];
         renderResults();
         renderMap();
-        $('download').disabled = lastRows.length === 0;
-        setStatus(`${(body.count ?? lastRows.length).toLocaleString('ja-JP')}件ヒット（${ms.toLocaleString('ja-JP')}ms）`, 'ok');
+        setStatus(lastRows.length
+          ? `${(body.count ?? lastRows.length).toLocaleString('ja-JP')}件`
+          : '該当する施設が見つかりませんでした。');
       } catch (err) {
         setStatus(`エラー: ${err.message}`, 'err');
       } finally {
@@ -618,7 +478,7 @@
       map.setPaintProperty('facilities-circle', 'circle-stroke-opacity', dimmed ? 0.12 : 1);
     }
 
-    /** 座標を持つ結果を地図に重ね、範囲検索でなければ結果の範囲へズームする。 */
+    /** 座標を持つ結果を地図に重ね、その範囲へズームする。 */
     function renderMap() {
       const features = [];
       let bbox = null; // [west, south, east, north]
@@ -645,32 +505,7 @@
       }
       map.getSource('results').setData({ type: 'FeatureCollection', features });
       dimAllFacilities(features.length > 0);
-      // 地図の表示範囲を使った検索では視点を動かさない（範囲がずれると混乱するため）。
-      if (bbox && $('scope').value === 'all') {
-        map.fitBounds(bbox, { padding: 60, maxZoom: 15, duration: 600 });
-      }
-    }
-
-    // ================= CSV ダウンロード =================
-    /** CSV セルのエスケープ（区切り・引用符・改行を含む場合のみ引用符で囲む）。 */
-    function csvCell(v) {
-      if (v === null || v === undefined) return '';
-      const s = String(v);
-      return /[",\r\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
-    }
-
-    /** 直近の検索結果を CSV（UTF-8 BOM 付き・Excel 対応）としてダウンロードする。 */
-    function downloadCsv() {
-      const lines = [RESULT_FIELDS.join(',')];
-      for (const row of lastRows) {
-        lines.push(RESULT_FIELDS.map((c) => csvCell(row[c])).join(','));
-      }
-      const blob = new Blob(['﻿' + lines.join('\n')], { type: 'text/csv;charset=utf-8' });
-      const a = document.createElement('a');
-      a.href = URL.createObjectURL(blob);
-      a.download = 'facilities-search-results.csv';
-      a.click();
-      URL.revokeObjectURL(a.href);
+      if (bbox) map.fitBounds(bbox, { padding: 60, maxZoom: 15, duration: 600 });
     }
 
     // ================= 統計（タイルの metadata.json から） =================
@@ -694,32 +529,20 @@
       })
       .catch(() => { /* 統計が取れなくても地図・検索は動く */ });
 
-    // ================= イベント =================
-    // フォームの変更はリクエスト URL 表示へ即時反映する。
-    for (const id of ['keyword', 'scope', 'limit', 'radius']) {
-      $(id).addEventListener('input', updateRequestUrl);
-    }
-    // 「近い順」のときだけ半径セレクトを見せる。
-    $('scope').addEventListener('input', () => {
-      $('radius').hidden = $('scope').value !== 'center';
-    });
+    // ================= イベント・初期化 =================
     $('search').addEventListener('click', run);
     // キーワード欄で Enter でも検索できるようにする。
     $('keyword').addEventListener('keydown', (e) => {
       if (e.key === 'Enter') run();
     });
-    $('download').addEventListener('click', downloadCsv);
 
-    // ================= 初期化 =================
     if (API_URL) {
       $('search').disabled = false;
     } else {
-      // エンドポイント未設定なら案内を出し、検索は無効のままにする（地図は使える）。
-      $('notice-no-api').classList.add('visible');
+      // 検索 API 未設定のあいだは検索窓を無効にし、地図の閲覧だけを提供する。
       $('keyword').disabled = true;
-      setStatus('検索は準備中です。地図はそのまま操作できます。');
+      $('keyword').placeholder = '検索は準備中です';
     }
-    updateRequestUrl();
   </script>
 </body>
 </html>

--- a/scripts/gen-attribution.js
+++ b/scripts/gen-attribution.js
@@ -521,7 +521,7 @@ ${sections.map(renderSection).join('\n')}
         誤りを見つけた場合は <a href="${REPO_URL}/issues">Issue</a> でお知らせください。
       </p>
       <p>
-        <a href="./">← トップへ戻る</a> · <a href="./map.html">地図・検索</a> ·
+        <a href="./">← トップへ戻る</a> · <a href="./map.html">プレビュー地図</a> ·
         <a href="${REPO_URL}">GitHub リポジトリ</a>
       </p>
     </footer>

--- a/scripts/gen-llms.js
+++ b/scripts/gen-llms.js
@@ -102,7 +102,7 @@ export function renderLlmsTxt(readme) {
   license_date, expire_date, sources, licenses
 - ベクトルタイル（MVT）: ${DATA}/api/tiles/{z}/{x}/{y}.pbf （レイヤ名 facilities、z6–12）
 - 市区町村別 JSON や検索 API はこのリポジトリからは配信していない。抽出は CSV から、
-  地図表示はタイルで行う（キーワード・近傍検索は ${PAGES}/map.html で試せる）
+  地図表示はタイルで行う
 - 全ファイル CORS 開放済み（Access-Control-Allow-Origin: *）。URL は更新後も不変
 - 毎週月曜 18:00 UTC（JST 火曜 3:00）に自動更新
 
@@ -114,7 +114,7 @@ ${stats}
 - [README](${RAW}/README.md): プロジェクト概要
 - [収録状況](${RAW}/docs/COVERAGE.md): 自治体ごとの収録有無・取得元・ライセンスの一覧
 - [タイルメタデータ](${DATA}/api/tiles/metadata.json): TileJSON（レイヤ定義・ズーム範囲・bounds）
-- [地図・検索ページ](${PAGES}/map.html): 全件をタイルで表示し、キーワード・近傍検索も試せる（geosearch の検索 API を利用）
+- [地図ページ](${PAGES}/map.html): 収録データをベクトルタイルで表示するプレビュー地図
 - [出典・ライセンス表示](${PAGES}/attribution.html): 利用時に必要な出典表示の文例
 `;
 }

--- a/scripts/map-search.test.js
+++ b/scripts/map-search.test.js
@@ -1,4 +1,4 @@
-// 地図・検索ページ(map.html)の検索機能と、検索 API 仕様との整合性テスト。
+// 地図ページ(map.html)の検索窓と、検索 API 仕様との整合性テスト。
 //   node scripts/map-search.test.js
 //
 // map.html は geosearch（https://github.com/naogify/geosearch）の検索 API を
@@ -7,8 +7,9 @@
 // ここでは API 仕様のスナップショットをこのファイルに固定し、map.html の
 // 記述と突き合わせる。API 仕様が変わったらこのスナップショットも更新すること。
 //
-// 旧 playground.html は map.html へ統合したため、公開済み URL からの導線が
-// 切れないようリダイレクトが残っていることもここで固定する。
+// ページはキーワード検索だけの最小構成で、API のプレイグラウンド機能
+// （範囲指定・件数指定・リクエストURL表示・CSV出力）は持たない。
+// 旧 playground.html は map.html へのリダイレクトだけを残してある。
 
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
@@ -44,28 +45,11 @@ test('API エンドポイントを ?api= で上書きでき、既定値の定数
 test('ページが組み立てるクエリパラメータが API 仕様の範囲内である', () => {
   // params.set('xxx', ...) で使っているキーを抽出して仕様と突き合わせる。
   const used = [...HTML.matchAll(/params\.set\('([a-z_]+)'/g)].map((m) => m[1]);
-  assert.ok(used.length >= 3, `クエリパラメータを組み立てている (${used.join(',')})`);
   for (const key of used) {
     assert.ok(API_QUERY_PARAMS.includes(key), `パラメータ ${key} が API 仕様に存在する`);
   }
-  // 主要な検索パラメータは一通り使っていること（機能の退行防止）。
-  for (const key of API_QUERY_PARAMS) {
-    assert.ok(used.includes(key), `パラメータ ${key} をページが利用している`);
-  }
-});
-
-test('CSV ダウンロードの列が API レスポンス仕様と一致する', () => {
-  // RESULT_FIELDS 配列（CSV の列定義）を抽出して仕様と突き合わせる。
-  const m = HTML.match(/const RESULT_FIELDS = \[([^\]]+)\]/);
-  assert.ok(m, 'RESULT_FIELDS が定義されている');
-  const fields = [...m[1].matchAll(/'([a-z_]+)'/g)].map((x) => x[1]);
-  for (const f of fields) {
-    assert.ok(API_RESULT_FIELDS.includes(f), `フィールド ${f} が API レスポンス仕様に存在する`);
-  }
-  // レスポンス仕様の全フィールドを CSV に出していること（情報の取りこぼし防止）。
-  for (const f of API_RESULT_FIELDS) {
-    assert.ok(fields.includes(f), `API のフィールド ${f} を CSV に出力する`);
-  }
+  // キーワード検索だけの最小構成なので q は必須。
+  assert.ok(used.includes('q'), 'キーワード q で検索している');
 });
 
 test('結果リスト・地図が参照するフィールドが API レスポンス仕様に存在する', () => {
@@ -93,6 +77,13 @@ test('検索結果を全件タイルとは別のソース・レイヤで重ね�
   assert.ok(/getSource\('results'\)\.setData/.test(HTML), '検索結果を setData で差し替える');
 });
 
+test('API プレイグラウンドの UI を持たない（最小構成を維持する）', () => {
+  // 統計表示と検索窓だけのページに保つ。復活させたい場合はこのテストも一緒に直す。
+  for (const gone of ['request-url', 'downloadCsv', 'RESULT_FIELDS', 'curl']) {
+    assert.ok(!HTML.includes(gone), `map.html が ${gone} を持たない`);
+  }
+});
+
 test('旧 playground.html が map.html へリダイレクトする', () => {
   assert.ok(
     /http-equiv="refresh"[^>]*url=\.\/map\.html/.test(PLAYGROUND),
@@ -111,4 +102,4 @@ test('廃止した配信形式・存在しないエンドポイントを参照�
   }
 });
 
-console.log(`\n✅ 地図・検索ページ 整合性テスト: ${passed}件すべて合格`);
+console.log(`\n✅ 地図ページ 整合性テスト: ${passed}件すべて合格`);


### PR DESCRIPTION
## 概要

地図ページ（`map.html`）を **統計表示と検索窓だけ** の最小構成にしました。検索 API のプレイグラウンドとしての機能は一旦不要とのことなので削除しています。

#65 で統合したページから、API を触って遊ぶための UI を落とし、「地図を見る」＋「名称・住所で探す」だけに絞った形です。

## 変更点

### `map.html`
- **残したもの**: 統計（都道府県 / 市区町村 / 施設数）、キーワード検索窓、検索結果一覧（クリックでその施設へ移動）、全件ベクトルタイル、出典リンク
- **外したもの**: 検索範囲の指定（`bbox` / `center`+`radius`）、上限件数の指定、API リクエスト URL の表示、CSV ダウンロード、`DEFAULT_API_URL` 未設定時の開発者向け案内
- 検索 API のエンドポイント（`DEFAULT_API_URL`）は未設定のままなので、**公開時点では検索窓は無効**（プレースホルダに「検索は準備中です」）。地図の閲覧はそのまま使えます

### ドキュメント
- README から検索に関する記述（「地図から検索する」節・ヘッダーリンクの「検索する」）を削除
- LP（`index.html`）・`AGENTS.md`・`llms.txt` / `llms-full.txt` からも検索機能の説明を削除し、`map.html` は「プレビュー地図」としての導線に戻した
- `scripts/map-search.test.js` はプレイグラウンド UI（リクエスト URL 表示・CSV 出力）を持たないことを固定するテストに変更

## 動作確認

- `npm run test:unit` 全件パス
- ローカルでモック検索 API を立てて確認: 検索 → 一覧3件・地図の青点・結果範囲へズーム
- API 未設定時（本番と同じ状態）: 統計と無効化された検索窓のみ、地図は操作可能
