### PR TITLE
地図の初期ズームをタイルの最小ズームに合わせる

### DIFF
--- a/map.html
+++ b/map.html
@@ -209,6 +209,9 @@
     const TILE_MAX_ZOOM = 12;
     // 日本のおおよその範囲 [west, south, east, north]
     const JAPAN_BOUNDS = [122, 20, 154, 46];
+    // 初期表示の中心（本州中央部あたり）。ズームはタイルの最小ズームに合わせるため、
+    // 全国を収める fitBounds ではなく中心＋ズーム指定で開く。
+    const INITIAL_CENTER = [138.2, 36.4];
 
     // 業種（business_type）の大分類。元データの表記は自治体ごとにゆれが大きく
     // （「飲食店営業」「① 飲食店営業」「飲食店営業(1)一般食堂・レストラン等」など）、
@@ -290,8 +293,10 @@
           },
         ],
       },
-      bounds: JAPAN_BOUNDS,
-      fitBoundsOptions: { padding: 20 },
+      // 開いた直後から施設の点が見えるよう、初期ズームをタイルの最小ズームに合わせる
+      // （全国を収める fitBounds だと z5 以下になり、タイルが無くて点が出ない）。
+      center: INITIAL_CENTER,
+      zoom: TILE_MIN_ZOOM,
       minZoom: 3,
       maxZoom: 18,
       attributionControl: false,

--- a/scripts/preview-map.test.js
+++ b/scripts/preview-map.test.js
@@ -66,6 +66,24 @@ test('TILE_MIN_ZOOM / TILE_MAX_ZOOM が gen-tiles の既定ズーム範囲と一
   });
 });
 
+test('初期ズームがタイルの最小ズーム以上で、開いた直後から点が出る', () => {
+  // fitBounds で全国を収めると z5 以下になり、タイルが無くて点が1つも出ない。
+  // 初期ズームはタイルの最小ズームに合わせる（定数を直接使っていることも確認する）。
+  assert.ok(/zoom: TILE_MIN_ZOOM/.test(HTML), '初期ズームに TILE_MIN_ZOOM を使う');
+  assert.ok(!/fitBoundsOptions/.test(HTML), '全国 fitBounds で初期表示していない');
+  withTiles({}, (meta) => {
+    const minZoom = Number(htmlValue(/TILE_MIN_ZOOM\s*=\s*(\d+)/, 'TILE_MIN_ZOOM'));
+    assert.ok(minZoom >= meta.minzoom, `初期ズーム(${minZoom}) がタイルの最小ズーム(${meta.minzoom})以上`);
+  });
+  // 初期中心が日本の範囲（タイルの bounds）に収まっていること。
+  const center = htmlValue(/INITIAL_CENTER = \[([^\]]+)\]/, 'INITIAL_CENTER')
+    .split(',').map((v) => Number(v.trim()));
+  const bounds = htmlValue(/JAPAN_BOUNDS = \[([^\]]+)\]/, 'JAPAN_BOUNDS')
+    .split(',').map((v) => Number(v.trim()));
+  assert.ok(center[0] > bounds[0] && center[0] < bounds[2], `初期中心の経度(${center[0]}) が日本の範囲内`);
+  assert.ok(center[1] > bounds[1] && center[1] < bounds[3], `初期中心の緯度(${center[1]}) が日本の範囲内`);
+});
+
 test('タイルURLテンプレートが「api/tiles/ + metadata.tiles[0]」の配置と一致する', () => {
   // データは CloudFront 配信のため、map.html は API_BASE（.../api）を基点に組み立てる。
   // API_BASE と組み立て後のパスを突き合わせ、配信物の配置と一致するか検証する。


### PR DESCRIPTION
## 概要

地図ページの初期ズームを、ベクトルタイルの最小ズーム（z6）に合わせました。

これまでは全国を収める `fitBounds`（`JAPAN_BOUNDS`）で開いていたため、初期表示は z5 以下になり、**タイルが存在しないので施設の点が1つも出ていませんでした**（「ズームインすると施設ピンが表示されます」のヒントだけが出ている状態）。

## 変更点

- 初期表示を `center: INITIAL_CENTER`（本州中央部 `[138.2, 36.4]`）＋ `zoom: TILE_MIN_ZOOM` に変更
- `fitBoundsOptions` は削除（`JAPAN_BOUNDS` はタイルソースの `bounds` として引き続き使用）
- ズームアウトしたときの案内（ヒント）はそのまま残す
- `scripts/preview-map.test.js` に、初期ズームがタイルの最小ズーム以上であること・全国 fitBounds に戻っていないこと・初期中心が日本の範囲内であることを固定するテストを追加

## 動作確認

読み込み直後の状態:

| 項目 | 値 |
|---|---|
| ズーム | 6 |
| 中心 | 138.2, 36.4 |
| 描画された施設の点 | 1,046,960 |
| ズームヒント | 非表示（z6 以上のため） |

`npm run test:unit` 全件パス。失敗したネットワークリクエストなし。
