### PR TITLE
都道府県別CSV（47ファイル）を生成して配信する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 AI コーディングエージェント（Claude Code / Codex 等）向けのガイド。
 このリポジトリは、全国の食品営業許可・届出データを収集・正規化し、
-**全件CSV** と **ベクトルタイル** の2形式で無料配信するオープンデータプロジェクト。
+**全件CSV**・**都道府県別CSV**・**ベクトルタイル** の3形式で無料配信するオープンデータプロジェクト。
 静的ページは GitHub Pages、データ（`api/`）は S3 + CloudFront から配信する。
 
 ## このデータでアプリを作る場合
@@ -14,9 +14,12 @@ AI コーディングエージェント（Claude Code / Codex 等）向けのガ
   - UTF-8 **BOMなし**、100万件超・数百MB（gzip 版は配信していない）。
     正確な件数・サイズは README の統計ブロック（自動生成）を参照する
   - 列: `prefecture, city, city_raw, name, name_kana, business_type, address, lat, lng, geocoding_level, phone, license_no, license_date, expire_date, sources, licenses`
+- 都道府県別CSV: `https://d1nptpfogf2ynv.cloudfront.net/api/prefectures/{JISコード2桁}-{ローマ字}.csv`
+  - 例 `13-tokyo.csv` / `01-hokkaido.csv`。47都道府県すべて存在し、列・内容は全件CSV と同じ。
+    ファイル一覧と件数は `api/prefectures/index.json`。1県だけ必要ならこちらを使う
 - ベクトルタイル（MVT）: `https://d1nptpfogf2ynv.cloudfront.net/api/tiles/{z}/{x}/{y}.pbf`
   - レイヤ名 `facilities`、z6–12、属性 `name` / `business_type` / `pref` / `city`
-- 市区町村別 JSON や検索 API は**このリポジトリからは配信していない**。データ抽出は
+- 市区町村別 CSV/JSON や検索 API は**このリポジトリからは配信していない**。データ抽出は
   CSV（DuckDB 推奨）、地図表示はタイルを使う。ブラウザから非圧縮 CSV を直接 fetch しない
 - `map.html` は統計表示と検索窓だけの最小構成のプレビュー地図。検索窓は
   [geosearch](https://github.com/naogify/geosearch) の検索 API を呼ぶが、

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 - 登録不要・APIキー不要
 - 商用利用可能
-- 全件CSVとベクトルタイルで配信
+- 全件CSV・都道府県別CSV・ベクトルタイルで配信
 - 住所の正規化と緯度経度の補完に対応
 - 毎週自動更新
 
@@ -69,7 +69,46 @@ df = pd.read_csv(
 )
 ```
 
-市区町村別JSONや検索APIは配信していません。必要な範囲をCSVから抽出してください。
+### 都道府県別CSV
+
+一部の地域だけが必要な場合は、全件CSV（数百MB）ではなく都道府県別CSVを使ってください。列と内容は全件CSVと同じで、都道府県ごとに分割してあります。
+
+| ファイル | URL |
+|---|---|
+| 都道府県別CSV | `https://d1nptpfogf2ynv.cloudfront.net/api/prefectures/{JISコード}-{ローマ字}.csv` |
+| ファイル一覧（JSON） | https://d1nptpfogf2ynv.cloudfront.net/api/prefectures/index.json |
+
+ファイル名は、JIS都道府県コード（2桁）とローマ字を組み合わせた `01-hokkaido.csv` 〜 `47-okinawa.csv` です。47都道府県すべてのURLが常に存在します。
+
+```bash
+# 東京都だけダウンロードする
+curl -O https://d1nptpfogf2ynv.cloudfront.net/api/prefectures/13-tokyo.csv
+```
+
+```python
+import pandas as pd
+
+df = pd.read_csv(
+    "https://d1nptpfogf2ynv.cloudfront.net/api/prefectures/13-tokyo.csv"
+)
+```
+
+各ファイルの件数とサイズは `index.json` で確認できます。
+
+```json
+{
+  "updated": 1785000000,
+  "columns": ["prefecture", "city", "..."],
+  "unassigned": 0,
+  "prefectures": [
+    { "code": "13", "name": "東京都", "romaji": "tokyo", "file": "13-tokyo.csv", "records": 123456, "bytes": 34567890 }
+  ]
+}
+```
+
+元データから都道府県を特定できなかったレコードは、都道府県別CSVには含まれません（件数は `index.json` の `unassigned` で確認できます）。これらを含む全レコードが必要な場合は全件CSVを使ってください。
+
+市区町村別CSVやJSON、検索APIは配信していません。必要な範囲をCSVから抽出してください。
 
 ### ベクトルタイル
 
@@ -167,7 +206,7 @@ Claude Code や Codex などのコーディングエージェントでこのデ�
 
 ## 更新頻度
 
-毎週月曜18:00 UTC（日本時間 火曜3:00）に自動でクロールし、CSVとベクトルタイルを再配信します。更新後もURLは変わりません。
+毎週月曜18:00 UTC（日本時間 火曜3:00）に自動でクロールし、全件CSV・都道府県別CSV・ベクトルタイルを再配信します。更新後もURLは変わりません。
 
 ## ライセンスと出典表示
 

--- a/_headers
+++ b/_headers
@@ -7,6 +7,16 @@
   Access-Control-Allow-Origin: *
   Cache-Control: public, max-age=3600, stale-while-revalidate=86400
 
+/api/prefectures/*.csv
+  Content-Type: text/csv; charset=utf-8
+  Access-Control-Allow-Origin: *
+  Cache-Control: public, max-age=3600, stale-while-revalidate=86400
+
+/api/prefectures/index.json
+  Content-Type: application/json; charset=utf-8
+  Access-Control-Allow-Origin: *
+  Cache-Control: public, max-age=3600, stale-while-revalidate=86400
+
 /api/tiles/*
   Content-Type: application/x-protobuf
   Access-Control-Allow-Origin: *

--- a/index.html
+++ b/index.html
@@ -233,12 +233,15 @@
     <div class="wrap">
       <h2>クイックスタート</h2>
       <p class="lead">
-        配信しているのは <strong>全件CSV</strong> と <strong>ベクトルタイル</strong> の2つだけです。
+        配信しているのは <strong>全件CSV</strong>・<strong>都道府県別CSV</strong>・<strong>ベクトルタイル</strong> の3つだけです。
         ベース URL は <code>https://d1nptpfogf2ynv.cloudfront.net/api/</code>。
       </p>
 
-      <p class="step">1. 全件CSV をダウンロードする（約 540MB）</p>
-<pre><code>curl -O https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv</code></pre>
+      <p class="step">1. CSV をダウンロードする（全件は約 540MB。1県だけなら都道府県別CSV が軽い）</p>
+<pre><code>curl -O https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv
+
+<span class="c"># 東京都だけ欲しい場合（ファイル名は {JISコード}-{ローマ字}.csv）</span>
+curl -O https://d1nptpfogf2ynv.cloudfront.net/api/prefectures/13-tokyo.csv</code></pre>
 
       <p class="step">2. pandas で読み込む（URL 直指定でもいけます）</p>
 <pre><code>import pandas as pd
@@ -274,7 +277,7 @@ print(naha[['name', 'address', 'lat', 'lng']].head())</code></pre>
   <section id="formats">
     <div class="wrap">
       <h2>配信している形式</h2>
-      <p class="lead">用途に合わせて2つから選べます。どちらも同じベース URL 配下の静的ファイルです。</p>
+      <p class="lead">用途に合わせて3つから選べます。いずれも同じベース URL 配下の静的ファイルです。</p>
       <div class="table-scroll">
         <table class="formats">
           <thead>
@@ -285,6 +288,14 @@ print(naha[['name', 'address', 'lat', 'lng']].head())</code></pre>
               <td>全件 CSV</td>
               <td><code>api/facilities-all.csv</code>（約 540MB）</td>
               <td>pandas・BI ツール・DB 取り込みで分析する。全項目入り・BOM なし UTF-8 です。</td>
+            </tr>
+            <tr>
+              <td>都道府県別 CSV</td>
+              <td><code>api/prefectures/{JISコード}-{ローマ字}.csv</code>（例 <code>13-tokyo.csv</code>）</td>
+              <td>
+                1県だけ必要なときに。列・内容は全件CSV と同じで、47都道府県すべて存在します。
+                ファイル一覧と件数は <code>api/prefectures/index.json</code>。
+              </td>
             </tr>
             <tr>
               <td>ベクトルタイル</td>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -18,7 +18,7 @@
 
 - 登録不要・APIキー不要
 - 商用利用可能
-- 全件CSVとベクトルタイルで配信
+- 全件CSV・都道府県別CSV・ベクトルタイルで配信
 - 住所の正規化と緯度経度の補完に対応
 - 毎週自動更新
 
@@ -62,7 +62,46 @@ df = pd.read_csv(
 )
 ```
 
-市区町村別JSONや検索APIは配信していません。必要な範囲をCSVから抽出してください。
+### 都道府県別CSV
+
+一部の地域だけが必要な場合は、全件CSV（数百MB）ではなく都道府県別CSVを使ってください。列と内容は全件CSVと同じで、都道府県ごとに分割してあります。
+
+| ファイル | URL |
+|---|---|
+| 都道府県別CSV | `https://d1nptpfogf2ynv.cloudfront.net/api/prefectures/{JISコード}-{ローマ字}.csv` |
+| ファイル一覧（JSON） | https://d1nptpfogf2ynv.cloudfront.net/api/prefectures/index.json |
+
+ファイル名は、JIS都道府県コード（2桁）とローマ字を組み合わせた `01-hokkaido.csv` 〜 `47-okinawa.csv` です。47都道府県すべてのURLが常に存在します。
+
+```bash
+# 東京都だけダウンロードする
+curl -O https://d1nptpfogf2ynv.cloudfront.net/api/prefectures/13-tokyo.csv
+```
+
+```python
+import pandas as pd
+
+df = pd.read_csv(
+    "https://d1nptpfogf2ynv.cloudfront.net/api/prefectures/13-tokyo.csv"
+)
+```
+
+各ファイルの件数とサイズは `index.json` で確認できます。
+
+```json
+{
+  "updated": 1785000000,
+  "columns": ["prefecture", "city", "..."],
+  "unassigned": 0,
+  "prefectures": [
+    { "code": "13", "name": "東京都", "romaji": "tokyo", "file": "13-tokyo.csv", "records": 123456, "bytes": 34567890 }
+  ]
+}
+```
+
+元データから都道府県を特定できなかったレコードは、都道府県別CSVには含まれません（件数は `index.json` の `unassigned` で確認できます）。これらを含む全レコードが必要な場合は全件CSVを使ってください。
+
+市区町村別CSVやJSON、検索APIは配信していません。必要な範囲をCSVから抽出してください。
 
 ### ベクトルタイル
 
@@ -160,7 +199,7 @@ Claude Code や Codex などのコーディングエージェントでこのデ�
 
 ## 更新頻度
 
-毎週月曜18:00 UTC（日本時間 火曜3:00）に自動でクロールし、CSVとベクトルタイルを再配信します。更新後もURLは変わりません。
+毎週月曜18:00 UTC（日本時間 火曜3:00）に自動でクロールし、全件CSV・都道府県別CSV・ベクトルタイルを再配信します。更新後もURLは変わりません。
 
 ## ライセンスと出典表示
 
@@ -235,7 +274,22 @@ FROM read_csv_auto('https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv
 WHERE prefecture = '沖縄県' AND city = '那覇市' AND business_type = '飲食店営業';
 ```
 
-### pandas で読む
+### 1都道府県だけ使う（都道府県別CSV）
+
+対象が1〜数県なら、全件CSV（数百MB）ではなく都道府県別CSV を落とす。列は全件CSV と同じ。
+
+```python
+import pandas as pd
+
+# ファイル名は {JISコード2桁}-{ローマ字}.csv（13-tokyo.csv, 01-hokkaido.csv, 47-okinawa.csv …）
+df = pd.read_csv('https://d1nptpfogf2ynv.cloudfront.net/api/prefectures/13-tokyo.csv')
+minato = df[df['city'] == '港区']
+```
+
+ファイル名・件数の一覧は `https://d1nptpfogf2ynv.cloudfront.net/api/prefectures/index.json` にある
+（`prefectures[].file` / `records` / `bytes`）。
+
+### pandas で読む（全件CSV）
 
 ```python
 import pandas as pd

--- a/llms.txt
+++ b/llms.txt
@@ -7,11 +7,15 @@
 重要な事実:
 
 - 全件CSV（gzip 版は配信していない）: https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv
+- 都道府県別CSV（列・内容は全件CSV と同じ。1県だけ必要ならこちらを使う）:
+  https://d1nptpfogf2ynv.cloudfront.net/api/prefectures/{JISコード2桁}-{ローマ字}.csv
+  例 13-tokyo.csv / 01-hokkaido.csv / 47-okinawa.csv。47都道府県すべて存在する。
+  ファイル一覧と件数: https://d1nptpfogf2ynv.cloudfront.net/api/prefectures/index.json
 - CSV は UTF-8（BOMなし）。列: prefecture, city, city_raw, name, name_kana,
   business_type, address, lat, lng, geocoding_level, phone, license_no,
   license_date, expire_date, sources, licenses
 - ベクトルタイル（MVT）: https://d1nptpfogf2ynv.cloudfront.net/api/tiles/{z}/{x}/{y}.pbf （レイヤ名 facilities、z6–12）
-- 市区町村別 JSON や検索 API はこのリポジトリからは配信していない。抽出は CSV から、
+- 市区町村別 CSV/JSON や検索 API はこのリポジトリからは配信していない。抽出は CSV から、
   地図表示はタイルで行う
 - 全ファイル CORS 開放済み（Access-Control-Allow-Origin: *）。URL は更新後も不変
 - 毎週月曜 18:00 UTC（JST 火曜 3:00）に自動更新

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:attribution": "node scripts/gen-attribution.js",
     "build:llms": "node scripts/gen-llms.js",
     "fetch:i2fas": "node scripts/fetch-i2fas.mjs",
-    "test:unit": "node scripts/crawl.test.js && node scripts/lib/config.test.js && node scripts/build-merged-csv.test.js && node scripts/gen-tiles.test.js && node scripts/preview-map.test.js && node scripts/map-search.test.js && node scripts/gen-readme-stats.test.js && node scripts/gen-llms.test.js && node scripts/gen-attribution.test.js && node scripts/workflows.test.js",
+    "test:unit": "node scripts/crawl.test.js && node scripts/lib/config.test.js && node scripts/build-merged-csv.test.js && node scripts/build-prefecture-csv.test.js && node scripts/gen-tiles.test.js && node scripts/preview-map.test.js && node scripts/map-search.test.js && node scripts/gen-readme-stats.test.js && node scripts/gen-llms.test.js && node scripts/gen-attribution.test.js && node scripts/workflows.test.js",
     "test": "npm run test:unit && node scripts/test.js"
   },
   "dependencies": {

--- a/scripts/build-prefecture-csv.js
+++ b/scripts/build-prefecture-csv.js
@@ -1,0 +1,189 @@
+// 都道府県別CSV の生成（api/prefectures/{code}-{romaji}.csv）。
+//
+// 全件CSV（facilities-all.csv）は数百MB あり、1県分だけ欲しい利用者には重すぎる。
+// そこで同じ列・同じレコード集合を都道府県ごとに分割した CSV も配信する。
+//
+// 入力は buildMergedCsv() が返す `unique`（＝重複除去後の施設）を渡すこと。
+// 元の facilities を渡すと全件CSV に載っていない重複行が県別CSV に入り、
+// 「県別の合計 ≠ 全件」という食い違いが生まれる。
+//
+// 出力:
+//   api/prefectures/{code}-{romaji}.csv   47都道府県ぶん（0件の県もヘッダーだけ出す）
+//   api/prefectures/index.json            ファイル一覧・件数・バイト数の索引
+//
+// 都道府県が特定できなかったレコード（pref が '不明' 等、47都道府県に一致しない）は
+// 県別CSV には含めない。件数は index.json の `unassigned` とログに残し、
+// 黙って消えないようにする（全件CSV には従来どおり含まれる）。
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { CSV_COLUMNS, csvCell, toRow } from './build-merged-csv.js';
+
+/**
+ * JIS都道府県コード順の都道府県定義。
+ * `code` はファイル名の接頭辞（ゼロ埋め2桁）、`romaji` はローマ字のスラッグ。
+ * URL に日本語を含めずに済むよう `{code}-{romaji}.csv` をファイル名に使う。
+ */
+export const PREFECTURES = [
+  { code: '01', name: '北海道', romaji: 'hokkaido' },
+  { code: '02', name: '青森県', romaji: 'aomori' },
+  { code: '03', name: '岩手県', romaji: 'iwate' },
+  { code: '04', name: '宮城県', romaji: 'miyagi' },
+  { code: '05', name: '秋田県', romaji: 'akita' },
+  { code: '06', name: '山形県', romaji: 'yamagata' },
+  { code: '07', name: '福島県', romaji: 'fukushima' },
+  { code: '08', name: '茨城県', romaji: 'ibaraki' },
+  { code: '09', name: '栃木県', romaji: 'tochigi' },
+  { code: '10', name: '群馬県', romaji: 'gunma' },
+  { code: '11', name: '埼玉県', romaji: 'saitama' },
+  { code: '12', name: '千葉県', romaji: 'chiba' },
+  { code: '13', name: '東京都', romaji: 'tokyo' },
+  { code: '14', name: '神奈川県', romaji: 'kanagawa' },
+  { code: '15', name: '新潟県', romaji: 'niigata' },
+  { code: '16', name: '富山県', romaji: 'toyama' },
+  { code: '17', name: '石川県', romaji: 'ishikawa' },
+  { code: '18', name: '福井県', romaji: 'fukui' },
+  { code: '19', name: '山梨県', romaji: 'yamanashi' },
+  { code: '20', name: '長野県', romaji: 'nagano' },
+  { code: '21', name: '岐阜県', romaji: 'gifu' },
+  { code: '22', name: '静岡県', romaji: 'shizuoka' },
+  { code: '23', name: '愛知県', romaji: 'aichi' },
+  { code: '24', name: '三重県', romaji: 'mie' },
+  { code: '25', name: '滋賀県', romaji: 'shiga' },
+  { code: '26', name: '京都府', romaji: 'kyoto' },
+  { code: '27', name: '大阪府', romaji: 'osaka' },
+  { code: '28', name: '兵庫県', romaji: 'hyogo' },
+  { code: '29', name: '奈良県', romaji: 'nara' },
+  { code: '30', name: '和歌山県', romaji: 'wakayama' },
+  { code: '31', name: '鳥取県', romaji: 'tottori' },
+  { code: '32', name: '島根県', romaji: 'shimane' },
+  { code: '33', name: '岡山県', romaji: 'okayama' },
+  { code: '34', name: '広島県', romaji: 'hiroshima' },
+  { code: '35', name: '山口県', romaji: 'yamaguchi' },
+  { code: '36', name: '徳島県', romaji: 'tokushima' },
+  { code: '37', name: '香川県', romaji: 'kagawa' },
+  { code: '38', name: '愛媛県', romaji: 'ehime' },
+  { code: '39', name: '高知県', romaji: 'kochi' },
+  { code: '40', name: '福岡県', romaji: 'fukuoka' },
+  { code: '41', name: '佐賀県', romaji: 'saga' },
+  { code: '42', name: '長崎県', romaji: 'nagasaki' },
+  { code: '43', name: '熊本県', romaji: 'kumamoto' },
+  { code: '44', name: '大分県', romaji: 'oita' },
+  { code: '45', name: '宮崎県', romaji: 'miyazaki' },
+  { code: '46', name: '鹿児島県', romaji: 'kagoshima' },
+  { code: '47', name: '沖縄県', romaji: 'okinawa' },
+];
+
+/** 都道府県名 → 定義（高速引き用）。 */
+const BY_NAME = new Map(PREFECTURES.map((p) => [p.name, p]));
+
+/** 索引ファイル名（ファイル一覧・件数を載せる JSON）。 */
+export const INDEX_FILENAME = 'index.json';
+
+/**
+ * 都道府県名 → CSV ファイル名（例: '東京都' → '13-tokyo.csv'）。
+ * 47都道府県に一致しない名前（'不明' 等）は null を返す。
+ */
+export function prefectureFileName(pref) {
+  const def = BY_NAME.get(String(pref || '').trim());
+  return def ? `${def.code}-${def.romaji}.csv` : null;
+}
+
+/** 書き込みバッファが埋まったら drain を待つ Promise を返す（不要なら null）。 */
+function write(stream, chunk) {
+  if (stream.write(chunk)) return null;
+  return new Promise((resolve) => stream.once('drain', resolve));
+}
+
+/**
+ * 施設を都道府県ごとに束ねる（純粋関数）。
+ * 戻り値は `{ groups, unassigned }`。`groups` は 都道府県名 → 施設配列（47件ぶん、
+ * 0件の県も空配列で必ず存在する）、`unassigned` は都道府県を特定できなかった施設数。
+ * 施設オブジェクトは複製せず参照のまま持つ（100万件規模でもメモリ増加を抑えるため）。
+ */
+export function groupByPrefecture(facilities) {
+  const groups = new Map(PREFECTURES.map((p) => [p.name, []]));
+  let unassigned = 0;
+  for (const f of facilities) {
+    const bucket = groups.get(String(f.pref || '').trim());
+    if (bucket) bucket.push(f);
+    else unassigned++;
+  }
+  return { groups, unassigned };
+}
+
+/**
+ * 索引 JSON の中身を組み立てる（純粋関数）。
+ * `entries` は `{ code, name, romaji, file, records, bytes }` の配列。
+ */
+export function renderIndex({ updated, entries, unassigned }) {
+  return {
+    // 生成時刻（UNIX秒）。全件CSV・タイルの metadata.json と同じ値を入れる。
+    updated: updated ?? null,
+    columns: CSV_COLUMNS,
+    // 都道府県を特定できず県別CSV に含まれなかったレコード数（全件CSV には含まれる）。
+    unassigned,
+    prefectures: entries,
+  };
+}
+
+/**
+ * 都道府県別CSV と索引 JSON を書き出す。
+ * `facilities` には buildMergedCsv() が返す `unique`（重複除去後）を渡すこと。
+ *
+ * 統計 `{ files, records, unassigned, bytes, entries }` を返す。
+ */
+export async function buildPrefectureCsvs(facilities, { outDir, updated, log = console.log } = {}) {
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const { groups, unassigned } = groupByPrefecture(facilities);
+  const header = CSV_COLUMNS.join(',') + '\n';
+
+  const entries = [];
+  let records = 0;
+  let bytes = 0;
+
+  // 47ファイルを同時に開くとメモリを食うため、県ごとに開いて閉じる。
+  for (const def of PREFECTURES) {
+    const file = `${def.code}-${def.romaji}.csv`;
+    const outPath = path.join(outDir, file);
+    const out = fs.createWriteStream(outPath, { encoding: 'utf-8' });
+
+    // ヘッダーは常に書く（0件の県でも URL とヘッダーが存在するようにするため）。
+    await write(out, header);
+
+    const rows = groups.get(def.name);
+    for (const f of rows) {
+      const backpressure = write(out, toRow(f).map(csvCell).join(',') + '\n');
+      if (backpressure) await backpressure;
+    }
+
+    // end() のコールバックは flush 完了時に呼ばれる。
+    await new Promise((resolve, reject) => {
+      out.once('error', reject);
+      out.end(resolve);
+    });
+
+    const size = fs.statSync(outPath).size;
+    records += rows.length;
+    bytes += size;
+    entries.push({ ...def, file, records: rows.length, bytes: size });
+  }
+
+  const indexPath = path.join(outDir, INDEX_FILENAME);
+  fs.writeFileSync(indexPath, JSON.stringify(renderIndex({ updated, entries, unassigned }), null, 2) + '\n');
+
+  // 0件の県は元データの取得漏れを疑う手がかりになるので名前を出す。
+  const empty = entries.filter((e) => e.records === 0).map((e) => e.name);
+
+  log(
+    `  都道府県別CSV: ${entries.length}ファイル / ${records.toLocaleString('en-US')}行` +
+      ` / ${(bytes / 1024 / 1024).toFixed(1)} MB`,
+  );
+  if (unassigned > 0) {
+    log(`    都道府県を特定できず県別CSV に含めなかったレコード: ${unassigned.toLocaleString('en-US')}行`);
+  }
+  if (empty.length > 0) log(`    0件の都道府県: ${empty.join('・')}`);
+
+  return { files: entries.length, records, unassigned, bytes, entries };
+}

--- a/scripts/build-prefecture-csv.test.js
+++ b/scripts/build-prefecture-csv.test.js
@@ -1,0 +1,184 @@
+// 都道府県別CSV の生成ロジックを検証する。
+//   node scripts/build-prefecture-csv.test.js
+//
+// 見るのは3点:
+//   - 47都道府県ぶんのファイルが必ず出る（0件の県もヘッダーだけ出す）
+//   - 各ファイルの中身がその県のレコードだけで、全件CSV と同じ列・同じ値になる
+//   - 都道府県を特定できないレコードが黙って消えず unassigned に計上される
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { CSV_COLUMNS } from './build-merged-csv.js';
+import {
+  PREFECTURES,
+  INDEX_FILENAME,
+  buildPrefectureCsvs,
+  groupByPrefecture,
+  prefectureFileName,
+  renderIndex,
+} from './build-prefecture-csv.js';
+import { readCsvRows } from './lib/csv-read.js';
+
+let passed = 0;
+async function test(name, fn) {
+  await fn();
+  passed++;
+  console.log(`  ✓ ${name}`);
+}
+
+console.log('build-prefecture-csv テスト\n');
+
+const col = Object.fromEntries(CSV_COLUMNS.map((c, i) => [c, i]));
+
+/** テスト用の施設（pref/city は名寄せ済みの想定）。 */
+function fac(over = {}) {
+  return {
+    pref: '東京都', city: '港区', city_raw: '港区',
+    name: '店A', name_kana: 'ミセエー', business_type: '飲食店営業',
+    address: '港区赤坂1-1', lat: 35.673, lng: 139.737, geocoding_level: 8,
+    phone: '03-0000-0000', license_no: '第1号', license_date: '2023-12-07', expire_date: '2030-01-31',
+    _source: '東京都食品営業許可', _license: 'CC BY 4.0',
+    ...over,
+  };
+}
+
+/** 一時ディレクトリに県別CSV を書き出す。 */
+async function writeCsvs(facilities, opts = {}) {
+  const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pref-csv-test-'));
+  const stats = await buildPrefectureCsvs(facilities, { outDir, log: () => {}, ...opts });
+  return { outDir, stats };
+}
+
+/** 県別CSV を読み、ヘッダーを除いた行配列を返す。 */
+function readRows(outDir, file) {
+  const rows = [...readCsvRows(path.join(outDir, file))];
+  return { header: rows[0], rows: rows.slice(1) };
+}
+
+// --- 純粋関数 ---------------------------------------------------------------
+await test('PREFECTURES: JISコード順の47都道府県', () => {
+  assert.equal(PREFECTURES.length, 47);
+  assert.deepEqual(PREFECTURES[0], { code: '01', name: '北海道', romaji: 'hokkaido' });
+  assert.deepEqual(PREFECTURES[46], { code: '47', name: '沖縄県', romaji: 'okinawa' });
+  // コード・ローマ字・名前はいずれも重複しない（ファイル名の衝突を防ぐ）
+  for (const key of ['code', 'name', 'romaji']) {
+    assert.equal(new Set(PREFECTURES.map((p) => p[key])).size, 47, `${key} が一意`);
+  }
+  // ローマ字は URL に安全な小文字英字のみ
+  assert.ok(PREFECTURES.every((p) => /^[a-z]+$/.test(p.romaji)), 'romaji は小文字英字のみ');
+});
+
+await test('prefectureFileName: 都道府県名 → ファイル名', () => {
+  assert.equal(prefectureFileName('東京都'), '13-tokyo.csv');
+  assert.equal(prefectureFileName('北海道'), '01-hokkaido.csv');
+  assert.equal(prefectureFileName(' 沖縄県 '), '47-okinawa.csv');
+  // 47都道府県に無い値は null（呼び出し側で未分類として扱う）
+  assert.equal(prefectureFileName('不明'), null);
+  assert.equal(prefectureFileName(''), null);
+  assert.equal(prefectureFileName(undefined), null);
+});
+
+await test('groupByPrefecture: 47県ぶんのバケツを必ず作り、不明は数えるだけ', () => {
+  const { groups, unassigned } = groupByPrefecture([
+    fac(), fac({ pref: '沖縄県' }), fac({ pref: '不明' }), fac({ pref: '' }),
+  ]);
+  assert.equal(groups.size, 47);
+  assert.equal(groups.get('東京都').length, 1);
+  assert.equal(groups.get('沖縄県').length, 1);
+  assert.equal(groups.get('京都府').length, 0, '0件の県も空配列で存在する');
+  assert.equal(unassigned, 2);
+});
+
+await test('renderIndex: 索引JSON の形', () => {
+  const index = renderIndex({
+    updated: 1783366001,
+    entries: [{ code: '13', name: '東京都', romaji: 'tokyo', file: '13-tokyo.csv', records: 2, bytes: 300 }],
+    unassigned: 1,
+  });
+  assert.equal(index.updated, 1783366001);
+  assert.deepEqual(index.columns, CSV_COLUMNS);
+  assert.equal(index.unassigned, 1);
+  assert.equal(index.prefectures[0].file, '13-tokyo.csv');
+  // updated 未指定は null（JSON に undefined を書かない）
+  assert.equal(renderIndex({ entries: [], unassigned: 0 }).updated, null);
+});
+
+// --- 書き出し ---------------------------------------------------------------
+await test('47ファイルを必ず出力し、0件の県もヘッダーだけ書く', async () => {
+  const { outDir, stats } = await writeCsvs([fac(), fac({ pref: '沖縄県', name: '店B' })]);
+
+  assert.equal(stats.files, 47);
+  assert.equal(stats.records, 2);
+  for (const def of PREFECTURES) {
+    const file = path.join(outDir, `${def.code}-${def.romaji}.csv`);
+    assert.ok(fs.existsSync(file), `${def.name} のCSV が存在する`);
+  }
+  const empty = readRows(outDir, '26-kyoto.csv');
+  assert.deepEqual(empty.header, CSV_COLUMNS, '0件の県もヘッダーは書く');
+  assert.equal(empty.rows.length, 0);
+});
+
+await test('各県のCSV にはその県のレコードだけが入る', async () => {
+  const { outDir } = await writeCsvs([
+    fac({ name: '東京A' }), fac({ name: '東京B' }), fac({ pref: '沖縄県', city: '那覇市', name: '那覇A' }),
+  ]);
+
+  const tokyo = readRows(outDir, '13-tokyo.csv');
+  assert.deepEqual(tokyo.header, CSV_COLUMNS);
+  assert.equal(tokyo.rows.length, 2);
+  assert.deepEqual(tokyo.rows.map((r) => r[col.name]), ['東京A', '東京B']);
+  assert.ok(tokyo.rows.every((r) => r[col.prefecture] === '東京都'));
+
+  const okinawa = readRows(outDir, '47-okinawa.csv');
+  assert.equal(okinawa.rows.length, 1);
+  assert.equal(okinawa.rows[0][col.city], '那覇市');
+});
+
+await test('特殊文字を含むセルが書き出し→読み戻しで元に戻る', async () => {
+  const tricky = fac({ name: 'カフェ, "ABC"\n2階', address: '港区赤坂1-1, 2F' });
+  const { outDir } = await writeCsvs([tricky]);
+  const { rows } = readRows(outDir, '13-tokyo.csv');
+  assert.equal(rows[0][col.name], 'カフェ, "ABC"\n2階');
+  assert.equal(rows[0][col.address], '港区赤坂1-1, 2F');
+});
+
+await test('都道府県が不明なレコードは県別CSV に入れず unassigned に数える', async () => {
+  const { outDir, stats } = await writeCsvs([fac(), fac({ pref: '不明', name: '不明店' })]);
+
+  assert.equal(stats.records, 1);
+  assert.equal(stats.unassigned, 1);
+  const index = JSON.parse(fs.readFileSync(path.join(outDir, INDEX_FILENAME), 'utf-8'));
+  assert.equal(index.unassigned, 1);
+  // どのファイルにも紛れ込んでいないこと
+  const all = PREFECTURES.flatMap((d) => readRows(outDir, `${d.code}-${d.romaji}.csv`).rows);
+  assert.ok(!all.some((r) => r[col.name] === '不明店'));
+});
+
+await test('index.json が実ファイルの件数・バイト数と一致する', async () => {
+  const { outDir, stats } = await writeCsvs(
+    [fac(), fac({ name: '東京B' }), fac({ pref: '北海道', city: '札幌市', name: '札幌A' })],
+    { updated: 1783366001 },
+  );
+
+  const index = JSON.parse(fs.readFileSync(path.join(outDir, INDEX_FILENAME), 'utf-8'));
+  assert.equal(index.updated, 1783366001);
+  assert.equal(index.prefectures.length, 47);
+  for (const entry of index.prefectures) {
+    const file = path.join(outDir, entry.file);
+    assert.equal(entry.bytes, fs.statSync(file).size, `${entry.name} の bytes が実ファイルと一致`);
+    assert.equal(entry.records, readRows(outDir, entry.file).rows.length, `${entry.name} の records が実行数と一致`);
+  }
+  // 統計は全ファイルの合計
+  assert.equal(index.prefectures.reduce((a, e) => a + e.records, 0), stats.records);
+  assert.equal(index.prefectures.reduce((a, e) => a + e.bytes, 0), stats.bytes);
+});
+
+await test('CSV は BOM なし UTF-8 で書き出す', async () => {
+  const { outDir } = await writeCsvs([fac()]);
+  const head = fs.readFileSync(path.join(outDir, '13-tokyo.csv'), { encoding: 'utf-8' }).slice(0, 1);
+  assert.notEqual(head, '﻿');
+});
+
+console.log(`\n✅ build-prefecture-csv テスト ${passed}件に合格`);

--- a/scripts/crawl.js
+++ b/scripts/crawl.js
@@ -9,8 +9,9 @@
 //   lib/geocode.js       ジオコーディング（住所→座標の補完）
 //   lib/city-normmap.js  市区町村名の名寄せ（表記ゆれ→公式名）
 //
-// 配信物は2種類だけ（用途が無い階層JSONは配信しない）:
+// 配信物は3種類だけ（用途が無い階層JSONは配信しない）:
 //   api/facilities-all.csv[.gz]   全件の結合CSV（build-merged-csv.js）
+//   api/prefectures/*.csv         都道府県別CSV + index.json（build-prefecture-csv.js）
 //   api/tiles/{z}/{x}/{y}.pbf     地図用ベクトルタイル + metadata.json（gen-tiles.js）
 //
 // 使い方:
@@ -35,6 +36,7 @@ import {
 import { enrichWithGeocoding } from './lib/geocode.js';
 import { buildCityNormMap, applyPrefCity } from './lib/city-normmap.js';
 import { buildMergedCsv } from './build-merged-csv.js';
+import { buildPrefectureCsvs } from './build-prefecture-csv.js';
 import { generateTiles } from './gen-tiles.js';
 import { generateReadmeStats } from './gen-readme-stats.js';
 import { generateLlmsFiles } from './gen-llms.js';
@@ -42,6 +44,7 @@ import { generateLlmsFiles } from './gen-llms.js';
 const CACHE_DIR = path.join(ROOT, '.cache');
 const API_DIR = path.join(ROOT, 'api');
 const CSV_PATH = path.join(API_DIR, 'facilities-all.csv');
+const PREF_CSV_DIR = path.join(API_DIR, 'prefectures');
 
 const DRY_RUN = process.argv.includes('--dry-run');
 const NO_GEOCODE = process.argv.includes('--no-geocode');
@@ -142,10 +145,12 @@ async function main() {
 
   const updated = Math.floor(Date.now() / 1000);
   const csv = await buildMergedCsv(facilities, { outPath: CSV_PATH });
+  // 都道府県別CSV も全件CSV と同じ集合（重複除去後）から作る。
+  const prefCsv = await buildPrefectureCsvs(csv.unique, { outDir: PREF_CSV_DIR, updated });
   // タイルは CSV と同じ集合（重複除去後）から作る。元の facilities を渡すと
   // CSV に載らない重複点がタイルに入り、配信物どうしで件数が食い違う。
   const tiles = generateTiles(csv.unique, { updated, stats: csv });
-  generateReadmeStats({ updated, csv, tiles });
+  generateReadmeStats({ updated, csv, prefCsv, tiles });
   // README の統計更新後に、AI エージェント向けの llms.txt / llms-full.txt を
   // README から再生成する（統計込みで最新化するため、必ず統計更新の後に呼ぶ）
   generateLlmsFiles();
@@ -153,7 +158,7 @@ async function main() {
   console.log(
     `\n✅ 生成完了: ${csv.prefectures}都道府県 / ${csv.cities}市区町村 / ${csv.rowsOut}レコード`,
   );
-  console.log(`   出力先: api/facilities-all.csv[.gz] / api/tiles/`);
+  console.log(`   出力先: api/facilities-all.csv[.gz] / api/prefectures/ / api/tiles/`);
 }
 
 // 直接実行された場合のみクロールを開始する（テストから import しても main は走らない）。

--- a/scripts/gen-llms.js
+++ b/scripts/gen-llms.js
@@ -97,11 +97,15 @@ export function renderLlmsTxt(readme) {
 重要な事実:
 
 - 全件CSV（gzip 版は配信していない）: ${DATA}/api/facilities-all.csv
+- 都道府県別CSV（列・内容は全件CSV と同じ。1県だけ必要ならこちらを使う）:
+  ${DATA}/api/prefectures/{JISコード2桁}-{ローマ字}.csv
+  例 13-tokyo.csv / 01-hokkaido.csv / 47-okinawa.csv。47都道府県すべて存在する。
+  ファイル一覧と件数: ${DATA}/api/prefectures/index.json
 - CSV は UTF-8（BOMなし）。列: prefecture, city, city_raw, name, name_kana,
   business_type, address, lat, lng, geocoding_level, phone, license_no,
   license_date, expire_date, sources, licenses
 - ベクトルタイル（MVT）: ${DATA}/api/tiles/{z}/{x}/{y}.pbf （レイヤ名 facilities、z6–12）
-- 市区町村別 JSON や検索 API はこのリポジトリからは配信していない。抽出は CSV から、
+- 市区町村別 CSV/JSON や検索 API はこのリポジトリからは配信していない。抽出は CSV から、
   地図表示はタイルで行う
 - 全ファイル CORS 開放済み（Access-Control-Allow-Origin: *）。URL は更新後も不変
 - 毎週月曜 18:00 UTC（JST 火曜 3:00）に自動更新
@@ -148,7 +152,22 @@ FROM read_csv_auto('${DATA}/api/facilities-all.csv')
 WHERE prefecture = '沖縄県' AND city = '那覇市' AND business_type = '飲食店営業';
 \`\`\`
 
-### pandas で読む
+### 1都道府県だけ使う（都道府県別CSV）
+
+対象が1〜数県なら、全件CSV（数百MB）ではなく都道府県別CSV を落とす。列は全件CSV と同じ。
+
+\`\`\`python
+import pandas as pd
+
+# ファイル名は {JISコード2桁}-{ローマ字}.csv（13-tokyo.csv, 01-hokkaido.csv, 47-okinawa.csv …）
+df = pd.read_csv('${DATA}/api/prefectures/13-tokyo.csv')
+minato = df[df['city'] == '港区']
+\`\`\`
+
+ファイル名・件数の一覧は \`${DATA}/api/prefectures/index.json\` にある
+（\`prefectures[].file\` / \`records\` / \`bytes\`）。
+
+### pandas で読む（全件CSV）
 
 \`\`\`python
 import pandas as pd

--- a/scripts/gen-readme-stats.js
+++ b/scripts/gen-readme-stats.js
@@ -32,7 +32,8 @@ function num(n) {
 
 /**
  * 統計から README に埋め込む Markdown テーブルを組み立てる（純粋関数）。
- * `s` は `{ updated, csv: {...}, tiles: {...} }`。
+ * `s` は `{ updated, csv: {...}, prefCsv: {...}, tiles: {...} }`。
+ * `prefCsv`（都道府県別CSV の統計）は省略可で、無ければその行を出さない。
  */
 export function renderStats(s) {
   const date = s.updated ? new Date(s.updated * 1000).toISOString().slice(0, 10) : '—';
@@ -46,6 +47,8 @@ export function renderStats(s) {
     `> | 都道府県 | ${num(s.csv.prefectures)} |`,
     `> | 市区町村 | ${num(s.csv.cities)} |`,
     `> | 結合CSV | ${humanSize(s.csv.bytes)} |`,
+    // 都道府県別CSV は全件CSV と同じレコードの分割配信なので、件数ではなくファイル数と総量を出す。
+    ...(s.prefCsv ? [`> | 都道府県別CSV | ${num(s.prefCsv.files)} ファイル / ${humanSize(s.prefCsv.bytes)} |`] : []),
     `> | ベクトルタイル | ${num(s.tiles.tiles)} 枚 / ${humanSize(s.tiles.bytes)} |`,
   ].join('\n');
 }

--- a/scripts/gen-readme-stats.test.js
+++ b/scripts/gen-readme-stats.test.js
@@ -25,6 +25,7 @@ const fixed = {
     cities: 1741,
     bytes: 540 * 1024 * 1024,
   },
+  prefCsv: { files: 47, records: 1495048, unassigned: 0, bytes: 538 * 1024 * 1024 },
   tiles: { tiles: 12345, points: 1106198, bytes: 250 * 1024 * 1024 },
 };
 const md = renderStats(fixed);
@@ -36,7 +37,12 @@ assert(md.includes('| 都道府県 | 47 |'), '都道府県数が出る');
 assert(md.includes('| 市区町村 | 1,741 |'), '市区町村数が出る');
 assert(md.includes('| 結合CSV | 約 540.0 MB |'), 'CSV サイズが出る');
 assert(!md.includes('gzip'), 'gzip 表記は出さない（非圧縮CSVのみ配布）');
+assert(md.includes('| 都道府県別CSV | 47 ファイル / 約 538.0 MB |'), '都道府県別CSV のファイル数とサイズが出る');
 assert(md.includes('| ベクトルタイル | 12,345 枚 / 約 250.0 MB |'), 'タイル枚数とサイズが出る');
+
+// prefCsv を渡さない場合は都道府県別CSV の行を出さない（旧形式の統計でも壊れないこと）。
+const noPref = renderStats({ ...fixed, prefCsv: undefined });
+assert(!noPref.includes('都道府県別CSV'), 'prefCsv が無ければ都道府県別CSV の行を出さない');
 
 // updated が無い場合はダッシュ表記。
 const noDate = renderStats({ ...fixed, updated: 0 });

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,7 +1,8 @@
 // 生成した配信物が正しいことを確認するバリデーションスクリプト。
 //
-// 検証対象は配信する2形式だけ:
+// 検証対象は配信する3形式だけ:
 //   api/facilities-all.csv[.gz]   全件の結合CSV
+//   api/prefectures/*.csv         都道府県別CSV + index.json
 //   api/tiles/{z}/{x}/{y}.pbf     ベクトルタイル + metadata.json（TileJSON）
 //
 //   node scripts/test.js
@@ -10,12 +11,14 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { CSV_COLUMNS } from './build-merged-csv.js';
+import { INDEX_FILENAME, PREFECTURES } from './build-prefecture-csv.js';
 import { readCsvRows } from './lib/csv-read.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
 const API_DIR = path.join(ROOT, 'api');
 const CSV_PATH = path.join(API_DIR, 'facilities-all.csv');
+const PREF_CSV_DIR = path.join(API_DIR, 'prefectures');
 const TILES_DIR = path.join(API_DIR, 'tiles');
 
 let failures = 0;
@@ -42,6 +45,7 @@ let rowCount = 0;
 let withCoords = 0;
 let header = null;
 const prefs = new Set();
+const prefCounts = new Map(); // 都道府県名 -> 全件CSV 内の行数（都道府県別CSV との突き合わせに使う）
 const cities = new Set();
 // 同種のエラーで何万行も出力しないよう、種類ごとに最初の数件だけ報告する。
 const reported = new Map();
@@ -71,6 +75,7 @@ for (const row of readCsvRows(CSV_PATH)) {
   if (!pref) reportOnce('pref', `${rowCount}行目: prefecture が空`);
   if (!city) reportOnce('city', `${rowCount}行目: city が空`);
   prefs.add(pref);
+  prefCounts.set(pref, (prefCounts.get(pref) || 0) + 1);
   cities.add(`${pref}/${city}`);
 
   // 座標: 両方空か、両方が日本の範囲内の数値であること。
@@ -111,7 +116,68 @@ for (const [kind, n] of reported) {
 // 配布は非圧縮CSV のみ。gzip 版が残っていると配信物が二重になるため、無いことを確認する。
 assert(!fs.existsSync(`${CSV_PATH}.gz`), 'api/facilities-all.csv.gz を配信しない');
 
-// --- 2. ベクトルタイル ------------------------------------------------------
+// --- 2. 都道府県別CSV -------------------------------------------------------
+// 全件CSV の分割配信なので、「47ファイルある」「中身が全件CSV と一致する」の2点を見る。
+const prefIndexPath = path.join(PREF_CSV_DIR, INDEX_FILENAME);
+assert(fs.existsSync(prefIndexPath), `api/prefectures/${INDEX_FILENAME} が存在する`);
+if (fs.existsSync(prefIndexPath)) {
+  const index = JSON.parse(fs.readFileSync(prefIndexPath, 'utf-8'));
+  assert(
+    JSON.stringify(index.columns) === JSON.stringify(CSV_COLUMNS),
+    'index.json の columns が結合CSV と同じ定義',
+  );
+  assert(
+    Array.isArray(index.prefectures) && index.prefectures.length === 47,
+    `index.json に47都道府県ぶんの項目がある (${index.prefectures?.length})`,
+  );
+
+  let prefRowTotal = 0;
+  const missing = []; // 実ファイルが無い都道府県
+  const mismatched = []; // 行数・都道府県列が食い違う都道府県
+
+  for (const def of PREFECTURES) {
+    const entry = (index.prefectures || []).find((e) => e.code === def.code);
+    const file = path.join(PREF_CSV_DIR, `${def.code}-${def.romaji}.csv`);
+    if (!entry || !fs.existsSync(file)) {
+      missing.push(def.name);
+      continue;
+    }
+
+    // 1ファイルずつ読み、ヘッダー・行数・prefecture 列を検証する。
+    let rows = 0;
+    let head = null;
+    let foreign = 0; // その県のファイルに入っている他県のレコード
+    for (const row of readCsvRows(file)) {
+      if (head === null) {
+        head = row;
+        continue;
+      }
+      rows++;
+      if (row[col.prefecture] !== def.name) foreign++;
+    }
+
+    if (JSON.stringify(head) !== JSON.stringify(CSV_COLUMNS)) mismatched.push(`${def.name}(ヘッダー)`);
+    if (rows !== entry.records) mismatched.push(`${def.name}(index ${entry.records}≠実 ${rows})`);
+    if (rows !== (prefCounts.get(def.name) || 0)) {
+      mismatched.push(`${def.name}(全件CSV ${prefCounts.get(def.name) || 0}≠県別 ${rows})`);
+    }
+    if (foreign > 0) mismatched.push(`${def.name}(他県のレコード ${foreign}行)`);
+    prefRowTotal += rows;
+  }
+
+  assert(missing.length === 0, `47都道府県ぶんの CSV がそろっている${missing.length ? `（欠落: ${missing.join('・')}）` : ''}`);
+  assert(
+    mismatched.length === 0,
+    `各県のCSV が全件CSV と一致する${mismatched.length ? `（不一致: ${mismatched.slice(0, 5).join(' / ')}）` : ''}`,
+  );
+  // 47都道府県に振り分けられなかったレコード（都道府県が不明な行）を足すと全件と合う。
+  assert(
+    prefRowTotal + (index.unassigned || 0) === rowCount,
+    `県別の合計 + 未分類(${index.unassigned}) が全件CSV の行数と一致 (${prefRowTotal + (index.unassigned || 0)} / ${rowCount})`,
+  );
+}
+
+// --- 3. ベクトルタイル ------------------------------------------------------
 const metaPath = path.join(TILES_DIR, 'metadata.json');
 assert(fs.existsSync(metaPath), 'api/tiles/metadata.json が存在する');
 if (fs.existsSync(metaPath)) {


### PR DESCRIPTION
## 概要

全件CSV（数百MB）しか配信していなかったため、1県分だけ欲しい利用者が数百MBを落とす必要があった。
全件CSV と同じ列・同じレコード集合を都道府県ごとに分割した CSV を追加で生成・配信する。

## 配信物

| パス | 内容 |
|---|---|
| `api/prefectures/{JISコード2桁}-{ローマ字}.csv` | 47都道府県ぶん（例 `13-tokyo.csv` / `01-hokkaido.csv`） |
| `api/prefectures/index.json` | ファイル一覧・件数・バイト数の索引 |

- ファイル名を JIS コード + ローマ字にして、URL に日本語が入らないようにした
- 0件の県もヘッダーだけ書き出し、47都道府県すべての URL が常に存在するようにした
- 元データから都道府県を特定できなかったレコードは県別CSV に含めない。
  黙って消えないよう、件数を `index.json` の `unassigned` とクロールのログに残す
  （全件CSV には従来どおり含まれる）
- 全件CSV と同じ「重複除去後」の集合（`buildMergedCsv()` が返す `unique`）から生成するので、
  県別の合計 + `unassigned` は必ず全件CSV の行数と一致する

## 変更点

- `scripts/build-prefecture-csv.js`（新規）: 分割・書き出し・索引生成
- `scripts/crawl.js`: 結合CSV 生成の直後に県別CSV を生成
- `scripts/test.js`: 配信物バリデーションに県別CSV の検査を追加
  （47ファイルの存在 / ヘッダー / 各行の `prefecture` 列 / 全件CSV との件数一致）
- `scripts/gen-readme-stats.js`: README 統計に「都道府県別CSV」の行を追加（`prefCsv` は省略可）
- ドキュメント: README / index.html / AGENTS.md / `_headers` / llms.txt / llms-full.txt

## テスト

- `scripts/build-prefecture-csv.test.js`（新規・10件）を `test:unit` に追加。`npm run test:unit` green
- 合成データで `api/` を作って `node scripts/test.js` を実行し、全チェック合格を確認。
  1ファイル削除した状態では意図どおり失敗することも確認済み
  （`✗ 47都道府県ぶんの CSV がそろっている（欠落: 東京都）`）

## 配信side の注意

S3 へのアップロードは Fargate クローラーの `aws s3 sync /app/api s3://.../api --delete` なので、
`api/prefectures/` は追加設定なしで同期される（Content-Type も拡張子から付く）。
ただしクローラーは自リポジトリ内の `scripts/` スナップショットを実行しているため、
**実際に配信されるのはクローラー側の `scripts/` を本 PR 反映後の main と同期してからになる**。