### PR TITLE
docs: 収録範囲・利用時の注意・更新頻度を docs/DATA.md に集約する

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@
 [![Contributors](https://img.shields.io/github/contributors/gl20percentclub/japan-food-facilities)](https://github.com/gl20percentclub/japan-food-facilities/graphs/contributors)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![GitHub Issues](https://img.shields.io/github/issues/gl20percentclub/japan-food-facilities)](https://github.com/gl20percentclub/japan-food-facilities/issues)
-[![Weekly Crawl](https://img.shields.io/badge/更新-毎週自動-blue)](#更新頻度)
+[![Weekly Crawl](https://img.shields.io/badge/更新-毎週自動-blue)](docs/DATA.md#更新頻度)
 
 [公式サイト](https://gl20percentclub.github.io/japan-food-facilities/) ·
 [地図で見る](https://gl20percentclub.github.io/japan-food-facilities/map.html) ·
 [CSVをダウンロード](https://food.japan-facilities.com/api/facilities-all.csv) ·
+[データの詳細](docs/DATA.md) ·
 [収録状況](docs/COVERAGE.md) ·
 [出典・ライセンス](https://gl20percentclub.github.io/japan-food-facilities/attribution.html)
 
@@ -114,54 +115,18 @@ Claude CodeやCodexなどに、次のURLを渡してください。
 
 市区町村名は、[normalize-japanese-addresses](https://github.com/geolonia/normalize-japanese-addresses)を利用して正規化しています。
 
+## データの詳細
 
+収集元、市区町村名の正規化、収録範囲、緯度経度の精度、鮮度と網羅性、更新頻度は、[`docs/DATA.md`](docs/DATA.md)にまとめています。利用前に次の点を確認してください。
 
-## 収録範囲
-
-全国1,741市区町村のうち、**1,727市区町村（99%）**をカバーしています。
-
-データは主に次の公開元から収集しています。
-
-1. 市区町村のオープンデータ
-2. 都道府県や保健所設置主体のオープンデータ
-3. 厚生労働省「食品衛生申請等システム（i2fas）」のオープンデータ
+| 項目                                                | 概要                                                        |
+| ------------------------------------------------- | --------------------------------------------------------- |
+| [収録範囲](docs/DATA.md#収録範囲)                     | 全国1,741市区町村のうち1,727市区町村（99%）をカバー          |
+| [緯度経度](docs/DATA.md#緯度経度)                   | 元データに座標がない場合は住所からジオコーディング。精度は`geocoding_level`で確認 |
+| [鮮度と網羅性](docs/DATA.md#鮮度と網羅性)           | 廃業済みや許可期限切れの施設が含まれる場合がある            |
+| [更新頻度](docs/DATA.md#更新頻度)                   | 毎週月曜18:00 UTC（日本時間 火曜3:00）に自動更新。URLは不変 |
 
 自治体ごとの収録状況は、[`docs/COVERAGE.md`](docs/COVERAGE.md)で確認できます。
-
-## データ利用時の注意
-
-### 緯度経度
-
-元データに座標がない場合は、住所からジオコーディングしています。
-
-| level | 精度       |
-| ----- | -------- |
-| `1`   | 都道府県の代表点 |
-| `2`   | 市区町村の代表点 |
-| `3`   | 町丁目の代表点  |
-| `8`   | 街区・地番レベル |
-
-値が小さいほど位置は大まかです。建物単位の精度が必要な場合は、`geocoding_level`を確認してください。
-
-### 鮮度と網羅性
-
-次のようなデータが含まれる場合があります。
-
-* 古い時点のスナップショット
-* 掲載に同意した施設のみを含むデータ
-* 廃業後も公開元に残っている施設
-* 許可期限が切れている施設
-* 所在地を正確に特定できない施設
-
-最新かつ正式な情報は、各自治体の公開情報を確認してください。
-
-収集元・加工方法・精度のより詳しい説明は、[`docs/DATA.md`](docs/DATA.md)を参照してください。
-
-## 更新頻度
-
-毎週月曜18:00 UTC（日本時間 火曜3:00）に自動更新します。
-
-更新後もCSVとベクトルタイルのURLは変わりません。
 
 ## ライセンスと出典表示
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -7,6 +7,7 @@
 [公式サイト](https://gl20percentclub.github.io/japan-food-facilities/) ·
 [地図で見る](https://gl20percentclub.github.io/japan-food-facilities/map.html) ·
 [CSVをダウンロード](https://food.japan-facilities.com/api/facilities-all.csv) ·
+[データの詳細](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities/main/docs/DATA.md) ·
 [収録状況](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities/main/docs/COVERAGE.md) ·
 [出典・ライセンス](https://gl20percentclub.github.io/japan-food-facilities/attribution.html)
 
@@ -107,52 +108,18 @@ Claude CodeやCodexなどに、次のURLを渡してください。
 
 市区町村名は、[normalize-japanese-addresses](https://github.com/geolonia/normalize-japanese-addresses)を利用して正規化しています。
 
-## 収録範囲
+## データの詳細
 
-全国1,741市区町村のうち、**1,727市区町村（99%）**をカバーしています。
+収集元、市区町村名の正規化、収録範囲、緯度経度の精度、鮮度と網羅性、更新頻度は、[`docs/DATA.md`](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities/main/docs/DATA.md)にまとめています。利用前に次の点を確認してください。
 
-データは主に次の公開元から収集しています。
-
-1. 市区町村のオープンデータ
-2. 都道府県や保健所設置主体のオープンデータ
-3. 厚生労働省「食品衛生申請等システム（i2fas）」のオープンデータ
+| 項目                                                | 概要                                                        |
+| ------------------------------------------------- | --------------------------------------------------------- |
+| [収録範囲](https://gl20percentclub.github.io/japan-food-facilities/docs/DATA.md#収録範囲)                     | 全国1,741市区町村のうち1,727市区町村（99%）をカバー          |
+| [緯度経度](https://gl20percentclub.github.io/japan-food-facilities/docs/DATA.md#緯度経度)                   | 元データに座標がない場合は住所からジオコーディング。精度は`geocoding_level`で確認 |
+| [鮮度と網羅性](https://gl20percentclub.github.io/japan-food-facilities/docs/DATA.md#鮮度と網羅性)           | 廃業済みや許可期限切れの施設が含まれる場合がある            |
+| [更新頻度](https://gl20percentclub.github.io/japan-food-facilities/docs/DATA.md#更新頻度)                   | 毎週月曜18:00 UTC（日本時間 火曜3:00）に自動更新。URLは不変 |
 
 自治体ごとの収録状況は、[`docs/COVERAGE.md`](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities/main/docs/COVERAGE.md)で確認できます。
-
-## データ利用時の注意
-
-### 緯度経度
-
-元データに座標がない場合は、住所からジオコーディングしています。
-
-| level | 精度       |
-| ----- | -------- |
-| `1`   | 都道府県の代表点 |
-| `2`   | 市区町村の代表点 |
-| `3`   | 町丁目の代表点  |
-| `8`   | 街区・地番レベル |
-
-値が小さいほど位置は大まかです。建物単位の精度が必要な場合は、`geocoding_level`を確認してください。
-
-### 鮮度と網羅性
-
-次のようなデータが含まれる場合があります。
-
-* 古い時点のスナップショット
-* 掲載に同意した施設のみを含むデータ
-* 廃業後も公開元に残っている施設
-* 許可期限が切れている施設
-* 所在地を正確に特定できない施設
-
-最新かつ正式な情報は、各自治体の公開情報を確認してください。
-
-収集元・加工方法・精度のより詳しい説明は、[`docs/DATA.md`](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities/main/docs/DATA.md)を参照してください。
-
-## 更新頻度
-
-毎週月曜18:00 UTC（日本時間 火曜3:00）に自動更新します。
-
-更新後もCSVとベクトルタイルのURLは変わりません。
 
 ## ライセンスと出典表示
 

--- a/llms.txt
+++ b/llms.txt
@@ -34,6 +34,7 @@
 
 - [llms-full.txt](https://gl20percentclub.github.io/japan-food-facilities/llms-full.txt): データ仕様・利用例・注意事項の全文（まずこれを読む）
 - [README](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities/main/README.md): プロジェクト概要
+- [データの詳細](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities/main/docs/DATA.md): 収集元・正規化・収録範囲・緯度経度の精度・鮮度・更新頻度
 - [収録状況](https://raw.githubusercontent.com/gl20percentclub/japan-food-facilities/main/docs/COVERAGE.md): 自治体ごとの収録有無・取得元・ライセンスの一覧
 - [タイルメタデータ](https://food.japan-facilities.com/api/tiles/metadata.json): TileJSON（レイヤ定義・ズーム範囲・bounds）
 - [地図ページ](https://gl20percentclub.github.io/japan-food-facilities/map.html): 収録データをベクトルタイルで表示するプレビュー地図

--- a/scripts/gen-llms.js
+++ b/scripts/gen-llms.js
@@ -117,6 +117,7 @@ ${stats}
 
 - [llms-full.txt](${PAGES}/llms-full.txt): データ仕様・利用例・注意事項の全文（まずこれを読む）
 - [README](${RAW}/README.md): プロジェクト概要
+- [データの詳細](${RAW}/docs/DATA.md): 収集元・正規化・収録範囲・緯度経度の精度・鮮度・更新頻度
 - [収録状況](${RAW}/docs/COVERAGE.md): 自治体ごとの収録有無・取得元・ライセンスの一覧
 - [タイルメタデータ](${DATA}/api/tiles/metadata.json): TileJSON（レイヤ定義・ズーム範囲・bounds）
 - [地図ページ](${PAGES}/map.html): 収録データをベクトルタイルで表示するプレビュー地図


### PR DESCRIPTION
## 概要

README に残っていた「収録範囲」「データ利用時の注意（緯度経度 / 鮮度と網羅性）」「更新頻度」は、すでに `docs/DATA.md` に同じ内容が書かれており二重管理になっていた。README からはこれらの節を外し、詳細は `docs/DATA.md` に一本化する。

README には要点だけを一覧表で残し、それぞれ `docs/DATA.md` の該当節へリンクする。

## 変更点

- README の「収録範囲」「データ利用時の注意」「更新頻度」を削除し、「データの詳細」節（要点＋DATA.md への導線）に置き換え
- 更新頻度バッジのリンク先を `#更新頻度` から `docs/DATA.md#更新頻度` に変更（節の削除でアンカーが壊れるため）
- ヘッダーのリンク集に「データの詳細」を追加
- `llms.txt` のドキュメント一覧に `docs/DATA.md` を追加。README から詳細が消えても AI エージェントが辿れるようにする
- `llms.txt` / `llms-full.txt` を README から再生成

## 情報の欠落について

削除した内容はすべて `docs/DATA.md` に存在することを確認済み（収集元の優先順位・収録範囲・`geocoding_level` の表・鮮度と網羅性・更新頻度）。DATA.md 側のほうが記述は詳しい。

## テスト

`npm run test:unit` 通過。