### PR TITLE
都道府県別CSV のファイル名を都道府県コードのみにする

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@ AI コーディングエージェント（Claude Code / Codex 等）向けのガ
   - UTF-8 **BOMなし**、100万件超・数百MB（gzip 版は配信していない）。
     正確な件数・サイズは README の統計ブロック（自動生成）を参照する
   - 列: `prefecture, city, city_raw, name, name_kana, business_type, address, lat, lng, geocoding_level, phone, license_no, license_date, expire_date, sources, licenses`
-- 都道府県別CSV: `https://food.japan-facilities.com/api/prefectures/{JISコード2桁}-{ローマ字}.csv`
-  - 例 `13-tokyo.csv` / `01-hokkaido.csv`。47都道府県すべて存在し、列・内容は全件CSV と同じ。
+- 都道府県別CSV: `https://food.japan-facilities.com/api/prefectures/{都道府県コード2桁}.csv`
+  - 例 `13.csv`（東京都）/ `01.csv`（北海道）。47都道府県すべて存在し、列・内容は全件CSV と同じ。
     ファイル一覧と件数は `api/prefectures/index.json`。1県だけ必要ならこちらを使う
 - ベクトルタイル（MVT）: `https://food.japan-facilities.com/api/tiles/{z}/{x}/{y}.pbf`
   - レイヤ名 `facilities`、z6–12、属性 `name` / `business_type` / `pref` / `city`

--- a/README.md
+++ b/README.md
@@ -75,21 +75,21 @@ df = pd.read_csv(
 
 | ファイル | URL |
 |---|---|
-| 都道府県別CSV | `https://food.japan-facilities.com/api/prefectures/{JISコード}-{ローマ字}.csv` |
+| 都道府県別CSV | `https://food.japan-facilities.com/api/prefectures/{都道府県コード}.csv` |
 | ファイル一覧（JSON） | https://food.japan-facilities.com/api/prefectures/index.json |
 
-ファイル名は、JIS都道府県コード（2桁）とローマ字を組み合わせた `01-hokkaido.csv` 〜 `47-okinawa.csv` です。47都道府県すべてのURLが常に存在します。
+ファイル名は、都道府県コード（JIS X 0401 の2桁・ゼロ埋め）の `01.csv`（北海道）〜 `47.csv`（沖縄県）です。47都道府県すべてのURLが常に存在します。
 
 ```bash
 # 東京都だけダウンロードする
-curl -O https://food.japan-facilities.com/api/prefectures/13-tokyo.csv
+curl -O https://food.japan-facilities.com/api/prefectures/13.csv
 ```
 
 ```python
 import pandas as pd
 
 df = pd.read_csv(
-    "https://food.japan-facilities.com/api/prefectures/13-tokyo.csv"
+    "https://food.japan-facilities.com/api/prefectures/13.csv"
 )
 ```
 
@@ -101,7 +101,7 @@ df = pd.read_csv(
   "columns": ["prefecture", "city", "..."],
   "unassigned": 0,
   "prefectures": [
-    { "code": "13", "name": "東京都", "romaji": "tokyo", "file": "13-tokyo.csv", "records": 123456, "bytes": 34567890 }
+    { "code": "13", "name": "東京都", "romaji": "tokyo", "file": "13.csv", "records": 123456, "bytes": 34567890 }
   ]
 }
 ```

--- a/index.html
+++ b/index.html
@@ -240,8 +240,8 @@
       <p class="step">1. CSV をダウンロードする（全件は約 540MB。1県だけなら都道府県別CSV が軽い）</p>
 <pre><code>curl -O https://food.japan-facilities.com/api/facilities-all.csv
 
-<span class="c"># 東京都だけ欲しい場合（ファイル名は {JISコード}-{ローマ字}.csv）</span>
-curl -O https://food.japan-facilities.com/api/prefectures/13-tokyo.csv</code></pre>
+<span class="c"># 東京都だけ欲しい場合（ファイル名は {都道府県コード}.csv）</span>
+curl -O https://food.japan-facilities.com/api/prefectures/13.csv</code></pre>
 
       <p class="step">2. pandas で読み込む（URL 直指定でもいけます）</p>
 <pre><code>import pandas as pd
@@ -291,7 +291,7 @@ print(naha[['name', 'address', 'lat', 'lng']].head())</code></pre>
             </tr>
             <tr>
               <td>都道府県別 CSV</td>
-              <td><code>api/prefectures/{JISコード}-{ローマ字}.csv</code>（例 <code>13-tokyo.csv</code>）</td>
+              <td><code>api/prefectures/{都道府県コード}.csv</code>（例 <code>13.csv</code>＝東京都）</td>
               <td>
                 1県だけ必要なときに。列・内容は全件CSV と同じで、47都道府県すべて存在します。
                 ファイル一覧と件数は <code>api/prefectures/index.json</code>。

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -68,21 +68,21 @@ df = pd.read_csv(
 
 | ファイル | URL |
 |---|---|
-| 都道府県別CSV | `https://food.japan-facilities.com/api/prefectures/{JISコード}-{ローマ字}.csv` |
+| 都道府県別CSV | `https://food.japan-facilities.com/api/prefectures/{都道府県コード}.csv` |
 | ファイル一覧（JSON） | https://food.japan-facilities.com/api/prefectures/index.json |
 
-ファイル名は、JIS都道府県コード（2桁）とローマ字を組み合わせた `01-hokkaido.csv` 〜 `47-okinawa.csv` です。47都道府県すべてのURLが常に存在します。
+ファイル名は、都道府県コード（JIS X 0401 の2桁・ゼロ埋め）の `01.csv`（北海道）〜 `47.csv`（沖縄県）です。47都道府県すべてのURLが常に存在します。
 
 ```bash
 # 東京都だけダウンロードする
-curl -O https://food.japan-facilities.com/api/prefectures/13-tokyo.csv
+curl -O https://food.japan-facilities.com/api/prefectures/13.csv
 ```
 
 ```python
 import pandas as pd
 
 df = pd.read_csv(
-    "https://food.japan-facilities.com/api/prefectures/13-tokyo.csv"
+    "https://food.japan-facilities.com/api/prefectures/13.csv"
 )
 ```
 
@@ -94,7 +94,7 @@ df = pd.read_csv(
   "columns": ["prefecture", "city", "..."],
   "unassigned": 0,
   "prefectures": [
-    { "code": "13", "name": "東京都", "romaji": "tokyo", "file": "13-tokyo.csv", "records": 123456, "bytes": 34567890 }
+    { "code": "13", "name": "東京都", "romaji": "tokyo", "file": "13.csv", "records": 123456, "bytes": 34567890 }
   ]
 }
 ```
@@ -283,8 +283,8 @@ WHERE prefecture = '沖縄県' AND city = '那覇市' AND business_type = '飲�
 ```python
 import pandas as pd
 
-# ファイル名は {JISコード2桁}-{ローマ字}.csv（13-tokyo.csv, 01-hokkaido.csv, 47-okinawa.csv …）
-df = pd.read_csv('https://food.japan-facilities.com/api/prefectures/13-tokyo.csv')
+# ファイル名は {都道府県コード2桁}.csv（01.csv 〜 47.csv。13.csv は東京都）
+df = pd.read_csv('https://food.japan-facilities.com/api/prefectures/13.csv')
 minato = df[df['city'] == '港区']
 ```
 

--- a/llms.txt
+++ b/llms.txt
@@ -8,8 +8,8 @@
 
 - 全件CSV（gzip 版は配信していない）: https://food.japan-facilities.com/api/facilities-all.csv
 - 都道府県別CSV（列・内容は全件CSV と同じ。1県だけ必要ならこちらを使う）:
-  https://food.japan-facilities.com/api/prefectures/{JISコード2桁}-{ローマ字}.csv
-  例 13-tokyo.csv / 01-hokkaido.csv / 47-okinawa.csv。47都道府県すべて存在する。
+  https://food.japan-facilities.com/api/prefectures/{都道府県コード2桁}.csv
+  例 13.csv（東京都）/ 01.csv（北海道）/ 47.csv（沖縄県）。47都道府県すべて存在する。
   ファイル一覧と件数: https://food.japan-facilities.com/api/prefectures/index.json
 - CSV は UTF-8（BOMなし）。列: prefecture, city, city_raw, name, name_kana,
   business_type, address, lat, lng, geocoding_level, phone, license_no,

--- a/scripts/build-prefecture-csv.js
+++ b/scripts/build-prefecture-csv.js
@@ -1,4 +1,4 @@
-// 都道府県別CSV の生成（api/prefectures/{code}-{romaji}.csv）。
+// 都道府県別CSV の生成（api/prefectures/{prefcode}.csv）。
 //
 // 全件CSV（facilities-all.csv）は数百MB あり、1県分だけ欲しい利用者には重すぎる。
 // そこで同じ列・同じレコード集合を都道府県ごとに分割した CSV も配信する。
@@ -8,8 +8,8 @@
 // 「県別の合計 ≠ 全件」という食い違いが生まれる。
 //
 // 出力:
-//   api/prefectures/{code}-{romaji}.csv   47都道府県ぶん（0件の県もヘッダーだけ出す）
-//   api/prefectures/index.json            ファイル一覧・件数・バイト数の索引
+//   api/prefectures/{prefcode}.csv   47都道府県ぶん（0件の県もヘッダーだけ出す）
+//   api/prefectures/index.json       ファイル一覧・件数・バイト数の索引
 //
 // 都道府県が特定できなかったレコード（pref が '不明' 等、47都道府県に一致しない）は
 // 県別CSV には含めない。件数は index.json の `unassigned` とログに残し、
@@ -21,8 +21,8 @@ import { CSV_COLUMNS, csvCell, toRow } from './build-merged-csv.js';
 
 /**
  * JIS都道府県コード順の都道府県定義。
- * `code` はファイル名の接頭辞（ゼロ埋め2桁）、`romaji` はローマ字のスラッグ。
- * URL に日本語を含めずに済むよう `{code}-{romaji}.csv` をファイル名に使う。
+ * `code` は都道府県コード（prefcode。ゼロ埋め2桁）で、そのまま `{prefcode}.csv` という
+ * ファイル名になる。`romaji` はファイル名には使わず、index.json に載せる英字ラベル。
  */
 export const PREFECTURES = [
   { code: '01', name: '北海道', romaji: 'hokkaido' },
@@ -81,12 +81,12 @@ const BY_NAME = new Map(PREFECTURES.map((p) => [p.name, p]));
 export const INDEX_FILENAME = 'index.json';
 
 /**
- * 都道府県名 → CSV ファイル名（例: '東京都' → '13-tokyo.csv'）。
+ * 都道府県名 → CSV ファイル名（例: '東京都' → '13.csv'）。
  * 47都道府県に一致しない名前（'不明' 等）は null を返す。
  */
 export function prefectureFileName(pref) {
   const def = BY_NAME.get(String(pref || '').trim());
-  return def ? `${def.code}-${def.romaji}.csv` : null;
+  return def ? `${def.code}.csv` : null;
 }
 
 /** 書き込みバッファが埋まったら drain を待つ Promise を返す（不要なら null）。 */
@@ -145,7 +145,7 @@ export async function buildPrefectureCsvs(facilities, { outDir, updated, log = c
 
   // 47ファイルを同時に開くとメモリを食うため、県ごとに開いて閉じる。
   for (const def of PREFECTURES) {
-    const file = `${def.code}-${def.romaji}.csv`;
+    const file = `${def.code}.csv`;
     const outPath = path.join(outDir, file);
     const out = fs.createWriteStream(outPath, { encoding: 'utf-8' });
 

--- a/scripts/build-prefecture-csv.test.js
+++ b/scripts/build-prefecture-csv.test.js
@@ -62,18 +62,20 @@ await test('PREFECTURES: JISコード順の47都道府県', () => {
   assert.equal(PREFECTURES.length, 47);
   assert.deepEqual(PREFECTURES[0], { code: '01', name: '北海道', romaji: 'hokkaido' });
   assert.deepEqual(PREFECTURES[46], { code: '47', name: '沖縄県', romaji: 'okinawa' });
-  // コード・ローマ字・名前はいずれも重複しない（ファイル名の衝突を防ぐ）
+  // コード・ローマ字・名前はいずれも重複しない（code の重複はファイル名の衝突になる）
   for (const key of ['code', 'name', 'romaji']) {
     assert.equal(new Set(PREFECTURES.map((p) => p[key])).size, 47, `${key} が一意`);
   }
-  // ローマ字は URL に安全な小文字英字のみ
+  // ローマ字は index.json 用の英字ラベル（小文字英字のみ）
   assert.ok(PREFECTURES.every((p) => /^[a-z]+$/.test(p.romaji)), 'romaji は小文字英字のみ');
 });
 
 await test('prefectureFileName: 都道府県名 → ファイル名', () => {
-  assert.equal(prefectureFileName('東京都'), '13-tokyo.csv');
-  assert.equal(prefectureFileName('北海道'), '01-hokkaido.csv');
-  assert.equal(prefectureFileName(' 沖縄県 '), '47-okinawa.csv');
+  assert.equal(prefectureFileName('東京都'), '13.csv');
+  assert.equal(prefectureFileName('北海道'), '01.csv');
+  assert.equal(prefectureFileName(' 沖縄県 '), '47.csv');
+  // 全県ぶんが「都道府県コード2桁 + .csv」だけの名前になっている（ローマ字は付けない）
+  assert.ok(PREFECTURES.every((p) => /^\d{2}\.csv$/.test(prefectureFileName(p.name))));
   // 47都道府県に無い値は null（呼び出し側で未分類として扱う）
   assert.equal(prefectureFileName('不明'), null);
   assert.equal(prefectureFileName(''), null);
@@ -94,13 +96,13 @@ await test('groupByPrefecture: 47県ぶんのバケツを必ず作り、不明�
 await test('renderIndex: 索引JSON の形', () => {
   const index = renderIndex({
     updated: 1783366001,
-    entries: [{ code: '13', name: '東京都', romaji: 'tokyo', file: '13-tokyo.csv', records: 2, bytes: 300 }],
+    entries: [{ code: '13', name: '東京都', romaji: 'tokyo', file: '13.csv', records: 2, bytes: 300 }],
     unassigned: 1,
   });
   assert.equal(index.updated, 1783366001);
   assert.deepEqual(index.columns, CSV_COLUMNS);
   assert.equal(index.unassigned, 1);
-  assert.equal(index.prefectures[0].file, '13-tokyo.csv');
+  assert.equal(index.prefectures[0].file, '13.csv');
   // updated 未指定は null（JSON に undefined を書かない）
   assert.equal(renderIndex({ entries: [], unassigned: 0 }).updated, null);
 });
@@ -112,10 +114,10 @@ await test('47ファイルを必ず出力し、0件の県もヘッダーだけ�
   assert.equal(stats.files, 47);
   assert.equal(stats.records, 2);
   for (const def of PREFECTURES) {
-    const file = path.join(outDir, `${def.code}-${def.romaji}.csv`);
+    const file = path.join(outDir, `${def.code}.csv`);
     assert.ok(fs.existsSync(file), `${def.name} のCSV が存在する`);
   }
-  const empty = readRows(outDir, '26-kyoto.csv');
+  const empty = readRows(outDir, '26.csv');
   assert.deepEqual(empty.header, CSV_COLUMNS, '0件の県もヘッダーは書く');
   assert.equal(empty.rows.length, 0);
 });
@@ -125,13 +127,13 @@ await test('各県のCSV にはその県のレコードだけが入る', async (
     fac({ name: '東京A' }), fac({ name: '東京B' }), fac({ pref: '沖縄県', city: '那覇市', name: '那覇A' }),
   ]);
 
-  const tokyo = readRows(outDir, '13-tokyo.csv');
+  const tokyo = readRows(outDir, '13.csv');
   assert.deepEqual(tokyo.header, CSV_COLUMNS);
   assert.equal(tokyo.rows.length, 2);
   assert.deepEqual(tokyo.rows.map((r) => r[col.name]), ['東京A', '東京B']);
   assert.ok(tokyo.rows.every((r) => r[col.prefecture] === '東京都'));
 
-  const okinawa = readRows(outDir, '47-okinawa.csv');
+  const okinawa = readRows(outDir, '47.csv');
   assert.equal(okinawa.rows.length, 1);
   assert.equal(okinawa.rows[0][col.city], '那覇市');
 });
@@ -139,7 +141,7 @@ await test('各県のCSV にはその県のレコードだけが入る', async (
 await test('特殊文字を含むセルが書き出し→読み戻しで元に戻る', async () => {
   const tricky = fac({ name: 'カフェ, "ABC"\n2階', address: '港区赤坂1-1, 2F' });
   const { outDir } = await writeCsvs([tricky]);
-  const { rows } = readRows(outDir, '13-tokyo.csv');
+  const { rows } = readRows(outDir, '13.csv');
   assert.equal(rows[0][col.name], 'カフェ, "ABC"\n2階');
   assert.equal(rows[0][col.address], '港区赤坂1-1, 2F');
 });
@@ -152,7 +154,7 @@ await test('都道府県が不明なレコードは県別CSV に入れず unassi
   const index = JSON.parse(fs.readFileSync(path.join(outDir, INDEX_FILENAME), 'utf-8'));
   assert.equal(index.unassigned, 1);
   // どのファイルにも紛れ込んでいないこと
-  const all = PREFECTURES.flatMap((d) => readRows(outDir, `${d.code}-${d.romaji}.csv`).rows);
+  const all = PREFECTURES.flatMap((d) => readRows(outDir, `${d.code}.csv`).rows);
   assert.ok(!all.some((r) => r[col.name] === '不明店'));
 });
 
@@ -177,7 +179,7 @@ await test('index.json が実ファイルの件数・バイト数と一致する
 
 await test('CSV は BOM なし UTF-8 で書き出す', async () => {
   const { outDir } = await writeCsvs([fac()]);
-  const head = fs.readFileSync(path.join(outDir, '13-tokyo.csv'), { encoding: 'utf-8' }).slice(0, 1);
+  const head = fs.readFileSync(path.join(outDir, '13.csv'), { encoding: 'utf-8' }).slice(0, 1);
   assert.notEqual(head, '﻿');
 });
 

--- a/scripts/gen-llms.js
+++ b/scripts/gen-llms.js
@@ -99,8 +99,8 @@ export function renderLlmsTxt(readme) {
 
 - 全件CSV（gzip 版は配信していない）: ${DATA}/api/facilities-all.csv
 - 都道府県別CSV（列・内容は全件CSV と同じ。1県だけ必要ならこちらを使う）:
-  ${DATA}/api/prefectures/{JISコード2桁}-{ローマ字}.csv
-  例 13-tokyo.csv / 01-hokkaido.csv / 47-okinawa.csv。47都道府県すべて存在する。
+  ${DATA}/api/prefectures/{都道府県コード2桁}.csv
+  例 13.csv（東京都）/ 01.csv（北海道）/ 47.csv（沖縄県）。47都道府県すべて存在する。
   ファイル一覧と件数: ${DATA}/api/prefectures/index.json
 - CSV は UTF-8（BOMなし）。列: prefecture, city, city_raw, name, name_kana,
   business_type, address, lat, lng, geocoding_level, phone, license_no,
@@ -160,8 +160,8 @@ WHERE prefecture = '沖縄県' AND city = '那覇市' AND business_type = '飲�
 \`\`\`python
 import pandas as pd
 
-# ファイル名は {JISコード2桁}-{ローマ字}.csv（13-tokyo.csv, 01-hokkaido.csv, 47-okinawa.csv …）
-df = pd.read_csv('${DATA}/api/prefectures/13-tokyo.csv')
+# ファイル名は {都道府県コード2桁}.csv（01.csv 〜 47.csv。13.csv は東京都）
+df = pd.read_csv('${DATA}/api/prefectures/13.csv')
 minato = df[df['city'] == '港区']
 \`\`\`
 

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -137,7 +137,7 @@ if (fs.existsSync(prefIndexPath)) {
 
   for (const def of PREFECTURES) {
     const entry = (index.prefectures || []).find((e) => e.code === def.code);
-    const file = path.join(PREF_CSV_DIR, `${def.code}-${def.romaji}.csv`);
+    const file = path.join(PREF_CSV_DIR, `${def.code}.csv`);
     if (!entry || !fs.existsSync(file)) {
       missing.push(def.name);
       continue;


### PR DESCRIPTION
## 概要

- 都道府県別CSV のファイル名を `{JISコード}-{ローマ字}.csv`（例 `13-tokyo.csv`）から
  **`{都道府県コード}.csv`（例 `13.csv`）** に変更する
- 都道府県コードだけで URL を組み立てられるようになり、ローマ字表記のゆれ（`hyogo` / `hyougo` 等）を
  利用者が気にする必要がなくなる

## 変更内容

- `scripts/build-prefecture-csv.js`: 出力ファイル名と `prefectureFileName()` を `{code}.csv` に変更
- `romaji` は `PREFECTURES` と `index.json` にそのまま残す（英字ラベルとして有用なため、
  `index.json` のスキーマは変更なし）。ファイル名には使わない
- `scripts/build-prefecture-csv.test.js` / `scripts/test.js`: 新しいファイル名に追従。
  あわせて「全47県のファイル名が `^\d{2}\.csv$` である」ことを検証するアサーションを追加
- ドキュメントを更新: `README.md` / `index.html` / `AGENTS.md` / `scripts/gen-llms.js`、
  および `npm run build:llms` で再生成した `llms.txt` / `llms-full.txt`

## テスト計画

- `npm run test:unit` … 全パス（`build-prefecture-csv` 10件を含む）
- 統合テスト `scripts/test.js` は `api/` の生成物が必要なため、クロール実行後の CI/Fargate 側で確認する

## 破壊的変更

**あり。配信 URL が変わる。**

- 旧: `https://food.japan-facilities.com/api/prefectures/13-tokyo.csv`
- 新: `https://food.japan-facilities.com/api/prefectures/13.csv`

旧ファイル名の URL は次回クロール後に生成されなくなる。あわせて **S3 上に残る旧 47ファイルの削除が必要**
（クローラー側の sync が `--delete` していない場合、新旧が並んで配信され続ける）。
対応は別リポジトリ `gl20percentclub/japan-facilities-crawler` 側で行う。

## 関連Issue

なし