### PR TITLE
fix: 名寄せの代表住所が無関係なレコードへ焼き付くのをやめる

### DIFF
--- a/scripts/build-merged-csv.test.js
+++ b/scripts/build-merged-csv.test.js
@@ -18,6 +18,7 @@ import {
   stripWardSuffix,
   stripCountyPrefix,
   toMunicipality,
+  isResolvablePair,
 } from './lib/city-normmap.js';
 
 /**
@@ -328,11 +329,65 @@ await test('collectCityPairs: ユニークな (都道府県, 市区町村) を�
     { _pref: '東京都', _city: '港区', address: '' },
     { _pref: '東京都', _city: '港区', address: '東京都港区赤坂1-1' },
     { _pref: '東京都', _city: '渋谷区', address: '東京都渋谷区1-1' },
-    { address: '住所のみ' }, // pref/city 未解決は「不明」に寄せる
+    { address: '住所のみ' }, // pref/city 未解決＝自治体を特定しないので対象外
   ]);
-  assert.equal(pairs.length, 3);
+  assert.equal(pairs.length, 2);
   assert.equal(pairs.find((p) => p.city === '港区').addr, '東京都港区赤坂1-1', '空でない住所を代表にする');
-  assert.ok(pairs.some((p) => p.pref === '不明' && p.city === '不明'));
+  assert.ok(
+    !pairs.some((p) => p.city === '不明'),
+    '「不明」ペアは代表住所を立てられないので名寄せ対象にしない',
+  );
+});
+
+// --- 代表住所の焼き付き防止 ---
+// 名寄せはペアごとに代表住所1件を正規化して全件へ適用するため、自治体を
+// 特定しないペア（'不明'）に適用すると無関係なレコードに自治体名が焼き付く。
+await test('isResolvablePair: 自治体を特定しないペアは名寄せ対象にしない', () => {
+  assert.equal(isResolvablePair('三重県', '四日市市'), true);
+  assert.equal(isResolvablePair('三重県', '不明'), false);
+  assert.equal(isResolvablePair('三重県', ''), false);
+  assert.equal(isResolvablePair('不明', '不明'), false);
+  assert.equal(isResolvablePair('9300000', '四日市市'), false, '都道府県が不正なら信用しない');
+});
+
+await test('resolvePrefCity: 「不明」ペアには名寄せ表を適用しない', () => {
+  // 実際に起きた事故: (不明, 不明) のバケツに横須賀市の住所が代表として入り、
+  // 四日市市のレコード3,740件が「神奈川県横須賀市」として出力された。
+  const normMap = { '不明\t不明': { pref: '神奈川県', city: '横須賀市' } };
+  const f = { _pref: '不明', _city: '不明', address: '四日市市安島1-3-18' };
+  const r = resolvePrefCity(f, normMap);
+  assert.notEqual(r.pref, '神奈川県', '他レコードの自治体名を焼き付けない');
+  assert.equal(r.city, '不明');
+});
+
+await test('resolvePrefCity: 市区町村カラムが無いソースは「不明」のままにする', () => {
+  // 住所から推測すると大字（「南ぬ浜町」= 石垣市の町名）や政令市の行政区を
+  // 自治体名として拾ってしまうため、実在しない市区町村を作るより不明を残す。
+  const r = resolvePrefCity({ _pref: '三重県', _city: '不明', address: '四日市市安島1-3-18' }, {});
+  assert.equal(r.pref, '三重県', '都道府県は元データの値を保つ');
+  assert.equal(r.city, '不明');
+});
+
+await test('applyPrefCity: 同じ「不明」バケツの別ソースが同じ自治体に化けない', () => {
+  // 実際に起きた事故: 鹿児島県・熊本県・静岡市など8県ぶんのソース 2,641件が
+  // すべて「福岡県久留米市」として配信されていた。
+  const facilities = [
+    { _pref: '不明', _city: '不明', address: '' },
+    { _pref: '不明', _city: '不明', address: '' },
+  ];
+  applyPrefCity(facilities, { '不明\t不明': { pref: '福岡県', city: '久留米市' } });
+  for (const f of facilities) {
+    assert.equal(f.pref, '不明');
+    assert.equal(f.city, '不明');
+  }
+});
+
+await test('resolvePrefCity: 都道府県が不明でも住所が県名で始まれば列ズレ補正で復元する', () => {
+  // 既存の列ズレ補正の経路。レコードごとに自分の住所を見るので焼き付きは起きない。
+  const normMap = { '不明\t不明': { pref: '福岡県', city: '久留米市' } };
+  const r = resolvePrefCity({ _pref: '不明', _city: '不明', address: '石川県河北郡津幡町字加賀爪ニ3' }, normMap);
+  assert.equal(r.pref, '石川県');
+  assert.equal(r.city, '津幡町');
 });
 
 // --- 配信物どうしの整合 ---

--- a/scripts/lib/city-normmap.js
+++ b/scripts/lib/city-normmap.js
@@ -52,14 +52,36 @@ export function toMunicipality(city) {
 }
 
 /**
+ * 名寄せ表を引いてよい生ペアかを判定する（純粋関数）。
+ *
+ * 名寄せは (都道府県, 市区町村) のペアごとに**代表住所1件**を正規化し、その結果を
+ * 同じペアの全レコードへ適用する。これは生の市区町村名がその1自治体を指している
+ * 場合にだけ正しい。'不明' のように自治体を特定しない値をペアに含めると、
+ * たまたま先頭にあったレコードの住所から得た自治体名が、無関係なソースの
+ * レコードにまで焼き付く（四日市市の3,740件が「神奈川県横須賀市」になった実例）。
+ */
+export function isResolvablePair(pref, city) {
+  if (!PREFS.has(pref)) return false; // 都道府県すら特定できていない
+  return isMeaningfulCity(city);
+}
+
+/** 市区町村名として意味のある値か（'不明'・空文字は自治体を特定しない）。 */
+export function isMeaningfulCity(city) {
+  const c = String(city || '').trim();
+  return c !== '' && c !== '不明';
+}
+
+/**
  * 施設配列から、名寄せ対象の (都道府県, 市区町村) ユニークペアを代表住所つきで集める。
  * normalize() は住所文字列を要するため、そのペアに属する最初の住所を1件拾う。
+ * 自治体を特定しないペア（'不明' 等）は代表住所を立てられないため対象外にする。
  */
 export function collectCityPairs(facilities) {
   const pairs = new Map(); // "pref\tcity" -> { pref, city, addr }
   for (const f of facilities) {
     const pref = f._pref || '不明';
     const city = f._city || '不明';
+    if (!isResolvablePair(pref, city)) continue;
     const key = `${pref}\t${city}`;
     const hit = pairs.get(key);
     if (!hit) pairs.set(key, { pref, city, addr: f.address || '' });
@@ -121,8 +143,9 @@ export async function buildCityNormMap(facilities, { concurrency = 8, log = cons
  *
  * 1. 列ズレ補正: pref が都道府県名でない（郵便番号等）／city に都道府県名が入っている
  *    ソース（富山県の数件）は、住所先頭から都道府県・市区町村を復元する。
- * 2. 名寄せ: 名寄せ表にあれば公式の都道府県・市区町村名を採用。無ければ元の表記を使う。
- * 3. 粒度統一: どちらの経路でも toMunicipality() を通し、郡名剥がしと行政区の集約を行う。
+ * 2. 名寄せ: 自治体を特定する生ペアにだけ名寄せ表を適用し、公式名を採用する。
+ *    特定しないペア（'不明' 等）は、代表住所1件の結果が全レコードへ焼き付くため引かない。
+ * 3. 粒度統一: どの経路でも toMunicipality() を通し、郡名剥がしと行政区の集約を行う。
  */
 export function resolvePrefCity(facility, normMap = {}) {
   const rawPref = facility._pref || '不明';
@@ -140,10 +163,18 @@ export function resolvePrefCity(facility, normMap = {}) {
     colFixed = true;
   }
 
-  const nm = normMap[`${rawPref}\t${rawCity}`];
+  // 名寄せ表は自治体を特定する生ペアにだけ引く（代表住所の焼き付き防止）。
+  const nm = isResolvablePair(rawPref, rawCity) ? normMap[`${rawPref}\t${rawCity}`] : null;
   if (nm?.pref && nm?.city) {
     return { pref: nm.pref, city: toMunicipality(nm.city), cityRaw, colFixed };
   }
+
+  // ここで住所から市区町村を推測してはいけない。splitPrefCity は町村の判定に
+  // 「〜町 / 〜村」の前方一致を使うため、住所の大字（「南ぬ浜町」= 石垣市の町名）や
+  // 政令市の行政区（「清水区」）を自治体名として拾ってしまう。配信中データで試算した
+  // ところ、救えるのは市区町村不明 12,457 件中 491 件で、その多くが実在しない
+  // 自治体名だった。公式の1,741自治体と突き合わせる仕組みを入れるまでは '不明' のままにする。
+
   // 名寄せできなかった分も同じ整形を通す。表記ゆれは残るが粒度だけは揃う。
   return { pref, city: toMunicipality(cityRaw), cityRaw, colFixed };
 }


### PR DESCRIPTION
#80 の検証中に見つけた、名寄せの構造的な問題を直す。

## 問題

名寄せは `(都道府県, 市区町村)` のユニークペアごとに**代表住所を1件だけ**正規化し、その結果を同じペアの全レコードへ適用する（140万件すべてを正規化しないための設計）。

これは生の市区町村名がその1自治体を指している場合にだけ正しい。ところが `不明` のように**自治体を特定しない値もペアとして扱っていた**ため、たまたま先頭にあったレコードの住所から得た自治体名が、無関係なソースのレコードにまで焼き付いていた。

配信中データのサンプル455,865件を調べた結果:

```
city_raw が不明なのに city が付いているレコード: 2,641 / 455,865

1345件  鹿児島県 のソース → 「福岡県 久留米市」
 733件  熊本県  のソース → 「福岡県 久留米市」
 283件  静岡市  のソース → 「福岡県 久留米市」
 191件  前橋市  のソース → 「福岡県 久留米市」
  78件  福岡市  のソース → 「福岡県 久留米市」  …計8ソース
```

**都道府県まで誤る**ため、都道府県別CSVの振り分けも狂う（鹿児島県の施設が `40-fukuoka.csv` に入る）。#80 で見つけた「四日市市の3,740件が神奈川県横須賀市になる」のも同じ原因。

## 修正

自治体を特定する生ペアにだけ名寄せ表を引く（`isResolvablePair()`）。特定できないものは `不明` のまま残し、統計の `cityUnknown` に数える。名寄せ対象のペア自体も減るので `normalize()` の呼び出しも減る。

## 見送った案: 住所からの復元

「市区町村が不明なら、そのレコード自身の住所から導出する」を実装して配信中データで試算したが、**害のほうが大きい**ので外した。

```
city='不明': 12,457件（サンプル9県）
  住所なし（救えない）: 6,592件
  住所から復元できる  : 491件 / 13市区町村
       356  八丈島八丈町     ← 正しい
        11  愛知県岡崎市     ← 県名が混入（住所と prefecture 列の不一致）
         8  清水区           ← 静岡市の行政区
         1  南ぬ浜町         ← 石垣市の町名（大字）
```

`splitPrefCity` は「〜町 / 〜村」の前方一致で町村を判定するため、住所の大字や政令市の行政区を自治体名として拾う。せっかく 1,741 以下に収めた市区町村数がまた実在しない名前で膨らむので、公式の1,741自治体と突き合わせる仕組みを入れてから改めて検討する（コメントに残した）。

なお、都道府県が不明で**住所が県名から始まる**レコードは、既存の列ズレ補正がレコードごとに自分の住所から復元するので従来どおり救われる（焼き付きも起きない）。

## テスト

```
✓ isResolvablePair: 自治体を特定しないペアは名寄せ対象にしない
✓ resolvePrefCity: 「不明」ペアには名寄せ表を適用しない
✓ resolvePrefCity: 市区町村カラムが無いソースは「不明」のままにする
✓ applyPrefCity: 同じ「不明」バケツの別ソースが同じ自治体に化けない
✓ resolvePrefCity: 都道府県が不明でも住所が県名で始まれば列ズレ補正で復元する
✓ collectCityPairs: ユニークな (都道府県, 市区町村) を代表住所つきで集める（不明ペアを除外）
```

`npm run test:unit` 全件パス。

## 影響

- 誤った自治体・都道府県に振られていたレコードが `不明` に戻る（統計の `cityUnknown` / `prefUnknown` が増える）。データが減るわけではなく、嘘が消える
- 反映は次回クロールから。クローラー側 `scripts/` の同期も必要