### PR TITLE
fix: 市区町村名の粒度を揃える（政令市の行政区を集約・町村を郡付きに統一）

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Claude Code や Codex などのコーディングエージェントでこのデ�
 | 列 | 内容 |
 |---|---|
 | `prefecture` | 都道府県 |
-| `city` | 正規化後の市区町村名 |
+| `city` | 正規化後の市区町村名（政令市は市に集約、町村は郡付き） |
 | `city_raw` | 元データの市区町村表記 |
 | `name` / `name_kana` | 施設名・カナ |
 | `business_type` | 営業許可・届出の業種 |
@@ -131,7 +131,7 @@ Claude Code や Codex などのコーディングエージェントでこのデ�
 | `license_date` / `expire_date` | 許可日・有効期限 |
 | `sources` / `licenses` | 元データの出典・ライセンス |
 
-市区町村名は、[normalize-japanese-addresses](https://github.com/geolonia/normalize-japanese-addresses) を利用して公式表記に正規化しています。
+市区町村名は、[normalize-japanese-addresses](https://github.com/geolonia/normalize-japanese-addresses) を利用して公式表記に正規化しています。粒度は市区町村に揃えており、政令指定都市の行政区は市に集約し（「横浜市戸塚区」→「横浜市」）、町村は郡付きの表記（「河北郡津幡町」）を使います。元データの表記は `city_raw` に残しています。
 
 ## 収録範囲
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -112,7 +112,7 @@ Claude Code や Codex などのコーディングエージェントでこのデ�
 | 列 | 内容 |
 |---|---|
 | `prefecture` | 都道府県 |
-| `city` | 正規化後の市区町村名 |
+| `city` | 正規化後の市区町村名（政令市は市に集約、町村は郡付き） |
 | `city_raw` | 元データの市区町村表記 |
 | `name` / `name_kana` | 施設名・カナ |
 | `business_type` | 営業許可・届出の業種 |
@@ -124,7 +124,7 @@ Claude Code や Codex などのコーディングエージェントでこのデ�
 | `license_date` / `expire_date` | 許可日・有効期限 |
 | `sources` / `licenses` | 元データの出典・ライセンス |
 
-市区町村名は、[normalize-japanese-addresses](https://github.com/geolonia/normalize-japanese-addresses) を利用して公式表記に正規化しています。
+市区町村名は、[normalize-japanese-addresses](https://github.com/geolonia/normalize-japanese-addresses) を利用して公式表記に正規化しています。粒度は市区町村に揃えており、政令指定都市の行政区は市に集約し（「横浜市戸塚区」→「横浜市」）、町村は郡付きの表記（「河北郡津幡町」）を使います。元データの表記は `city_raw` に残しています。
 
 ## 収録範囲
 

--- a/scripts/build-merged-csv.test.js
+++ b/scripts/build-merged-csv.test.js
@@ -11,7 +11,13 @@ import path from 'node:path';
 import { buildMergedCsv, CSV_COLUMNS, csvCell } from './build-merged-csv.js';
 import { generateTiles } from './gen-tiles.js';
 import { readCsvRows } from './lib/csv-read.js';
-import { resolvePrefCity, applyPrefCity, collectCityPairs } from './lib/city-normmap.js';
+import {
+  resolvePrefCity,
+  applyPrefCity,
+  collectCityPairs,
+  stripWardSuffix,
+  buildCountyAliasMap,
+} from './lib/city-normmap.js';
 
 let passed = 0;
 async function test(name, fn) {
@@ -183,15 +189,65 @@ await test('CSV: gzip 版は生成しない（配布は非圧縮CSVのみ）', a
 
 // --- 市区町村の名寄せ（純粋関数） ---
 await test('resolvePrefCity: 名寄せ表があれば公式名を採用する', () => {
-  const f = { _pref: '大分県', _city: '玖珠郡九重町', address: '大分県玖珠郡九重町大字後野上8-1' };
-  const r = resolvePrefCity(f, { '大分県\t玖珠郡九重町': { pref: '大分県', city: '九重町' } });
-  assert.deepEqual(r, { pref: '大分県', city: '九重町', cityRaw: '玖珠郡九重町', colFixed: false });
+  const f = { _pref: '大分県', _city: '九重町', address: '大分県九重町大字後野上8-1' };
+  // normalize() は郡付きの公式名を返す。
+  const r = resolvePrefCity(f, { '大分県\t九重町': { pref: '大分県', city: '玖珠郡九重町' } });
+  assert.deepEqual(r, { pref: '大分県', city: '玖珠郡九重町', cityRaw: '九重町', colFixed: false });
 });
 
-await test('resolvePrefCity: 名寄せ表に無ければ郡名を剥がす', () => {
+await test('resolvePrefCity: 名寄せ表にも対応表にも無ければ元の表記を保つ', () => {
   const f = { _pref: '大分県', _city: '玖珠郡九重町', address: '大分県玖珠郡九重町…' };
-  assert.equal(resolvePrefCity(f, {}).city, '九重町');
+  assert.equal(resolvePrefCity(f, {}).city, '玖珠郡九重町', '郡名は勝手に剥がさない');
   assert.equal(resolvePrefCity(f, {}).cityRaw, '玖珠郡九重町');
+});
+
+// --- 粒度の統一: 政令指定都市の行政区は市に集約する ---
+await test('stripWardSuffix: 政令市の行政区を市に集約し、特別区はそのまま返す', () => {
+  assert.equal(stripWardSuffix('横浜市戸塚区'), '横浜市');
+  assert.equal(stripWardSuffix('京都市北区'), '京都市');
+  assert.equal(stripWardSuffix('北九州市八幡西区'), '北九州市');
+  assert.equal(stripWardSuffix('千代田区'), '千代田区', '特別区は市区町村そのもの');
+  assert.equal(stripWardSuffix('四日市市'), '四日市市', '「市」で終わる市名は無傷');
+  assert.equal(stripWardSuffix('河北郡津幡町'), '河北郡津幡町');
+});
+
+await test('resolvePrefCity: 名寄せ結果の行政区を市へ集約する', () => {
+  const f = { _pref: '神奈川県', _city: '横浜市', address: '神奈川県横浜市戸塚区戸塚町16-1' };
+  const normMap = { '神奈川県\t横浜市': { pref: '神奈川県', city: '横浜市戸塚区' } };
+  const r = resolvePrefCity(f, normMap);
+  assert.equal(r.city, '横浜市');
+  assert.equal(r.cityRaw, '横浜市', '元データの表記は city_raw に残す');
+});
+
+// --- 粒度の統一: 町村は郡付きの公式表記へ寄せる ---
+await test('buildCountyAliasMap: 名寄せ結果から「郡なし→郡付き」の対応表を作る', () => {
+  const alias = buildCountyAliasMap({
+    '石川県\t河北郡津幡町': { pref: '石川県', city: '河北郡津幡町' },
+    '東京都\t港区': { pref: '東京都', city: '港区' },
+    '不明\t不明': null,
+  });
+  assert.deepEqual(alias, { '石川県\t津幡町': '河北郡津幡町' }, '郡付きの値だけが対応表になる');
+});
+
+await test('resolvePrefCity: 郡なしの町村名を郡付きの公式表記へ寄せる', () => {
+  const f = { _pref: '石川県', _city: '津幡町', address: '石川県津幡町字加賀爪ニ3' };
+  const alias = { '石川県\t津幡町': '河北郡津幡町' };
+  const r = resolvePrefCity(f, {}, alias);
+  assert.equal(r.city, '河北郡津幡町');
+  assert.equal(r.cityRaw, '津幡町');
+});
+
+await test('applyPrefCity: 郡あり・郡なしの表記ゆれが同じ市区町村に揃う', () => {
+  const facilities = [
+    { _pref: '石川県', _city: '河北郡津幡町', address: '石川県河北郡津幡町字加賀爪ニ3' },
+    { _pref: '石川県', _city: '津幡町', address: '石川県津幡町字加賀爪ニ3' },
+  ];
+  // 郡付き側だけ名寄せに成功したケース（郡なし側は対応表で救う）。
+  applyPrefCity(facilities, {
+    '石川県\t河北郡津幡町': { pref: '石川県', city: '河北郡津幡町' },
+  });
+  assert.equal(facilities[0].city, '河北郡津幡町');
+  assert.equal(facilities[1].city, '河北郡津幡町', '郡なし表記も同じ値に寄る');
 });
 
 await test('resolvePrefCity: 列ズレ（pref に郵便番号・city に都道府県名）を住所から復元する', () => {
@@ -207,12 +263,14 @@ await test('applyPrefCity: 施設に pref / city / city_raw を書き込み件�
     { _pref: '大分県', _city: '玖珠郡九重町', address: '大分県玖珠郡九重町…' },
     { _pref: '東京都', _city: '港区', address: '東京都港区赤坂1-1' },
   ];
-  const { colFixedCount, mergedCount } = applyPrefCity(facilities, {});
-  assert.equal(facilities[0].city, '九重町');
+  const { colFixedCount, mergedCount } = applyPrefCity(facilities, {
+    '大分県\t玖珠郡九重町': { pref: '大分県', city: '玖珠郡九重町' },
+  });
+  assert.equal(facilities[0].city, '玖珠郡九重町');
   assert.equal(facilities[0].city_raw, '玖珠郡九重町');
   assert.equal(facilities[1].city, '港区');
   assert.equal(colFixedCount, 0);
-  assert.equal(mergedCount, 1);
+  assert.equal(mergedCount, 0, '表記が変わらなければ名寄せ件数に数えない');
 });
 
 await test('collectCityPairs: ユニークな (都道府県, 市区町村) を代表住所つきで集める', () => {

--- a/scripts/lib/city-normmap.js
+++ b/scripts/lib/city-normmap.js
@@ -5,6 +5,14 @@
 // @geolonia/normalize-japanese-addresses で公式の都道府県・市区町村名へ寄せた
 // 対応表を作り、各施設に確定した pref / city / city_raw を付与する。
 //
+// 出力する city の粒度は「市区町村」に揃える。具体的には次の2点を保証する:
+//   - 政令指定都市の行政区は市に集約する（「横浜市戸塚区」→「横浜市」）。
+//     splitPrefCity（normalize.js）と同じ粒度に合わせるため。
+//   - 町村は郡付きの公式表記に揃える（「津幡町」→「河北郡津幡町」）。
+//     名寄せに成功した表記が郡付きなので、解決できなかった側をそちらへ寄せる。
+// 揃えないと、同じ自治体が「横浜市戸塚区」「河北郡津幡町」「津幡町」のように
+// 複数の値へ分裂し、市区町村の異なり数が実際の自治体数（1,741）を超えてしまう。
+//
 // 正規化の呼び出しは (都道府県, 市区町村) のユニークなペア（全国で約2,000通り）だけに
 // 絞る。施設全件（140万件超）を正規化する必要はないため、並列8本で数分で終わる。
 
@@ -14,12 +22,40 @@ import { PREFECTURE_NAMES, splitPrefCity } from './normalize.js';
 const PREFS = new Set(PREFECTURE_NAMES);
 
 /**
- * 郡名プレフィックスを剥がすフォールバック（名寄せ表で解決できなかった場合）。
- * 例: 「玖珠郡九重町」→「九重町」
+ * 郡名プレフィックスを剥がす。例: 「玖珠郡九重町」→「九重町」
+ * 郡付き・郡なしの表記ゆれを突き合わせるためのキー作りに使う（出力値には使わない）。
  */
 function stripCountyPrefix(city) {
   const m = String(city).match(/郡(.+?[町村])$/);
   return m ? m[1] : city;
+}
+
+/**
+ * 政令指定都市の行政区を市に集約する（純粋関数）。
+ * 例: 「横浜市戸塚区」→「横浜市」、「京都市北区」→「京都市」
+ * 市名を含まない特別区（「千代田区」）や行政区単独の値はそのまま返す。
+ */
+export function stripWardSuffix(city) {
+  const m = String(city).match(/^(.+?市).+区$/);
+  return m ? m[1] : city;
+}
+
+/**
+ * 名寄せ表の値から「郡なし町村名 → 郡付き公式名」の対応表を作る（純粋関数）。
+ * キーは `"都道府県\t郡なし町村名"`。
+ *
+ * 名寄せに失敗したペア（normMap の値が null）は郡付きの公式名が分からないため、
+ * 同じ実行内で名寄せに成功した他ソースの結果を辞書として流用する。
+ */
+export function buildCountyAliasMap(normMap = {}) {
+  const alias = {};
+  for (const v of Object.values(normMap)) {
+    if (!v?.pref || !v?.city) continue;
+    const short = stripCountyPrefix(v.city);
+    // 郡付きの値だけが対応表になる（「九重町」→「玖珠郡九重町」）。
+    if (short !== v.city) alias[`${v.pref}\t${short}`] = v.city;
+  }
+  return alias;
 }
 
 /**
@@ -92,9 +128,11 @@ export async function buildCityNormMap(facilities, { concurrency = 8, log = cons
  *
  * 1. 列ズレ補正: pref が都道府県名でない（郵便番号等）／city に都道府県名が入っている
  *    ソース（富山県の数件）は、住所先頭から都道府県・市区町村を復元する。
- * 2. 名寄せ: 名寄せ表にあれば公式の都道府県・市区町村名を採用。無ければ郡名剥がし。
+ * 2. 名寄せ: 名寄せ表にあれば公式の都道府県・市区町村名を採用。無ければ郡付き対応表
+ *    （countyAlias）で公式表記を補う。
+ * 3. 粒度統一: どちらの経路でも政令指定都市の行政区は市に集約する。
  */
-export function resolvePrefCity(facility, normMap = {}) {
+export function resolvePrefCity(facility, normMap = {}, countyAlias = {}) {
   const rawPref = facility._pref || '不明';
   const rawCity = facility._city || '不明';
 
@@ -111,20 +149,25 @@ export function resolvePrefCity(facility, normMap = {}) {
   }
 
   const nm = normMap[`${rawPref}\t${rawCity}`];
-  if (nm?.pref && nm?.city) return { pref: nm.pref, city: nm.city, cityRaw, colFixed };
-  return { pref, city: stripCountyPrefix(cityRaw), cityRaw, colFixed };
+  if (nm?.pref && nm?.city) {
+    return { pref: nm.pref, city: stripWardSuffix(nm.city), cityRaw, colFixed };
+  }
+  // 名寄せできなかった分は、郡付き対応表があれば公式表記へ寄せる（無ければ元の表記のまま）。
+  const official = countyAlias[`${pref}\t${stripCountyPrefix(cityRaw)}`];
+  return { pref, city: stripWardSuffix(official || cityRaw), cityRaw, colFixed };
 }
 
 /**
  * 施設配列に確定した pref / city / city_raw を書き込む（破壊的）。
  * 以降の出力（結合CSV・ベクトルタイル）は共通してこの値を使う。
+ * 郡付き対応表は名寄せ表から自動で作る（テスト等から明示的に渡すこともできる）。
  * 補正・名寄せの件数を返す。
  */
-export function applyPrefCity(facilities, normMap) {
+export function applyPrefCity(facilities, normMap, countyAlias = buildCountyAliasMap(normMap)) {
   let colFixedCount = 0;
   let mergedCount = 0;
   for (const f of facilities) {
-    const { pref, city, cityRaw, colFixed } = resolvePrefCity(f, normMap);
+    const { pref, city, cityRaw, colFixed } = resolvePrefCity(f, normMap, countyAlias);
     f.pref = pref;
     f.city = city;
     f.city_raw = cityRaw;


### PR DESCRIPTION
## 背景

配信中のデータの市区町村の異なり数が **1,796** で、実在の自治体数 1,741 を超えていた。
同じ自治体が複数の `city` 値へ分裂していたのが原因（S3 の全件CSV 1,488,756 件を集計して確認）。

内訳:

| 要因 | 数 | 例 |
|---|---|---|
| 政令指定都市の行政区が市に集約されていない | 28値 / 14市 | `横浜市戸塚区`, `京都市北区` |
| 町村の郡あり・郡なしが両方存在する | 3組 | `河北郡津幡町` ↔ `津幡町` |
| `不明` バケツ | 44 | `福井県/不明`（16,313件）等 |
| `県外` 由来 | 1 | `県外/小矢部市` |

このPRは上2つ（行政区・郡表記）を直す。`不明` / `県外` の扱いは別途対応。

## 変更内容

### 1. 政令指定都市の行政区を市に集約する

`normalize()` が返す `横浜市戸塚区` をそのまま `city` にしていたため、`splitPrefCity()`（`normalize.js`）の「政令市は市に集約」という粒度と食い違っていた。`stripWardSuffix()` を追加し、名寄せ経路・フォールバック経路の両方で市へ寄せる。特別区（`千代田区`）や `四日市市` は対象外。

あわせて、名寄せ表が **(都道府県, 市区町村) ペアごとに代表住所1件だけ**を正規化する作りのせいで起きていた誤配置も解消する。たとえば京都市の 35,018 件は、代表住所がたまたま北区だったせいで全件が `京都市北区` になっていた（横浜市も全件 `横浜市戸塚区`）。

### 2. 町村を郡付きの公式表記に統一する

名寄せに失敗したときのフォールバックが郡名を剥がしていたため、成功側（`河北郡津幡町`）と失敗側（`津幡町`）で値が割れていた。剥がすのをやめ、同じ実行内で名寄せに成功した結果から「郡なし → 郡付き」の対応表（`buildCountyAliasMap()`）を作って寄せる。対応表にも無ければ元の表記を保つ。

## 検証

配信中のCSVの `(prefecture, city)` 全ペアに同じ変換を適用:

```
修正前: 1796 → 修正後: 1779
うち 不明/県外: 45 → 実自治体: 1734   （1,741 以下に収まる）
```

実際のクロールでも確認（`--only=kyoto-city,toyama-pref,kanazawa --no-geocode`）:

```
35018 京都府  京都市              ← 修正前は「京都市北区」に全件
  448 富山県  中新川郡立山町       ← 郡付きを維持
    1 石川県  河北郡津幡町
```

ユニットテストを7件追加（`stripWardSuffix` / `buildCountyAliasMap` / 名寄せ経路・フォールバック経路の両方）。`npm run test:unit` は全件パス。`npm test` の統合テストは生成済みの `api/` を要するためローカルでは実行不可（CI も `test:unit` のみ）。

## 影響

- `city` 列の値が変わる（政令市 → 市名、郡なし町村 → 郡付き）。元データの表記は従来どおり `city_raw` に残る
- 反映は次回のクロール（毎週月曜 18:00 UTC / Fargate）から
- README のデータ項目説明を更新し、`llms-full.txt` を再生成