### PR TITLE
fix: 404 で取得できなくなっていた4ソースを復旧し、廃止された名古屋市を外す

### DIFF
--- a/attribution.html
+++ b/attribution.html
@@ -138,7 +138,7 @@
     <p class="lead">
       <a href="https://gl20percentclub.github.io/japan-food-facilities/">Japan Food Facilities</a> は、各自治体・省庁が公開する食品営業許可・届出のオープンデータを
       取得し、全国共通フォーマットへの正規化と緯度経度の付与を行って配信しています。
-      本ページは収録している全 82 ソースの出典 URL とライセンス、および
+      本ページは収録している全 81 ソースの出典 URL とライセンス、および
       各データが求める出典表示形式に沿った表示文の一覧です。
     </p>
 
@@ -164,7 +164,7 @@
     <nav class="toc" aria-label="ライセンス別の目次">
       <strong>ライセンス別の一覧</strong>
       <ul>
-      <li><a href="#cc-by-4-0">CC BY 4.0</a> <span class="count">60</span></li>
+      <li><a href="#cc-by-4-0">CC BY 4.0</a> <span class="count">59</span></li>
       <li><a href="#cc-by-3-0">CC BY 3.0</a> <span class="count">1</span></li>
       <li><a href="#cc-by-2-1-jp">CC BY 2.1 JP</a> <span class="count">13</span></li>
       <li><a href="#cc-by-2-0">CC BY 2.0</a> <span class="count">2</span></li>
@@ -175,7 +175,7 @@
     </nav>
 
     <section class="license" id="cc-by-4-0">
-      <h2>CC BY 4.0 <span class="count">60 ソース</span></h2>
+      <h2>CC BY 4.0 <span class="count">59 ソース</span></h2>
       <p class="requirement">出典（提供者名・データセット名・出典 URL）の明示と、改変した旨の表示が必要です。本 API は正規化・緯度経度付与などの加工を行っているため、「加工して作成」の旨を必ず含めてください。 — <a href="https://creativecommons.org/licenses/by/4.0/deed.ja" target="_blank" rel="noopener">ライセンス本文</a></p>
       <article class="src" id="src-iwaki">
         <h3>いわき市<span class="dataset">食品営業許可施設一覧</span></h3>
@@ -225,7 +225,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://data.bodik.jp/dataset/142018_00_18_syokuhin_all" target="_blank" rel="noopener">https://data.bodik.jp/dataset/142018_00_18_syokuhin_all</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=8d4bc9c9-b5b2-495c-a1fa-a34eeaa4fe23" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=8d4bc9c9-b5b2-495c-…</a></dd>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=99d87c24-fabd-4b5e-9c6e-90843a55eb84" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=99d87c24-fabd-4b5e-…</a></dd>
         </dl>
         <span class="badge">元の表記: Creative Commons Attribution 4.0 International</span>
         <div class="attr">
@@ -477,7 +477,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://data.bodik.jp/dataset/242021_00131" target="_blank" rel="noopener">https://data.bodik.jp/dataset/242021_00131</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=a0a4bc9b-d981-4499-b736-f6d9b7cf35ea" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=a0a4bc9b-d981-4499-…</a></dd>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=75f68ddf-0c8f-4093-a7d2-b100a63ad2a2" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=75f68ddf-0c8f-4093-…</a></dd>
         </dl>
         <span class="badge">元の表記: Creative Commons Attribution 4.0 International</span>
         <div class="attr">
@@ -841,7 +841,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://data.bodik.jp/dataset/272272_15" target="_blank" rel="noopener">https://data.bodik.jp/dataset/272272_15</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=45bffc27-277f-4a7e-a965-768fe026626a" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=45bffc27-277f-4a7e-…</a></dd>
+          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=a0416f70-bda0-46fe-a684-b22a95135c32" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=a0416f70-bda0-46fe-…</a></dd>
         </dl>
         <span class="badge">元の表記: Creative Commons Attribution 4.0 International</span>
         <div class="attr">
@@ -883,7 +883,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://www.city.amagasaki.hyogo.jp/op_data/1000922/1001025.html" target="_blank" rel="noopener">https://www.city.amagasaki.hyogo.jp/op_data/1000922/1001025.html</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://www.city.amagasaki.hyogo.jp/_res/projects/default_project/_page_/001/001/025/kyoka202605.csv" target="_blank" rel="noopener">https://www.city.amagasaki.hyogo.jp/_res/projects/default_project/_page…</a></dd>
+          <dd><a href="https://www.city.amagasaki.hyogo.jp/op_data/1000922/1001025.html" target="_blank" rel="noopener">https://www.city.amagasaki.hyogo.jp/op_data/1000922/1001025.html</a></dd>
         </dl>
         
         <div class="attr">
@@ -987,20 +987,6 @@
         <div class="attr">
           <code>出典：北九州市「北九州市　食品衛生法等許可施設一覧」（https://data.bodik.jp/dataset/822fb681-346a-444e-b482-33c67b50cac3）を加工して作成（CC BY 4.0）</code>
           <button type="button" class="copy" data-copy="出典：北九州市「北九州市　食品衛生法等許可施設一覧」（https://data.bodik.jp/dataset/822fb681-346a-444e-b482-33c67b50cac3）を加工して作成（CC BY 4.0）">コピー</button>
-        </div>
-      </article>
-      <article class="src" id="src-bodik-979f325a">
-        <h3>名古屋市<span class="dataset">【名古屋市】食品営業許可施設一覧</span></h3>
-        <dl>
-          <dt>出典ページ</dt>
-          <dd><a href="https://data.bodik.jp/dataset/231002_1304020000_01" target="_blank" rel="noopener">https://data.bodik.jp/dataset/231002_1304020000_01</a></dd>
-          <dt>取得URL</dt>
-          <dd><a href="https://data.bodik.jp/api/3/action/resource_show?id=55e4db0f-05e4-4863-a7d4-22954e3fec7d" target="_blank" rel="noopener">https://data.bodik.jp/api/3/action/resource_show?id=55e4db0f-05e4-4863-…</a></dd>
-        </dl>
-        <span class="badge">元の表記: Creative Commons Attribution 4.0 International</span>
-        <div class="attr">
-          <code>出典：名古屋市「【名古屋市】食品営業許可施設一覧」（https://data.bodik.jp/dataset/231002_1304020000_01）を加工して作成（CC BY 4.0）</code>
-          <button type="button" class="copy" data-copy="出典：名古屋市「【名古屋市】食品営業許可施設一覧」（https://data.bodik.jp/dataset/231002_1304020000_01）を加工して作成（CC BY 4.0）">コピー</button>
         </div>
       </article>
       <article class="src" id="src-bodik-ec8a7389">

--- a/config/sources.yaml
+++ b/config/sources.yaml
@@ -241,10 +241,12 @@ sources:
     acquire:
       type: ckan
       ckanBase: https://data.bodik.jp
-      resourceId: 8d4bc9c9-b5b2-495c-a1fa-a34eeaa4fe23
+      resourceId: 99d87c24-fabd-4b5e-9c6e-90843a55eb84
     source: 横須賀市 【横須賀市】食品営業許可施設公開情報 （食品営業許可を取得している全施設）
     sourceUrl: https://data.bodik.jp/dataset/142018_00_18_syokuhin_all
     license: Creative Commons Attribution 4.0 International
+    defaultPref: 神奈川県
+    defaultCity: 横須賀市
   - key: bodik-aabced9d
     acquire:
       type: ckan
@@ -310,10 +312,12 @@ sources:
     acquire:
       type: ckan
       ckanBase: https://data.bodik.jp
-      resourceId: a0a4bc9b-d981-4499-b736-f6d9b7cf35ea
+      resourceId: 75f68ddf-0c8f-4093-a7d2-b100a63ad2a2
     source: 四日市市 【三重県四日市市】食品営業許可施設一覧
     sourceUrl: https://data.bodik.jp/dataset/242021_00131
     license: Creative Commons Attribution 4.0 International
+    defaultPref: 三重県
+    defaultCity: 四日市市
   - key: bodik-1bca2ed4
     acquire:
       type: ckan
@@ -375,10 +379,12 @@ sources:
     acquire:
       type: ckan
       ckanBase: https://data.bodik.jp
-      resourceId: 45bffc27-277f-4a7e-a965-768fe026626a
+      resourceId: a0416f70-bda0-46fe-a684-b22a95135c32
     source: 東大阪市 食品等営業許可一覧
     sourceUrl: https://data.bodik.jp/dataset/272272_15
     license: Creative Commons Attribution 4.0 International
+    defaultPref: 大阪府
+    defaultCity: 東大阪市
   - key: bodik-cbd20a26
     acquire:
       type: ckan
@@ -421,14 +427,12 @@ sources:
     sourceUrl: https://data.bodik.jp/dataset/822fb681-346a-444e-b482-33c67b50cac3
     # 北九州市オープンデータ利用規約（https://odcs.bodik.jp/401005/tos/）が表示4.0国際を指定
     license: CC BY 4.0
-  - key: bodik-979f325a
-    acquire:
-      type: ckan
-      ckanBase: https://data.bodik.jp
-      resourceId: 55e4db0f-05e4-4863-a7d4-22954e3fec7d
-    source: 名古屋市 【名古屋市】食品営業許可施設一覧
-    sourceUrl: https://data.bodik.jp/dataset/231002_1304020000_01
-    license: Creative Commons Attribution 4.0 International
+  # 名古屋市は全施設一覧の公開をやめ、月次の「新規営業許可施設」だけになった
+  # （旧リソース 55e4db0f は削除済み・resource_show が 404）。月次ファイルは
+  # 令和7年7月以降の新規許可のみで全施設の代替にならないため収録しない。
+  # 名古屋市の施設は厚労省 i2fas 経由で収録する。
+  # 再収録は全件公開が再開されたときに検討する:
+  # https://data.bodik.jp/dataset/231002_1304020000_01
   - key: bodik-ec8a7389
     acquire:
       type: ckan
@@ -865,9 +869,12 @@ sources:
     defaultPref: 兵庫県
     defaultCity: 神戸市
   - key: amagasaki
+    # ファイル名に年月が入り毎月変わる（kyoka202605.csv → kyoka202606.csv）ため、
+    # URL 直指定ではなく掲載ページからリンクを解決する。
     acquire:
-      type: get
-      url: https://www.city.amagasaki.hyogo.jp/_res/projects/default_project/_page_/001/001/025/kyoka202605.csv
+      type: resolve
+      pageUrl: https://www.city.amagasaki.hyogo.jp/op_data/1000922/1001025.html
+      linkPattern: 食品営業許可施設
       format: csv
       encoding: utf-8
     source: 尼崎市食品営業許可施設

--- a/docs/COVERAGE.md
+++ b/docs/COVERAGE.md
@@ -1004,7 +1004,7 @@
 | 静岡県 | 榛原郡吉田町 | 静岡県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 静岡県 | 榛原郡川根本町 | 静岡県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 静岡県 | 周智郡森町 | 静岡県（都道府県） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
-| 愛知県 | 名古屋市 | 名古屋市（指定都市） | ✅ | 自身 | [link](https://data.bodik.jp/dataset/979f325a-1b27-45d0-8eb5-dd4aeb85b1f5) | Creative Commons Attribution 4.0 International |
+| 愛知県 | 名古屋市 | 名古屋市（指定都市） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 愛知県 | 豊橋市 | 豊橋市（中核市） | ✅ | i2fas | [link](https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action) | 公共データ利用規約（第1.0版, PDL1.0） |
 | 愛知県 | 岡崎市 | 岡崎市（中核市） | ✅ | 自身 | [link](https://data.bodik.jp/dataset/aabced9d-d86e-422d-8ad0-2781d0f30671) | Creative Commons Attribution 4.0 International |
 | 愛知県 | 一宮市 | 一宮市（中核市） | ✅ | 自身 | [link](https://www.city.ichinomiya.aichi.jp/_res/projects/default_project/_page_/001/040/636/232033_Food_Business_All_20260331.csv) | CC BY 4.0 |

--- a/index.html
+++ b/index.html
@@ -181,7 +181,7 @@
         <div class="stat"><span class="num" id="stat-facility">149万</span><span class="lbl">施設レコード</span></div>
         <div class="stat"><span class="num" id="stat-pref">52</span><span class="lbl">都道府県</span></div>
         <div class="stat"><span class="num" id="stat-city">1,958</span><span class="lbl">市区町村</span></div>
-        <div class="stat"><span class="num" data-source-count>82</span><span class="lbl">データソース</span></div>
+        <div class="stat"><span class="num" data-source-count>81</span><span class="lbl">データソース</span></div>
       </div>
       <p class="stats-note" id="stats-note">毎週月曜に自動更新</p>
       <p class="stats-note">1レコード＝1つの営業許可です。同じ施設が業種違いで複数レコードになる場合があります。</p>
@@ -335,7 +335,7 @@ print(naha[['name', 'address', 'lat', 'lng']].head())</code></pre>
       </div>
       <div class="notice">
         <strong>📢 出典表示文は <a href="./attribution.html">出典・ライセンス表示ページ</a> にまとめています。</strong><br>
-        全 <span data-source-count>82</span> ソースの出典 URL とライセンス、およびそのまま貼れる出典表示文を一覧化しています。
+        全 <span data-source-count>81</span> ソースの出典 URL とライセンス、およびそのまま貼れる出典表示文を一覧化しています。
       </div>
       <div class="notice">
         <strong>緯度経度は本サービスが独自に付与した参考情報です。</strong>


### PR DESCRIPTION
クロールのログで 404 を出し続けていた5ソースを追跡した。

## まず前提の訂正

この5件は**直近のレコード減（1,488,756 → 1,353,429、-135,327）とは無関係**だった。2026-08-01 の実行ログと突き合わせたところ、5件はそのときも同じ 404 で失敗していた（東大阪市は当時まだ設定に無い）。

```
旧(08-01): 97ソース / 1,495,663件
新(08-02): 82ソース / 1,360,106件

hyogo-pref   32,447 -> 0    nagano-pref  30,581 -> 0    sendai      14,724 -> 0
shiga-pref   14,483 -> 0    nara-pref    13,010 -> 0    chiba-city   9,083 -> 0  ...（計15ソース）
```

消えたのは**ライセンス未確定で除外した15ソース**。今回が「クローラーが公開リポの `sources.yaml` を読む」最初のクロールだったため、除外が今になって反映された（意図どおり）。したがって本PRの復旧は**純増**になる。

## 修正内容

| ソース | 状況 | 対応 |
|---|---|---|
| 横須賀市 | CKAN リソース差し替えで ID 変更 | 現在の ID に更新 |
| 四日市市 | 同上 | 現在の ID に更新 |
| 東大阪市 | 同上 | 「全許可（令和8年4月1日現在）」の ID に更新（同一データセットに月次の新規許可が混在するため選択に注意） |
| 尼崎市 | ファイル名に年月（`kyoka202605.csv`）が入り毎月変わる | URL 直指定をやめ `resolve`（掲載ページからリンク解決）に変更 |
| 名古屋市 | **全施設一覧の公開が終了**。月次の「新規営業許可施設」のみ、旧リソースは削除済み | 収録をやめる（下記） |

### 名古屋市について

市の公式ページも BODIK のデータセットを指しているだけで、そこには令和7年7月以降の月次「新規営業許可施設」しか無い。これは全件の代替にならないため収録しない。名古屋市の施設は **i2fas 経由で 3,978 件を既に収録済み**（配信中の `23-aichi.csv` で確認）なのでカバレッジは落ちない。`docs/COVERAGE.md` の収集経路を i2fas に更新した。

## ついでに見つけた不具合

復旧後に検証したところ、**四日市市の3,740件が「神奈川県横須賀市」として出力**されていた。

```
6602 兵庫県  尼崎市
6521 大阪府  東大阪市
7885 神奈川県 横須賀市   ← 4,145 + 3,740（四日市市が混入）
```

3ソースとも都道府県・市区町村のカラムを持たず住所にも県名が無いため `(不明, 不明)` のペアに落ちる。名寄せは**ペアごとに代表住所1件だけ**を正規化してその結果を全件に適用するので、同じバケツに入った横須賀市の住所が全件に焼き付いていた。

本PRでは3ソースに `defaultPref` / `defaultCity` を明示して回避する。修正後:

```
6627 兵庫県  尼崎市      6521 大阪府 東大阪市
4145 神奈川県 横須賀市    3740 三重県 四日市市     → 4都道府県 / 4市区町村
```

なお「代表住所1件を全件に適用する」名寄せの構造自体は残っている（#67 で政令市の症状は消えたが根本は同じ）。別途対応が必要。

## 検証

```
$ node scripts/crawl.js --only=amagasaki,bodik-3a1aaf46,bodik-e5809d89,bodik-b5eeed4c --no-geocode
  リンク解決: 「食品営業許可施設【令和8年(2026年）6月30日現在】」 -> .../kyoka202606.csv
  横須賀市 4,145 / 四日市市 3,740 / 東大阪市 6,521 / 尼崎市 6,627
  結合CSV: 21,008行 / 4都道府県 / 4市区町村
```

`attribution.html` は再生成、LP のソース数は 82 → 81 に更新（ユニットテストが検知した）。`npm run test:unit` 全件パス。