### PR TITLE
ポップアップに実データが持つ属性を表示する

### DIFF
--- a/map.html
+++ b/map.html
@@ -360,42 +360,66 @@
     map.on('load', updateHint);
 
     // ================= ポップアップ =================
+    // ポップアップは「そのデータが実際に持っている属性」だけを出す。
+    // 見出し（施設名）以外は属性を1件ずつ行にし、値が空のものは行ごと省く。
+    // ラベルが未定義のキーが増えたときは、キー名をそのまま見出しに使って必ず表示する。
+
+    // ベクトルタイル(facilities レイヤ)が持つ属性のラベル。
+    // scripts/gen-tiles.js の buildFeatureCollection が作る properties と対応させる。
+    const TILE_PROP_LABELS = {
+      name: '名称',
+      business_type: '業種',
+      pref: '都道府県',
+      city: '市区町村',
+    };
+    // 検索 API のレスポンス results[] が持つ属性のラベル。
+    const SEARCH_PROP_LABELS = {
+      name: '名称',
+      name_kana: '名称カナ',
+      business_type: '業種',
+      prefecture: '都道府県',
+      city: '市区町村',
+      address: '住所',
+      lat: '緯度',
+      lng: '経度',
+      level: 'ジオコーディング精度',
+    };
+
     /**
-     * 施設のポップアップを表示する。`info` は { name, business_type, place, address } で、
-     * ベクトルタイルの feature と検索結果の行の両方から組み立てて渡す。
+     * 属性オブジェクトからポップアップの HTML を組み立てる（純粋な文字列生成）。
+     * `name` は見出しに使い、それ以外の値のある属性をラベル付きの行にする。
      */
-    function showPopup(lngLat, info) {
+    function popupHtml(props, labels) {
       const rows = [];
-      if (info.business_type) rows.push(`<p class="fac-row"><span class="k">業種</span>${esc(info.business_type)}</p>`);
-      if (info.place) rows.push(`<p class="fac-row"><span class="k">所在</span>${esc(info.place)}</p>`);
-      if (info.address) rows.push(`<p class="fac-row"><span class="k">住所</span>${esc(info.address)}</p>`);
-      new maplibregl.Popup({ offset: 8, maxWidth: '280px' })
+      for (const [key, value] of Object.entries(props)) {
+        // 見出しに使う name と、空文字・null・undefined の属性は行にしない。
+        if (key === 'name') continue;
+        if (value === null || value === undefined || value === '') continue;
+        rows.push(`<p class="fac-row"><span class="k">${esc(labels[key] || key)}</span>${esc(value)}</p>`);
+      }
+      const title = props.name ? esc(props.name) : '（名称なし）';
+      return `<p class="fac-name">${title}</p>${rows.join('')}`;
+    }
+
+    let currentPopup = null; // 表示中のポップアップ（属性が混ざらないよう常に1つに保つ）
+
+    /** 施設のポップアップを地図上に表示する。`props` はそのデータが持つ属性そのまま。 */
+    function showPopup(lngLat, props, labels) {
+      if (currentPopup) currentPopup.remove();
+      currentPopup = new maplibregl.Popup({ offset: 8, maxWidth: '280px' })
         .setLngLat(lngLat)
-        .setHTML(`<p class="fac-name">${esc(info.name) || '（名称なし）'}</p>${rows.join('')}`)
+        .setHTML(popupHtml(props, labels))
         .addTo(map);
     }
 
-    /** 検索結果の1行からポップアップ用の情報を組み立てる。 */
-    function rowToInfo(row) {
-      return {
-        name: row.name,
-        business_type: row.business_type,
-        place: [row.prefecture, row.city].filter(Boolean).join(' '),
-        address: row.address,
-      };
-    }
-
-    // ベクトルタイルの点をクリック（属性は name / business_type / pref / city）。
+    // ベクトルタイルの点をクリック（属性はタイルが持つものをそのまま出す）。
     map.on('click', 'facilities-circle', (e) => {
-      const p = e.features[0].properties || {};
-      showPopup(e.lngLat, {
-        name: p.name,
-        business_type: p.business_type,
-        place: [p.pref, p.city].filter(Boolean).join(' '),
-      });
+      showPopup(e.lngLat, e.features[0].properties || {}, TILE_PROP_LABELS);
     });
     // 検索結果の点をクリック（属性は検索 API のレスポンスをそのまま入れてある）。
-    map.on('click', 'results-circle', (e) => showPopup(e.lngLat, rowToInfo(e.features[0].properties || {})));
+    map.on('click', 'results-circle', (e) => {
+      showPopup(e.lngLat, e.features[0].properties || {}, SEARCH_PROP_LABELS);
+    });
     for (const layer of ['facilities-circle', 'results-circle']) {
       map.on('mouseenter', layer, () => { map.getCanvas().style.cursor = 'pointer'; });
       map.on('mouseleave', layer, () => { map.getCanvas().style.cursor = ''; });
@@ -459,7 +483,7 @@
         const focus = () => {
           if (!Number.isFinite(row.lat) || !Number.isFinite(row.lng)) return;
           map.flyTo({ center: [row.lng, row.lat], zoom: Math.max(map.getZoom(), 14) });
-          showPopup([row.lng, row.lat], rowToInfo(row));
+          showPopup([row.lng, row.lat], row, SEARCH_PROP_LABELS);
         };
         li.addEventListener('click', focus);
         li.addEventListener('keydown', (e) => { if (e.key === 'Enter') focus(); });
@@ -487,13 +511,8 @@
         features.push({
           type: 'Feature',
           geometry: { type: 'Point', coordinates: [row.lng, row.lat] },
-          properties: {
-            name: row.name,
-            business_type: row.business_type,
-            prefecture: row.prefecture,
-            city: row.city,
-            address: row.address,
-          },
+          // API が返した属性をそのまま持たせる（ポップアップは実データの属性だけを出す）。
+          properties: { ...row },
         });
         if (!bbox) bbox = [row.lng, row.lat, row.lng, row.lat];
         else {

--- a/scripts/map-search.test.js
+++ b/scripts/map-search.test.js
@@ -65,6 +65,20 @@ test('結果リスト・地図が参照するフィールドが API レスポン
   }
 });
 
+test('ポップアップのラベル定義が API レスポンス仕様と過不足なく一致する', () => {
+  // ポップアップは検索結果が実際に持つ属性を出すため、ラベル定義(SEARCH_PROP_LABELS)が
+  // API 仕様とズレるとキー名がそのまま画面に出てしまう。
+  const m = HTML.match(/const SEARCH_PROP_LABELS = \{([^}]+)\}/);
+  assert.ok(m, 'map.html に SEARCH_PROP_LABELS が定義されている');
+  const labeled = [...m[1].matchAll(/^\s*([a-z_]+):/gm)].map((x) => x[1]);
+  for (const key of API_RESULT_FIELDS) {
+    assert.ok(labeled.includes(key), `API のフィールド ${key} のラベルが定義されている`);
+  }
+  for (const key of labeled) {
+    assert.ok(API_RESULT_FIELDS.includes(key), `ラベル定義の ${key} が API レスポンス仕様に存在する`);
+  }
+});
+
 test('レスポンスの count / results / error を仕様どおり参照している', () => {
   assert.ok(/body\.results/.test(HTML), 'results 配列を読んでいる');
   assert.ok(/body\.count/.test(HTML), 'count を読んでいる');

--- a/scripts/preview-map.test.js
+++ b/scripts/preview-map.test.js
@@ -83,13 +83,18 @@ test('タイルURLテンプレートが「api/tiles/ + metadata.tiles[0]」の�
   });
 });
 
-test('ポップアップで参照する施設属性がすべて生成featureに存在する', () => {
-  const props = buildFeatureCollection(FACILITIES).features[0].properties;
-  // map.html が p.<prop> として参照している属性を抽出する。
-  const referenced = new Set([...HTML.matchAll(/\bp\.([a-z_]+)\b/g)].map((m) => m[1]));
-  assert.ok(referenced.size >= 3, `map.html が施設属性を参照している (${[...referenced].join(',')})`);
-  for (const key of referenced) {
-    assert.ok(key in props, `属性 ${key} が生成feature.properties に存在する`);
+test('ポップアップのラベル定義が生成featureの属性と過不足なく一致する', () => {
+  // ポップアップは feature が実際に持つ属性を出すため、ラベル定義(TILE_PROP_LABELS)が
+  // 生成物とズレるとキー名がそのまま画面に出る／表示されない属性が生まれる。
+  const props = Object.keys(buildFeatureCollection(FACILITIES).features[0].properties);
+  const m = HTML.match(/const TILE_PROP_LABELS = \{([^}]+)\}/);
+  assert.ok(m, 'map.html に TILE_PROP_LABELS が定義されている');
+  const labeled = [...m[1].matchAll(/^\s*([a-z_]+):/gm)].map((x) => x[1]);
+  for (const key of props) {
+    assert.ok(labeled.includes(key), `生成属性 ${key} のラベルが定義されている`);
+  }
+  for (const key of labeled) {
+    assert.ok(props.includes(key), `ラベル定義の ${key} が生成feature.properties に存在する`);
   }
 });
 


### PR DESCRIPTION
## 概要

地図のポップアップが、**そのデータが実際に持っている属性**を表示するようにしました。

これまでは表示内容が固定（業種 / 所在 / 住所）で、実データの属性と噛み合っていませんでした。

- ベクトルタイルの属性は `name` / `business_type` / `pref` / `city` の4つだけなのに、`pref` と `city` を「所在」にまとめて出していた
- タイルには存在しない「住所」の行を用意していた（常に出ない死んだ分岐）
- 検索結果の feature も一部の属性しか持たせておらず、`name_kana` / `level` などは捨てていた

## 変更点

- `popupHtml()` が feature の `properties` を走査し、**値のある属性だけ**をラベル付きで並べる方式に変更（`name` は見出し）
- 属性ラベルを定義に切り出し、生成物・API 仕様と過不足なく一致することをテストで固定
  - `TILE_PROP_LABELS` … `scripts/gen-tiles.js` の `buildFeatureCollection` が作る属性と一致（`scripts/preview-map.test.js`）
  - `SEARCH_PROP_LABELS` … 検索 API のレスポンス仕様と一致（`scripts/map-search.test.js`）
  - ラベル未定義のキーはキー名のまま表示するので、属性が増えても取りこぼさない
- 検索結果の feature には API のレスポンスをそのまま持たせた（`{ ...row }`）
- あわせて、ポップアップは常に1つだけ開くようにした（別の施設の属性が並ぶとどれの属性か分からなくなるため）

## 表示例

タイルの点（実データ・渋谷）:

```
シャンティー
業種       ⑬ その他の食料・飲料販売業
都道府県   東京都
市区町村   渋谷区
```

検索結果の点（モック API のレスポンス）:

```
渋谷ラーメン本店
名称カナ            シブヤラーメンホンテン
都道府県            東京都
市区町村            渋谷区
住所                東京都渋谷区道玄坂1-1-1
業種                飲食店営業
緯度                35.6595
経度                139.7005
ジオコーディング精度  8
```

## 動作確認

- `npm run test:unit` 全件パス
- ブラウザで CloudFront の実タイルをクリック → タイルが持つ4属性のみ表示
- モック検索 API の結果をクリック → レスポンスの全属性を表示、ポップアップは常に1つ
