### PR TITLE
docs: 緯度経度のジオコーディングにも normalize-japanese-addresses を使っていることを明記する

### DIFF
--- a/docs/DATA.md
+++ b/docs/DATA.md
@@ -52,9 +52,11 @@ Japan Food Facilitiesで配信しているデータの収集元、加工方法�
 
 元データに緯度経度が含まれていない場合は、住所をもとにジオコーディングしています。
 
+ジオコーディングにも、市区町村名の正規化と同じ[normalize-japanese-addresses](https://github.com/geolonia/normalize-japanese-addresses)を利用しています。
+
 緯度経度はWGS84形式で、`lat`列と`lng`列に格納されます。
 
-ジオコーディング結果のおおよその精度は、`geocoding_level`列で確認できます。
+ジオコーディング結果のおおよその精度は、`geocoding_level`列で確認できます。この値はnormalize-japanese-addressesが返す正規化レベルです。
 
 | level | 精度       |
 | ----- | -------- |


### PR DESCRIPTION
## 概要

`docs/DATA.md` の「緯度経度」セクションに、ジオコーディングでも
[normalize-japanese-addresses](https://github.com/geolonia/normalize-japanese-addresses)（nja）を
使っていることを追記しました。

これまで nja への言及は「市区町村名の正規化」セクションだけで、緯度経度の付与にも
同じライブラリを使っている（`scripts/lib/geocode.js`）ことがドキュメントから読み取れませんでした。

## 変更点

- ジオコーディングにも normalize-japanese-addresses を利用している旨を追記
- `geocoding_level` が nja の返す正規化レベルであることを明記

ドキュメントのみの変更で、生成物（llms.txt / attribution.html 等）には影響しません。