### PR TITLE
fix: 自治体の異なり数を実在の自治体だけで数え、町村の郡名を外す

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Claude Code や Codex などのコーディングエージェントでこのデ�
 | 列 | 内容 |
 |---|---|
 | `prefecture` | 都道府県 |
-| `city` | 正規化後の市区町村名（政令市は市に集約、町村は郡付き） |
+| `city` | 正規化後の市区町村名（政令市は市に集約、町村は郡名なし） |
 | `city_raw` | 元データの市区町村表記 |
 | `name` / `name_kana` | 施設名・カナ |
 | `business_type` | 営業許可・届出の業種 |
@@ -161,7 +161,9 @@ Claude Code や Codex などのコーディングエージェントでこのデ�
 | `license_date` / `expire_date` | 許可日・有効期限 |
 | `sources` / `licenses` | 元データの出典・ライセンス |
 
-市区町村名は、[normalize-japanese-addresses](https://github.com/geolonia/normalize-japanese-addresses) を利用して公式表記に正規化しています。粒度は市区町村に揃えており、政令指定都市の行政区は市に集約し（「横浜市戸塚区」→「横浜市」）、町村は郡付きの表記（「河北郡津幡町」）を使います。元データの表記は `city_raw` に残しています。
+市区町村名は、[normalize-japanese-addresses](https://github.com/geolonia/normalize-japanese-addresses) を利用して公式表記に正規化しています。粒度は市区町村に揃えており、政令指定都市の行政区は市に集約し（「横浜市戸塚区」→「横浜市」）、町村は郡名を外した表記（「河北郡津幡町」→「津幡町」）を使います。元データの表記は `city_raw` に残しています。
+
+都道府県・市区町村を特定できなかったレコードには `不明` が入ります。統計の「都道府県」「市区町村」は実在の自治体だけを数えるため、これらは含みません（レコード自体はCSVに含まれます）。
 
 ## 収録範囲
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -142,7 +142,7 @@ Claude Code や Codex などのコーディングエージェントでこのデ�
 | 列 | 内容 |
 |---|---|
 | `prefecture` | 都道府県 |
-| `city` | 正規化後の市区町村名（政令市は市に集約、町村は郡付き） |
+| `city` | 正規化後の市区町村名（政令市は市に集約、町村は郡名なし） |
 | `city_raw` | 元データの市区町村表記 |
 | `name` / `name_kana` | 施設名・カナ |
 | `business_type` | 営業許可・届出の業種 |
@@ -154,7 +154,9 @@ Claude Code や Codex などのコーディングエージェントでこのデ�
 | `license_date` / `expire_date` | 許可日・有効期限 |
 | `sources` / `licenses` | 元データの出典・ライセンス |
 
-市区町村名は、[normalize-japanese-addresses](https://github.com/geolonia/normalize-japanese-addresses) を利用して公式表記に正規化しています。粒度は市区町村に揃えており、政令指定都市の行政区は市に集約し（「横浜市戸塚区」→「横浜市」）、町村は郡付きの表記（「河北郡津幡町」）を使います。元データの表記は `city_raw` に残しています。
+市区町村名は、[normalize-japanese-addresses](https://github.com/geolonia/normalize-japanese-addresses) を利用して公式表記に正規化しています。粒度は市区町村に揃えており、政令指定都市の行政区は市に集約し（「横浜市戸塚区」→「横浜市」）、町村は郡名を外した表記（「河北郡津幡町」→「津幡町」）を使います。元データの表記は `city_raw` に残しています。
+
+都道府県・市区町村を特定できなかったレコードには `不明` が入ります。統計の「都道府県」「市区町村」は実在の自治体だけを数えるため、これらは含みません（レコード自体はCSVに含まれます）。
 
 ## 収録範囲
 

--- a/scripts/build-merged-csv.js
+++ b/scripts/build-merged-csv.js
@@ -17,6 +17,11 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { PREFECTURE_NAMES } from './lib/normalize.js';
+
+// 「都道府県／市区町村の異なり数」に数えてよい値かを判定するための集合。
+// 元データには '不明'（解決できなかった）や '県外'（管轄外を表す独自の値）が混ざる。
+const REAL_PREFECTURES = new Set(PREFECTURE_NAMES);
 
 /** 結合CSV の列（この順で出力する）。 */
 export const CSV_COLUMNS = [
@@ -54,9 +59,23 @@ function write(stream, chunk) {
 }
 
 /**
+ * 施設の都道府県・市区町村が実在の自治体として数えられるかを判定する（純粋関数）。
+ * `prefOk` が false なら都道府県すら特定できていないので、市区町村も数えない。
+ */
+export function countableArea(facility) {
+  const prefOk = REAL_PREFECTURES.has(facility.pref);
+  const city = facility.city;
+  return { prefOk, cityOk: prefOk && !!city && city !== '不明' };
+}
+
+/**
  * 結合CSV を書き出す（BOM なし UTF-8）。
- * 統計 `{ rowsIn, rowsOut, dupSkipped, prefectures, cities, bytes }` と、
- * 重複を除いたあとの施設 `unique` を返す。
+ * 統計 `{ rowsIn, rowsOut, dupSkipped, prefectures, cities, prefUnknown, cityUnknown, bytes }`
+ * と、重複を除いたあとの施設 `unique` を返す。
+ *
+ * `prefectures` / `cities` は実在の自治体だけを数える。'不明' や '県外' を混ぜると、
+ * 47都道府県・1,741市区町村という上限を超えた値が統計に出てしまうため、
+ * これらはレコードとしては残したうえで `prefUnknown` / `cityUnknown` に集計する。
  *
  * `unique` はベクトルタイルの生成にも使う。重複判定はここでしか行わないため、
  * これを渡さずに元の配列からタイルを作ると、CSV には無い重複点がタイルに載り、
@@ -74,6 +93,8 @@ export async function buildMergedCsv(facilities, { outPath, log = console.log } 
   const seen = new Set(); // 出典を除く全列一致の重複判定
   const prefs = new Set();
   const cities = new Set();
+  let prefUnknown = 0; // 都道府県を特定できなかったレコード数
+  let cityUnknown = 0; // 市区町村を特定できなかったレコード数
   const unique = []; // CSV に書いた施設（＝タイルに載せる施設）
 
   for (const f of facilities) {
@@ -92,8 +113,13 @@ export async function buildMergedCsv(facilities, { outPath, log = console.log } 
     if (backpressure) await backpressure;
     rowsOut++;
     unique.push(f);
-    prefs.add(f.pref);
-    cities.add(`${f.pref}/${f.city}`);
+
+    // 異なり数は実在の自治体だけを数え、特定できなかったものは件数として別に持つ。
+    const { prefOk, cityOk } = countableArea(f);
+    if (prefOk) prefs.add(f.pref);
+    else prefUnknown++;
+    if (cityOk) cities.add(`${f.pref}/${f.city}`);
+    else cityUnknown++;
   }
 
   // end() のコールバックは flush 完了時に呼ばれる。
@@ -110,6 +136,12 @@ export async function buildMergedCsv(facilities, { outPath, log = console.log } 
       ` / ${prefs.size}都道府県 / ${cities.size}市区町村` +
       ` / ${(bytes / 1024 / 1024).toFixed(1)} MB`,
   );
+  if (cityUnknown) {
+    log(
+      `  自治体を特定できないレコード: 都道府県 ${prefUnknown.toLocaleString('en-US')}件` +
+        ` / 市区町村 ${cityUnknown.toLocaleString('en-US')}件（CSV には残す）`,
+    );
+  }
 
   return {
     rowsIn,
@@ -117,6 +149,8 @@ export async function buildMergedCsv(facilities, { outPath, log = console.log } 
     dupSkipped,
     prefectures: prefs.size,
     cities: cities.size,
+    prefUnknown,
+    cityUnknown,
     bytes,
     unique,
   };

--- a/scripts/build-merged-csv.test.js
+++ b/scripts/build-merged-csv.test.js
@@ -16,7 +16,8 @@ import {
   applyPrefCity,
   collectCityPairs,
   stripWardSuffix,
-  buildCountyAliasMap,
+  stripCountyPrefix,
+  toMunicipality,
 } from './lib/city-normmap.js';
 
 let passed = 0;
@@ -171,6 +172,27 @@ await test('CSV: 都道府県・市区町村の異なり数を数える', async 
   try {
     assert.equal(stats.prefectures, 2);
     assert.equal(stats.cities, 3);
+    assert.equal(stats.prefUnknown, 0);
+    assert.equal(stats.cityUnknown, 0);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+await test('CSV: 「不明」「県外」は自治体として数えず、件数だけ残す', async () => {
+  const { dir, stats, rows } = await writeCsv([
+    fac(),
+    fac({ name: '店B', city: '不明', city_raw: '不明' }),
+    fac({ name: '店C', pref: '不明', city: '不明', city_raw: '不明' }),
+    fac({ name: '店D', pref: '県外', city: '小矢部市', city_raw: '小矢部市' }),
+  ]);
+  try {
+    assert.equal(stats.prefectures, 1, '実在の都道府県だけ数える（47を超えない）');
+    assert.equal(stats.cities, 1, '実在の市区町村だけ数える（1,741を超えない）');
+    assert.equal(stats.prefUnknown, 2, '不明・県外のレコード数');
+    assert.equal(stats.cityUnknown, 3, '市区町村を特定できないレコード数');
+    assert.equal(stats.rowsOut, 4, 'レコード自体は CSV に残す');
+    assert.equal(rows.length, 4, '不明・県外の行も CSV から消えない');
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -190,15 +212,15 @@ await test('CSV: gzip 版は生成しない（配布は非圧縮CSVのみ）', a
 // --- 市区町村の名寄せ（純粋関数） ---
 await test('resolvePrefCity: 名寄せ表があれば公式名を採用する', () => {
   const f = { _pref: '大分県', _city: '九重町', address: '大分県九重町大字後野上8-1' };
-  // normalize() は郡付きの公式名を返す。
+  // normalize() は郡付きの公式名を返すが、出力は郡名を外した表記に揃える。
   const r = resolvePrefCity(f, { '大分県\t九重町': { pref: '大分県', city: '玖珠郡九重町' } });
-  assert.deepEqual(r, { pref: '大分県', city: '玖珠郡九重町', cityRaw: '九重町', colFixed: false });
+  assert.deepEqual(r, { pref: '大分県', city: '九重町', cityRaw: '九重町', colFixed: false });
 });
 
-await test('resolvePrefCity: 名寄せ表にも対応表にも無ければ元の表記を保つ', () => {
+await test('resolvePrefCity: 名寄せ表に無くても郡名は外す', () => {
   const f = { _pref: '大分県', _city: '玖珠郡九重町', address: '大分県玖珠郡九重町…' };
-  assert.equal(resolvePrefCity(f, {}).city, '玖珠郡九重町', '郡名は勝手に剥がさない');
-  assert.equal(resolvePrefCity(f, {}).cityRaw, '玖珠郡九重町');
+  assert.equal(resolvePrefCity(f, {}).city, '九重町');
+  assert.equal(resolvePrefCity(f, {}).cityRaw, '玖珠郡九重町', '元の表記は city_raw に残す');
 });
 
 // --- 粒度の統一: 政令指定都市の行政区は市に集約する ---
@@ -211,6 +233,22 @@ await test('stripWardSuffix: 政令市の行政区を市に集約し、特別区
   assert.equal(stripWardSuffix('河北郡津幡町'), '河北郡津幡町');
 });
 
+// --- 粒度の統一: 町村は郡名を外す ---
+await test('stripCountyPrefix: 郡名を外し、郡を含む市名は残す', () => {
+  assert.equal(stripCountyPrefix('河北郡津幡町'), '津幡町');
+  assert.equal(stripCountyPrefix('国頭郡今帰仁村'), '今帰仁村');
+  assert.equal(stripCountyPrefix('津幡町'), '津幡町', '郡なしはそのまま');
+  assert.equal(stripCountyPrefix('郡上市'), '郡上市', '市名の「郡」は郡名ではない');
+  assert.equal(stripCountyPrefix('大和郡山市'), '大和郡山市');
+  assert.equal(stripCountyPrefix('郡山市'), '郡山市');
+});
+
+await test('toMunicipality: 郡名剥がしと行政区の集約をまとめて行う', () => {
+  assert.equal(toMunicipality('河北郡津幡町'), '津幡町');
+  assert.equal(toMunicipality('横浜市戸塚区'), '横浜市');
+  assert.equal(toMunicipality('千代田区'), '千代田区');
+});
+
 await test('resolvePrefCity: 名寄せ結果の行政区を市へ集約する', () => {
   const f = { _pref: '神奈川県', _city: '横浜市', address: '神奈川県横浜市戸塚区戸塚町16-1' };
   const normMap = { '神奈川県\t横浜市': { pref: '神奈川県', city: '横浜市戸塚区' } };
@@ -219,35 +257,18 @@ await test('resolvePrefCity: 名寄せ結果の行政区を市へ集約する', 
   assert.equal(r.cityRaw, '横浜市', '元データの表記は city_raw に残す');
 });
 
-// --- 粒度の統一: 町村は郡付きの公式表記へ寄せる ---
-await test('buildCountyAliasMap: 名寄せ結果から「郡なし→郡付き」の対応表を作る', () => {
-  const alias = buildCountyAliasMap({
-    '石川県\t河北郡津幡町': { pref: '石川県', city: '河北郡津幡町' },
-    '東京都\t港区': { pref: '東京都', city: '港区' },
-    '不明\t不明': null,
-  });
-  assert.deepEqual(alias, { '石川県\t津幡町': '河北郡津幡町' }, '郡付きの値だけが対応表になる');
-});
-
-await test('resolvePrefCity: 郡なしの町村名を郡付きの公式表記へ寄せる', () => {
-  const f = { _pref: '石川県', _city: '津幡町', address: '石川県津幡町字加賀爪ニ3' };
-  const alias = { '石川県\t津幡町': '河北郡津幡町' };
-  const r = resolvePrefCity(f, {}, alias);
-  assert.equal(r.city, '河北郡津幡町');
-  assert.equal(r.cityRaw, '津幡町');
-});
-
 await test('applyPrefCity: 郡あり・郡なしの表記ゆれが同じ市区町村に揃う', () => {
   const facilities = [
     { _pref: '石川県', _city: '河北郡津幡町', address: '石川県河北郡津幡町字加賀爪ニ3' },
     { _pref: '石川県', _city: '津幡町', address: '石川県津幡町字加賀爪ニ3' },
   ];
-  // 郡付き側だけ名寄せに成功したケース（郡なし側は対応表で救う）。
+  // 郡付き側だけ名寄せに成功したケース（名寄せの成否によらず同じ値になる）。
   applyPrefCity(facilities, {
     '石川県\t河北郡津幡町': { pref: '石川県', city: '河北郡津幡町' },
   });
-  assert.equal(facilities[0].city, '河北郡津幡町');
-  assert.equal(facilities[1].city, '河北郡津幡町', '郡なし表記も同じ値に寄る');
+  assert.equal(facilities[0].city, '津幡町');
+  assert.equal(facilities[1].city, '津幡町');
+  assert.equal(facilities[0].city_raw, '河北郡津幡町', '元の表記は city_raw に残す');
 });
 
 await test('resolvePrefCity: 列ズレ（pref に郵便番号・city に都道府県名）を住所から復元する', () => {
@@ -266,11 +287,11 @@ await test('applyPrefCity: 施設に pref / city / city_raw を書き込み件�
   const { colFixedCount, mergedCount } = applyPrefCity(facilities, {
     '大分県\t玖珠郡九重町': { pref: '大分県', city: '玖珠郡九重町' },
   });
-  assert.equal(facilities[0].city, '玖珠郡九重町');
+  assert.equal(facilities[0].city, '九重町');
   assert.equal(facilities[0].city_raw, '玖珠郡九重町');
   assert.equal(facilities[1].city, '港区');
   assert.equal(colFixedCount, 0);
-  assert.equal(mergedCount, 0, '表記が変わらなければ名寄せ件数に数えない');
+  assert.equal(mergedCount, 1, '表記が変わった件数を数える');
 });
 
 await test('collectCityPairs: ユニークな (都道府県, 市区町村) を代表住所つきで集める', () => {

--- a/scripts/gen-readme-stats.js
+++ b/scripts/gen-readme-stats.js
@@ -46,6 +46,9 @@ export function renderStats(s) {
     `> | 座標を持つ施設 | ${num(s.tiles.points)} 件 |`,
     `> | 都道府県 | ${num(s.csv.prefectures)} |`,
     `> | 市区町村 | ${num(s.csv.cities)} |`,
+    // 「不明」等で自治体に紐づけられなかったレコードは異なり数に数えていないので、
+    // 数え落としに見えないよう件数を別行で出す（0件なら行ごと省く）。
+    ...(s.csv.cityUnknown ? [`> | うち市区町村を特定できない施設 | ${num(s.csv.cityUnknown)} 件 |`] : []),
     `> | 結合CSV | ${humanSize(s.csv.bytes)} |`,
     // 都道府県別CSV は全件CSV と同じレコードの分割配信なので、件数ではなくファイル数と総量を出す。
     ...(s.prefCsv ? [`> | 都道府県別CSV | ${num(s.prefCsv.files)} ファイル / ${humanSize(s.prefCsv.bytes)} |`] : []),

--- a/scripts/gen-readme-stats.test.js
+++ b/scripts/gen-readme-stats.test.js
@@ -40,6 +40,19 @@ assert(!md.includes('gzip'), 'gzip 表記は出さない（非圧縮CSVのみ配
 assert(md.includes('| 都道府県別CSV | 47 ファイル / 約 538.0 MB |'), '都道府県別CSV のファイル数とサイズが出る');
 assert(md.includes('| ベクトルタイル | 12,345 枚 / 約 250.0 MB |'), 'タイル枚数とサイズが出る');
 
+assert(
+  !md.includes('市区町村を特定できない施設'),
+  '特定できない施設が0件ならその行を出さない',
+);
+
+// 市区町村を特定できないレコードがある場合は、異なり数と別に件数を出す。
+const withUnknown = renderStats({ ...fixed, csv: { ...fixed.csv, cityUnknown: 61234 } });
+assert(
+  withUnknown.includes('| うち市区町村を特定できない施設 | 61,234 件 |'),
+  '特定できない施設の件数を別行で出す',
+);
+assert(withUnknown.includes('| 市区町村 | 1,741 |'), '異なり数には数えない');
+
 // prefCsv を渡さない場合は都道府県別CSV の行を出さない（旧形式の統計でも壊れないこと）。
 const noPref = renderStats({ ...fixed, prefCsv: undefined });
 assert(!noPref.includes('都道府県別CSV'), 'prefCsv が無ければ都道府県別CSV の行を出さない');

--- a/scripts/lib/city-normmap.js
+++ b/scripts/lib/city-normmap.js
@@ -8,8 +8,9 @@
 // 出力する city の粒度は「市区町村」に揃える。具体的には次の2点を保証する:
 //   - 政令指定都市の行政区は市に集約する（「横浜市戸塚区」→「横浜市」）。
 //     splitPrefCity（normalize.js）と同じ粒度に合わせるため。
-//   - 町村は郡付きの公式表記に揃える（「津幡町」→「河北郡津幡町」）。
-//     名寄せに成功した表記が郡付きなので、解決できなかった側をそちらへ寄せる。
+//   - 町村は郡名を外した表記に揃える（「河北郡津幡町」→「津幡町」）。
+//     全国1,741市区町村を都道府県ごとに見ると、郡名を外しても名前が衝突する自治体は
+//     無い（docs/COVERAGE.md の一覧で確認済み）。
 // 揃えないと、同じ自治体が「横浜市戸塚区」「河北郡津幡町」「津幡町」のように
 // 複数の値へ分裂し、市区町村の異なり数が実際の自治体数（1,741）を超えてしまう。
 //
@@ -22,10 +23,11 @@ import { PREFECTURE_NAMES, splitPrefCity } from './normalize.js';
 const PREFS = new Set(PREFECTURE_NAMES);
 
 /**
- * 郡名プレフィックスを剥がす。例: 「玖珠郡九重町」→「九重町」
- * 郡付き・郡なしの表記ゆれを突き合わせるためのキー作りに使う（出力値には使わない）。
+ * 郡名プレフィックスを剥がす（純粋関数）。
+ * 例: 「玖珠郡九重町」→「九重町」、「国頭郡今帰仁村」→「今帰仁村」
+ * 「郡上市」「大和郡山市」のように郡名でない「郡」を含む市名は対象外。
  */
-function stripCountyPrefix(city) {
+export function stripCountyPrefix(city) {
   const m = String(city).match(/郡(.+?[町村])$/);
   return m ? m[1] : city;
 }
@@ -41,21 +43,12 @@ export function stripWardSuffix(city) {
 }
 
 /**
- * 名寄せ表の値から「郡なし町村名 → 郡付き公式名」の対応表を作る（純粋関数）。
- * キーは `"都道府県\t郡なし町村名"`。
- *
- * 名寄せに失敗したペア（normMap の値が null）は郡付きの公式名が分からないため、
- * 同じ実行内で名寄せに成功した他ソースの結果を辞書として流用する。
+ * 市区町村名を出力用の表記に揃える（純粋関数）。
+ * 郡名を外し、政令指定都市の行政区を市に集約する。
+ * 名寄せの成否にかかわらず、city 列に出す値はすべてここを通す。
  */
-export function buildCountyAliasMap(normMap = {}) {
-  const alias = {};
-  for (const v of Object.values(normMap)) {
-    if (!v?.pref || !v?.city) continue;
-    const short = stripCountyPrefix(v.city);
-    // 郡付きの値だけが対応表になる（「九重町」→「玖珠郡九重町」）。
-    if (short !== v.city) alias[`${v.pref}\t${short}`] = v.city;
-  }
-  return alias;
+export function toMunicipality(city) {
+  return stripWardSuffix(stripCountyPrefix(city));
 }
 
 /**
@@ -128,11 +121,10 @@ export async function buildCityNormMap(facilities, { concurrency = 8, log = cons
  *
  * 1. 列ズレ補正: pref が都道府県名でない（郵便番号等）／city に都道府県名が入っている
  *    ソース（富山県の数件）は、住所先頭から都道府県・市区町村を復元する。
- * 2. 名寄せ: 名寄せ表にあれば公式の都道府県・市区町村名を採用。無ければ郡付き対応表
- *    （countyAlias）で公式表記を補う。
- * 3. 粒度統一: どちらの経路でも政令指定都市の行政区は市に集約する。
+ * 2. 名寄せ: 名寄せ表にあれば公式の都道府県・市区町村名を採用。無ければ元の表記を使う。
+ * 3. 粒度統一: どちらの経路でも toMunicipality() を通し、郡名剥がしと行政区の集約を行う。
  */
-export function resolvePrefCity(facility, normMap = {}, countyAlias = {}) {
+export function resolvePrefCity(facility, normMap = {}) {
   const rawPref = facility._pref || '不明';
   const rawCity = facility._city || '不明';
 
@@ -150,24 +142,22 @@ export function resolvePrefCity(facility, normMap = {}, countyAlias = {}) {
 
   const nm = normMap[`${rawPref}\t${rawCity}`];
   if (nm?.pref && nm?.city) {
-    return { pref: nm.pref, city: stripWardSuffix(nm.city), cityRaw, colFixed };
+    return { pref: nm.pref, city: toMunicipality(nm.city), cityRaw, colFixed };
   }
-  // 名寄せできなかった分は、郡付き対応表があれば公式表記へ寄せる（無ければ元の表記のまま）。
-  const official = countyAlias[`${pref}\t${stripCountyPrefix(cityRaw)}`];
-  return { pref, city: stripWardSuffix(official || cityRaw), cityRaw, colFixed };
+  // 名寄せできなかった分も同じ整形を通す。表記ゆれは残るが粒度だけは揃う。
+  return { pref, city: toMunicipality(cityRaw), cityRaw, colFixed };
 }
 
 /**
  * 施設配列に確定した pref / city / city_raw を書き込む（破壊的）。
  * 以降の出力（結合CSV・ベクトルタイル）は共通してこの値を使う。
- * 郡付き対応表は名寄せ表から自動で作る（テスト等から明示的に渡すこともできる）。
  * 補正・名寄せの件数を返す。
  */
-export function applyPrefCity(facilities, normMap, countyAlias = buildCountyAliasMap(normMap)) {
+export function applyPrefCity(facilities, normMap) {
   let colFixedCount = 0;
   let mergedCount = 0;
   for (const f of facilities) {
-    const { pref, city, cityRaw, colFixed } = resolvePrefCity(f, normMap, countyAlias);
+    const { pref, city, cityRaw, colFixed } = resolvePrefCity(f, normMap);
     f.pref = pref;
     f.city = city;
     f.city_raw = cityRaw;


### PR DESCRIPTION
統計に出る「都道府県 48 / 市区町村 1,796」が、実在する 47 / 1,741 を超えていた件の残り2つを直す。

## 1. 「不明」「県外」を自治体として数えていた（①）

都道府県・市区町村を特定できなかったレコードには `不明` が入る。これが1自治体として異なり数に混ざっていた（`県外` は元データ由来の値で9件）。

- 異なり数は**実在の47都道府県に属するものだけ**を数える
- 特定できなかったレコードは `prefUnknown` / `cityUnknown` に**件数として集計**する。レコード自体は従来どおり全件CSVに残す（都道府県別CSVの `unassigned` と同じ考え方）
- README の統計に「うち市区町村を特定できない施設」の行を追加（0件なら行ごと省く）

これで**定義上、47 / 1,741 を超えられなくなる**。

## 2. 町村の郡あり・郡なしを郡なしに統一

`河北郡津幡町` と `津幡町` が別々の値として残っていた分を、**郡名を外した表記**に統一する。

衝突しないことは全1,741市区町村の一覧（`docs/COVERAGE.md`）で確認した:

```
$ 都道府県ごとに郡名を外して重複チェック
（衝突なし。1,741件すべて一意）
```

#67 では逆に郡付きへ寄せていたが、方針変更にともない `buildCountyAliasMap()`（同じ実行内の名寄せ成功結果から対応表を作る仕組み）が不要になり、`toMunicipality()` に一本化できた。

## 検証

配信中のCSV（1,488,756件）の全ペアに、このPRの変換と集計をそのまま適用:

```
市区町村: 1796 → 1734          ← 1,741以下 ✓
都道府県: → 47                  ← 47以下 ✓
都道府県を特定できない:      9 件
市区町村を特定できない: 58,190 件
```

実際のクロールでも確認（`--only=kyoto-city,toyama-pref,kanazawa --no-geocode`）:

```
結合CSV: 56,351行 / 7都道府県 / 25市区町村 / 12.8 MB
自治体を特定できないレコード: 都道府県 9件 / 市区町村 100件（CSV には残す）

 448 富山県  立山町   ← city_raw は「中新川郡立山町」
  41 富山県  舟橋村   ← city_raw は「中新川郡舟橋村」
```

ユニットテスト4件追加（`stripCountyPrefix` / `toMunicipality` / 不明・県外の集計 / README統計の新しい行）。`npm run test:unit` は全件パス。

## 影響

- `city` 列の町村名から郡名が消える（`city_raw` には元の表記が残る）
- 統計の都道府県・市区町村が実態に合う値になる
- 反映は次回のクロールから