### PR TITLE
データ配信の URL を独自ドメイン food.japan-facilities.com に張り替え

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,21 +3,22 @@
 AI コーディングエージェント（Claude Code / Codex 等）向けのガイド。
 このリポジトリは、全国の食品営業許可・届出データを収集・正規化し、
 **全件CSV**・**都道府県別CSV**・**ベクトルタイル** の3形式で無料配信するオープンデータプロジェクト。
-静的ページは GitHub Pages、データ（`api/`）は S3 + CloudFront から配信する。
+静的ページは GitHub Pages、データ（`api/`）は S3 + CloudFront（独自ドメイン
+`food.japan-facilities.com`）から配信する。
 
 ## このデータでアプリを作る場合
 
 **まず https://gl20percentclub.github.io/japan-food-facilities/llms-full.txt を読むこと。**
 データ仕様・コピペで動く利用例・注意事項がすべてまとまっている。要点だけ挙げる:
 
-- 全件CSV: `https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv`
+- 全件CSV: `https://food.japan-facilities.com/api/facilities-all.csv`
   - UTF-8 **BOMなし**、100万件超・数百MB（gzip 版は配信していない）。
     正確な件数・サイズは README の統計ブロック（自動生成）を参照する
   - 列: `prefecture, city, city_raw, name, name_kana, business_type, address, lat, lng, geocoding_level, phone, license_no, license_date, expire_date, sources, licenses`
-- 都道府県別CSV: `https://d1nptpfogf2ynv.cloudfront.net/api/prefectures/{JISコード2桁}-{ローマ字}.csv`
+- 都道府県別CSV: `https://food.japan-facilities.com/api/prefectures/{JISコード2桁}-{ローマ字}.csv`
   - 例 `13-tokyo.csv` / `01-hokkaido.csv`。47都道府県すべて存在し、列・内容は全件CSV と同じ。
     ファイル一覧と件数は `api/prefectures/index.json`。1県だけ必要ならこちらを使う
-- ベクトルタイル（MVT）: `https://d1nptpfogf2ynv.cloudfront.net/api/tiles/{z}/{x}/{y}.pbf`
+- ベクトルタイル（MVT）: `https://food.japan-facilities.com/api/tiles/{z}/{x}/{y}.pbf`
   - レイヤ名 `facilities`、z6–12、属性 `name` / `business_type` / `pref` / `city`
 - 市区町村別 CSV/JSON や検索 API は**このリポジトリからは配信していない**。データ抽出は
   CSV（DuckDB 推奨）、地図表示はタイルを使う。ブラウザから非圧縮 CSV を直接 fetch しない
@@ -73,7 +74,7 @@ attribution.html        # 出典表示ページ（sources.yaml から自動生�
 ## 配信の仕組み
 
 - **データ（`api/`）は S3 + CloudFront で配信**する。ベース URL は
-  `https://d1nptpfogf2ynv.cloudfront.net`（CORS 全オリジン許可済み）。
+  `https://food.japan-facilities.com`（CORS 全オリジン許可済み）。
   クロールと S3 への配信は別リポジトリ
   [japan-facilities-crawler](https://github.com/gl20percentclub/japan-facilities-crawler)
   の Fargate タスクが毎週月曜 18:00 UTC に実行する。このリポジトリでは `api/` を生成も

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 [公式サイト](https://gl20percentclub.github.io/japan-food-facilities/) ·
 [地図で見る](https://gl20percentclub.github.io/japan-food-facilities/map.html) ·
-[CSVをダウンロード](https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv) ·
+[CSVをダウンロード](https://food.japan-facilities.com/api/facilities-all.csv) ·
 [収録状況](docs/COVERAGE.md) ·
 [出典・ライセンス](https://gl20percentclub.github.io/japan-food-facilities/attribution.html)
 
@@ -52,20 +52,20 @@
 
 | ファイル | URL |
 |---|---|
-| 全件CSV | https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv |
+| 全件CSV | https://food.japan-facilities.com/api/facilities-all.csv |
 
 - 文字コード: UTF-8（BOMなし）
 - 全列が一致する重複レコードは除去済み
 
 ```bash
-curl -O https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv
+curl -O https://food.japan-facilities.com/api/facilities-all.csv
 ```
 
 ```python
 import pandas as pd
 
 df = pd.read_csv(
-    "https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv"
+    "https://food.japan-facilities.com/api/facilities-all.csv"
 )
 ```
 
@@ -75,21 +75,21 @@ df = pd.read_csv(
 
 | ファイル | URL |
 |---|---|
-| 都道府県別CSV | `https://d1nptpfogf2ynv.cloudfront.net/api/prefectures/{JISコード}-{ローマ字}.csv` |
-| ファイル一覧（JSON） | https://d1nptpfogf2ynv.cloudfront.net/api/prefectures/index.json |
+| 都道府県別CSV | `https://food.japan-facilities.com/api/prefectures/{JISコード}-{ローマ字}.csv` |
+| ファイル一覧（JSON） | https://food.japan-facilities.com/api/prefectures/index.json |
 
 ファイル名は、JIS都道府県コード（2桁）とローマ字を組み合わせた `01-hokkaido.csv` 〜 `47-okinawa.csv` です。47都道府県すべてのURLが常に存在します。
 
 ```bash
 # 東京都だけダウンロードする
-curl -O https://d1nptpfogf2ynv.cloudfront.net/api/prefectures/13-tokyo.csv
+curl -O https://food.japan-facilities.com/api/prefectures/13-tokyo.csv
 ```
 
 ```python
 import pandas as pd
 
 df = pd.read_csv(
-    "https://d1nptpfogf2ynv.cloudfront.net/api/prefectures/13-tokyo.csv"
+    "https://food.japan-facilities.com/api/prefectures/13-tokyo.csv"
 )
 ```
 
@@ -118,7 +118,7 @@ df = pd.read_csv(
 map.addSource("facilities", {
   type: "vector",
   tiles: [
-    "https://d1nptpfogf2ynv.cloudfront.net/api/tiles/{z}/{x}/{y}.pbf",
+    "https://food.japan-facilities.com/api/tiles/{z}/{x}/{y}.pbf",
   ],
   minzoom: 6,
   maxzoom: 12,
@@ -131,7 +131,7 @@ map.addSource("facilities", {
 
 - レイヤー名: `facilities`
 - 主な属性: `name` / `business_type` / `pref` / `city`
-- 詳細: [`api/tiles/metadata.json`](https://d1nptpfogf2ynv.cloudfront.net/api/tiles/metadata.json)
+- 詳細: [`api/tiles/metadata.json`](https://food.japan-facilities.com/api/tiles/metadata.json)
 
 収録データは[地図ページ](https://gl20percentclub.github.io/japan-food-facilities/map.html)でも確認できます。
 

--- a/index.html
+++ b/index.html
@@ -234,19 +234,19 @@
       <h2>クイックスタート</h2>
       <p class="lead">
         配信しているのは <strong>全件CSV</strong>・<strong>都道府県別CSV</strong>・<strong>ベクトルタイル</strong> の3つだけです。
-        ベース URL は <code>https://d1nptpfogf2ynv.cloudfront.net/api/</code>。
+        ベース URL は <code>https://food.japan-facilities.com/api/</code>。
       </p>
 
       <p class="step">1. CSV をダウンロードする（全件は約 540MB。1県だけなら都道府県別CSV が軽い）</p>
-<pre><code>curl -O https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv
+<pre><code>curl -O https://food.japan-facilities.com/api/facilities-all.csv
 
 <span class="c"># 東京都だけ欲しい場合（ファイル名は {JISコード}-{ローマ字}.csv）</span>
-curl -O https://d1nptpfogf2ynv.cloudfront.net/api/prefectures/13-tokyo.csv</code></pre>
+curl -O https://food.japan-facilities.com/api/prefectures/13-tokyo.csv</code></pre>
 
       <p class="step">2. pandas で読み込む（URL 直指定でもいけます）</p>
 <pre><code>import pandas as pd
 
-df = pd.read_csv('https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv')
+df = pd.read_csv('https://food.japan-facilities.com/api/facilities-all.csv')
 <span class="c"># 那覇市の飲食店営業だけ抜き出す</span>
 naha = df[(df.city == '那覇市') &amp; (df.business_type == '飲食店営業')]
 print(naha[['name', 'address', 'lat', 'lng']].head())</code></pre>
@@ -254,7 +254,7 @@ print(naha[['name', 'address', 'lat', 'lng']].head())</code></pre>
       <p class="step">3. 地図に出す（MapLibre GL JS・タイルサーバー不要）</p>
 <pre><code>map.addSource('facilities', {
   type: 'vector',
-  tiles: ['https://d1nptpfogf2ynv.cloudfront.net/api/tiles/{z}/{x}/{y}.pbf'],
+  tiles: ['https://food.japan-facilities.com/api/tiles/{z}/{x}/{y}.pbf'],
   minzoom: 6, maxzoom: 12,
   <span class="c">// 出典表示（source に入れると地図のアトリビューションに自動で表示される）</span>
   attribution:
@@ -380,7 +380,7 @@ print(naha[['name', 'address', 'lat', 'lng']].head())</code></pre>
     // 取得できない場合は HTML に書かれた既定値をそのまま残す（表示は壊さない）。
     // データは CloudFront 配信（このページ自身は GitHub Pages）なので、
     // 相対パスではなく配信元の絶対 URL を指す。CORS は全オリジン許可済み。
-    const API_BASE = 'https://d1nptpfogf2ynv.cloudfront.net/api';
+    const API_BASE = 'https://food.japan-facilities.com/api';
 
     /** 数値を「149万」「1,958」のような読みやすい表記にする。 */
     function formatCount(n) {

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6,7 +6,7 @@
 
 [公式サイト](https://gl20percentclub.github.io/japan-food-facilities/) ·
 [地図で見る](https://gl20percentclub.github.io/japan-food-facilities/map.html) ·
-[CSVをダウンロード](https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv) ·
+[CSVをダウンロード](https://food.japan-facilities.com/api/facilities-all.csv) ·
 [収録状況](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities/main/docs/COVERAGE.md) ·
 [出典・ライセンス](https://gl20percentclub.github.io/japan-food-facilities/attribution.html)
 
@@ -45,20 +45,20 @@
 
 | ファイル | URL |
 |---|---|
-| 全件CSV | https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv |
+| 全件CSV | https://food.japan-facilities.com/api/facilities-all.csv |
 
 - 文字コード: UTF-8（BOMなし）
 - 全列が一致する重複レコードは除去済み
 
 ```bash
-curl -O https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv
+curl -O https://food.japan-facilities.com/api/facilities-all.csv
 ```
 
 ```python
 import pandas as pd
 
 df = pd.read_csv(
-    "https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv"
+    "https://food.japan-facilities.com/api/facilities-all.csv"
 )
 ```
 
@@ -68,21 +68,21 @@ df = pd.read_csv(
 
 | ファイル | URL |
 |---|---|
-| 都道府県別CSV | `https://d1nptpfogf2ynv.cloudfront.net/api/prefectures/{JISコード}-{ローマ字}.csv` |
-| ファイル一覧（JSON） | https://d1nptpfogf2ynv.cloudfront.net/api/prefectures/index.json |
+| 都道府県別CSV | `https://food.japan-facilities.com/api/prefectures/{JISコード}-{ローマ字}.csv` |
+| ファイル一覧（JSON） | https://food.japan-facilities.com/api/prefectures/index.json |
 
 ファイル名は、JIS都道府県コード（2桁）とローマ字を組み合わせた `01-hokkaido.csv` 〜 `47-okinawa.csv` です。47都道府県すべてのURLが常に存在します。
 
 ```bash
 # 東京都だけダウンロードする
-curl -O https://d1nptpfogf2ynv.cloudfront.net/api/prefectures/13-tokyo.csv
+curl -O https://food.japan-facilities.com/api/prefectures/13-tokyo.csv
 ```
 
 ```python
 import pandas as pd
 
 df = pd.read_csv(
-    "https://d1nptpfogf2ynv.cloudfront.net/api/prefectures/13-tokyo.csv"
+    "https://food.japan-facilities.com/api/prefectures/13-tokyo.csv"
 )
 ```
 
@@ -111,7 +111,7 @@ df = pd.read_csv(
 map.addSource("facilities", {
   type: "vector",
   tiles: [
-    "https://d1nptpfogf2ynv.cloudfront.net/api/tiles/{z}/{x}/{y}.pbf",
+    "https://food.japan-facilities.com/api/tiles/{z}/{x}/{y}.pbf",
   ],
   minzoom: 6,
   maxzoom: 12,
@@ -124,7 +124,7 @@ map.addSource("facilities", {
 
 - レイヤー名: `facilities`
 - 主な属性: `name` / `business_type` / `pref` / `city`
-- 詳細: [`api/tiles/metadata.json`](https://d1nptpfogf2ynv.cloudfront.net/api/tiles/metadata.json)
+- 詳細: [`api/tiles/metadata.json`](https://food.japan-facilities.com/api/tiles/metadata.json)
 
 収録データは[地図ページ](https://gl20percentclub.github.io/japan-food-facilities/map.html)でも確認できます。
 
@@ -272,7 +272,7 @@ Claude Code や Codex などのコーディングエージェントでこのデ�
 ```sql
 INSTALL httpfs; LOAD httpfs;
 SELECT name, address, lat, lng
-FROM read_csv_auto('https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv')
+FROM read_csv_auto('https://food.japan-facilities.com/api/facilities-all.csv')
 WHERE prefecture = '沖縄県' AND city = '那覇市' AND business_type = '飲食店営業';
 ```
 
@@ -284,11 +284,11 @@ WHERE prefecture = '沖縄県' AND city = '那覇市' AND business_type = '飲�
 import pandas as pd
 
 # ファイル名は {JISコード2桁}-{ローマ字}.csv（13-tokyo.csv, 01-hokkaido.csv, 47-okinawa.csv …）
-df = pd.read_csv('https://d1nptpfogf2ynv.cloudfront.net/api/prefectures/13-tokyo.csv')
+df = pd.read_csv('https://food.japan-facilities.com/api/prefectures/13-tokyo.csv')
 minato = df[df['city'] == '港区']
 ```
 
-ファイル名・件数の一覧は `https://d1nptpfogf2ynv.cloudfront.net/api/prefectures/index.json` にある
+ファイル名・件数の一覧は `https://food.japan-facilities.com/api/prefectures/index.json` にある
 （`prefectures[].file` / `records` / `bytes`）。
 
 ### pandas で読む（全件CSV）
@@ -296,7 +296,7 @@ minato = df[df['city'] == '港区']
 ```python
 import pandas as pd
 
-df = pd.read_csv('https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv')
+df = pd.read_csv('https://food.japan-facilities.com/api/facilities-all.csv')
 naha = df[(df['prefecture'] == '沖縄県') & (df['city'] == '那覇市')]
 ```
 
@@ -307,7 +307,7 @@ naha = df[(df['prefecture'] == '沖縄県') & (df['city'] == '那覇市')]
 ```js
 map.addSource('facilities', {
   type: 'vector',
-  tiles: ['https://d1nptpfogf2ynv.cloudfront.net/api/tiles/{z}/{x}/{y}.pbf'],
+  tiles: ['https://food.japan-facilities.com/api/tiles/{z}/{x}/{y}.pbf'],
   minzoom: 6,
   maxzoom: 12,
   // 出典表示は必須。source の attribution に入れると地図の出典表示に自動で出る

--- a/llms.txt
+++ b/llms.txt
@@ -6,15 +6,15 @@
 
 重要な事実:
 
-- 全件CSV（gzip 版は配信していない）: https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv
+- 全件CSV（gzip 版は配信していない）: https://food.japan-facilities.com/api/facilities-all.csv
 - 都道府県別CSV（列・内容は全件CSV と同じ。1県だけ必要ならこちらを使う）:
-  https://d1nptpfogf2ynv.cloudfront.net/api/prefectures/{JISコード2桁}-{ローマ字}.csv
+  https://food.japan-facilities.com/api/prefectures/{JISコード2桁}-{ローマ字}.csv
   例 13-tokyo.csv / 01-hokkaido.csv / 47-okinawa.csv。47都道府県すべて存在する。
-  ファイル一覧と件数: https://d1nptpfogf2ynv.cloudfront.net/api/prefectures/index.json
+  ファイル一覧と件数: https://food.japan-facilities.com/api/prefectures/index.json
 - CSV は UTF-8（BOMなし）。列: prefecture, city, city_raw, name, name_kana,
   business_type, address, lat, lng, geocoding_level, phone, license_no,
   license_date, expire_date, sources, licenses
-- ベクトルタイル（MVT）: https://d1nptpfogf2ynv.cloudfront.net/api/tiles/{z}/{x}/{y}.pbf （レイヤ名 facilities、z6–12）
+- ベクトルタイル（MVT）: https://food.japan-facilities.com/api/tiles/{z}/{x}/{y}.pbf （レイヤ名 facilities、z6–12）
 - 市区町村別 CSV/JSON や検索 API はこのリポジトリからは配信していない。抽出は CSV から、
   地図表示はタイルで行う
 - 全ファイル CORS 開放済み（Access-Control-Allow-Origin: *）。URL は更新後も不変
@@ -36,6 +36,6 @@
 - [llms-full.txt](https://gl20percentclub.github.io/japan-food-facilities/llms-full.txt): データ仕様・利用例・注意事項の全文（まずこれを読む）
 - [README](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities/main/README.md): プロジェクト概要
 - [収録状況](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities/main/docs/COVERAGE.md): 自治体ごとの収録有無・取得元・ライセンスの一覧
-- [タイルメタデータ](https://d1nptpfogf2ynv.cloudfront.net/api/tiles/metadata.json): TileJSON（レイヤ定義・ズーム範囲・bounds）
+- [タイルメタデータ](https://food.japan-facilities.com/api/tiles/metadata.json): TileJSON（レイヤ定義・ズーム範囲・bounds）
 - [地図ページ](https://gl20percentclub.github.io/japan-food-facilities/map.html): 収録データをベクトルタイルで表示するプレビュー地図
 - [出典・ライセンス表示](https://gl20percentclub.github.io/japan-food-facilities/attribution.html): 利用時に必要な出典表示の文例

--- a/map.html
+++ b/map.html
@@ -190,7 +190,7 @@
       <span id="updated"></span><br>
       <a href="./">トップ</a> ·
       <a href="https://github.com/gl20percentclub/japan-food-facilities">GitHub</a> ·
-      <a href="https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv">全件CSV</a> ·
+      <a href="https://food.japan-facilities.com/api/facilities-all.csv">全件CSV</a> ·
       <a href="./attribution.html">出典・ライセンス</a>
     </p>
   </div>
@@ -203,7 +203,7 @@
     // データ配信ベース URL。このページ自身は GitHub Pages だが、データ（api/）は
     // S3 + CloudFront から配信されるため、相対参照ではなく絶対 URL を指す。
     // CORS は全オリジン許可済みなので、ローカルで開いた場合もそのまま読める。
-    const API_BASE = 'https://d1nptpfogf2ynv.cloudfront.net/api';
+    const API_BASE = 'https://food.japan-facilities.com/api';
     // ベクトルタイルのズーム範囲（scripts/gen-tiles.js の設定と一致させる）
     const TILE_MIN_ZOOM = 6;
     const TILE_MAX_ZOOM = 12;

--- a/scripts/gen-llms.js
+++ b/scripts/gen-llms.js
@@ -23,10 +23,11 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
 const README_PATH = path.join(ROOT, 'README.md');
 
-// 配信 URL の基点。静的ページは GitHub Pages、データ（api/）は S3 + CloudFront と
-// 配信元が分かれている。RAW はリポジトリ内 Markdown の取得先。
+// 配信 URL の基点。静的ページは GitHub Pages、データ（api/）は S3 + CloudFront
+// （独自ドメイン food.japan-facilities.com）と配信元が分かれている。
+// RAW はリポジトリ内 Markdown の取得先。
 const PAGES = 'https://gl20percentclub.github.io/japan-food-facilities';
-const DATA = 'https://d1nptpfogf2ynv.cloudfront.net';
+const DATA = 'https://food.japan-facilities.com';
 const REPO = 'https://github.com/gl20percentclub/japan-food-facilities';
 const RAW = 'https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities/main';
 

--- a/scripts/gen-llms.test.js
+++ b/scripts/gen-llms.test.js
@@ -78,10 +78,10 @@ assert(!/\n{3,}/.test(stripped), '3連以上の空行が残らない');
 const llms = renderLlmsTxt(readme);
 assert(llms.startsWith('# Japan Food Facilities Data'), 'H1 で始まる（llms.txt 仕様）');
 assert(llms.split('\n')[2].startsWith('> '), 'H1 直後に blockquote の要約がある');
-// データ（api/）は CloudFront 配信。Pages のホストを指していたら張り替え漏れなので落とす。
+// データ（api/）は独自ドメインで配信。Pages のホストを指していたら張り替え漏れなので落とす。
 assert(
-  llms.includes('https://d1nptpfogf2ynv.cloudfront.net/api/facilities-all.csv'),
-  'CSV の URL は CloudFront を指す',
+  llms.includes('https://food.japan-facilities.com/api/facilities-all.csv'),
+  'CSV の URL は配信用の独自ドメインを指す',
 );
 assert(!llms.includes('facilities-all.csv.gz'), '配信していない gzip 版を案内しない');
 assert(llms.includes('{z}/{x}/{y}.pbf'), 'タイルの URL テンプレートが載る');


### PR DESCRIPTION
## 概要

CSV とベクトルタイルの配信元を、CloudFront のデフォルトドメイン
（`d1nptpfogf2ynv.cloudfront.net`）から独自ドメイン
**`https://food.japan-facilities.com`** に張り替える。

配信パス（`/api/...`）は変更していない。デフォルトドメインも引き続き有効なので、
外部に出回っている旧 URL も切れない。

## 変更内容

- `README.md` / `index.html` / `map.html` / `AGENTS.md` / `scripts/gen-llms.js` の
  配信 URL を新ドメインへ
- `llms.txt` / `llms-full.txt` は生成元の変更にあわせて再生成
- `scripts/gen-llms.test.js` の期待値も追従

## インフラ側

`gl20percentclub/japan-facilities-crawler#14` でデプロイ済み。

- Route 53 ホストゾーン `Z063930525KY1LPN9JLJY`（お名前.com から NS 委任）
- ACM 証明書（us-east-1、DNS 検証）
- CloudFront の代替ドメイン名 + A / AAAA エイリアス

## 動作確認

新ドメインでの疎通を確認済み。

```
DNS      A / AAAA とも CloudFront に解決
metadata 200 (application/json)
タイル    200
CSV      206 (Range リクエスト)
CORS     access-control-allow-origin: *
```

`npm run test:unit` 全通過（171 件）。