### PR TITLE
refactor: scripts のファイル名を実態に合わせ、拡張子を .js に統一する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,9 @@ AI コーディングエージェント（Claude Code / Codex 等）向けのガ
 
 ```bash
 npm ci                  # 依存関係のインストール
-npm test                # 全テスト（unit + 統合）。PR 前に必ず通すこと
+npm test                # 全テスト（unit + 配信物バリデーション）。PR 前に必ず通すこと
 npm run test:unit       # 純粋関数のユニットテストのみ（高速）
+npm run test:api        # 生成済み api/ のバリデーション（クロール後でないと動かない）
 npm run build:dry       # キャッシュを使ったクロール（ダウンロードなし）
 npm run build           # 本番クロール（全ソースをダウンロード。重い・メモリ大量消費）
 npm run build:llms      # llms.txt / llms-full.txt を README から再生成

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ sources:
 node scripts/crawl.js --only=osaka-city
 ```
 
-BODIK に掲載されているデータは、`scripts/gen-bodik-sources.mjs` でエントリを生成して
+BODIK に掲載されているデータは、`scripts/gen-bodik-sources.js` でエントリを生成して
 手動マージできます。
 
 ---
@@ -62,6 +62,7 @@ npm ci
 | --- | --- |
 | `npm test` | 全テスト（ユニット + 配信物のバリデーション） |
 | `npm run test:unit` | 純粋関数のユニットテストのみ（高速。PR前はこれを通す） |
+| `npm run test:api` | 生成済み `api/` のバリデーション（クロール後でないと動かない） |
 | `npm run build:dry` | キャッシュを使ったクロール（ダウンロードなし） |
 | `npm run build` | 本番クロール（全ソースをダウンロード） |
 | `npm run build:llms` | `llms.txt` / `llms-full.txt` を README から再生成 |

--- a/config/sources.yaml
+++ b/config/sources.yaml
@@ -31,7 +31,7 @@
 #   allSheets      Excel全シートを結合（京都市: 区ごとシート）
 #   locateByAddress 市区町村カラムを信用せず施設住所から導出（i2fas: カラムは管轄自治体）
 #
-# BODIK 掲載分は scripts/gen-bodik-sources.mjs で sources へ追記再生成できる。
+# BODIK 掲載分は scripts/gen-bodik-sources.js で sources へ追記再生成できる。
 
 columns:
   city_code:

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
     "build:dry": "node scripts/crawl.js --dry-run",
     "build:attribution": "node scripts/gen-attribution.js",
     "build:llms": "node scripts/gen-llms.js",
-    "fetch:i2fas": "node scripts/fetch-i2fas.mjs",
+    "fetch:i2fas": "node scripts/fetch-i2fas.js",
     "test:unit": "node scripts/crawl.test.js && node scripts/lib/config.test.js && node scripts/build-merged-csv.test.js && node scripts/build-prefecture-csv.test.js && node scripts/gen-tiles.test.js && node scripts/preview-map.test.js && node scripts/map-filter.test.js && node scripts/gen-readme-stats.test.js && node scripts/gen-llms.test.js && node scripts/gen-attribution.test.js && node scripts/workflows.test.js",
-    "test": "npm run test:unit && node scripts/test.js"
+    "test:api": "node scripts/validate-api.js",
+    "test": "npm run test:unit && npm run test:api"
   },
   "dependencies": {
     "@geolonia/normalize-japanese-addresses": "^3.1.3",

--- a/scripts/analyze-geocoding.js
+++ b/scripts/analyze-geocoding.js
@@ -9,9 +9,9 @@
 //   analysis/no-coord.csv   座標を付与できなかった住所だけ（原因分析用・reason 付き）
 //
 // 使い方:
-//   node scripts/analyze-geocoding.mjs                全ソース
-//   node scripts/analyze-geocoding.mjs --only=osaka-city,okinawa-bodik   指定ソースのみ
-//   node scripts/analyze-geocoding.mjs --concurrency=8
+//   node scripts/analyze-geocoding.js                全ソース
+//   node scripts/analyze-geocoding.js --only=osaka-city,okinawa-bodik   指定ソースのみ
+//   node scripts/analyze-geocoding.js --concurrency=8
 
 import fs from 'node:fs';
 import path from 'node:path';

--- a/scripts/build-merged-csv.test.js
+++ b/scripts/build-merged-csv.test.js
@@ -67,12 +67,12 @@ async function writeCsv(facilities, opts = {}) {
 
 // --- 依存関係: 配信物の生成・検証は config/sources.yaml を要求しない ---
 // クローラー（別リポジトリ）は sources.yaml をコミットせず、クロール実行時だけ
-// CONFIG_PATH で公開リポのクローンを指す。配信物バリデーション（scripts/test.js）は
+// CONFIG_PATH で公開リポのクローンを指す。配信物バリデーション（scripts/validate-api.js）は
 // その環境変数なしで走るため、ここから config.js に到達すると起動時に落ちる。
 // 実際に「build-merged-csv.js → lib/normalize.js → loadConfig()」の連鎖でクロールが
 // 停止したことがあるので、到達不可であることを固定する。
 await test('依存関係: 配信物まわりのモジュールが lib/config.js に依存しない', () => {
-  for (const entry of ['./scripts/test.js', './scripts/build-merged-csv.js']) {
+  for (const entry of ['./scripts/validate-api.js', './scripts/build-merged-csv.js']) {
     const reached = [...reachableModules(entry)];
     const config = reached.find((p) => p.endsWith(`${path.sep}lib${path.sep}config.js`));
     assert.equal(config, undefined, `${entry} から lib/config.js に到達してはいけない`);
@@ -391,7 +391,7 @@ await test('resolvePrefCity: 都道府県が不明でも住所が県名で始ま
 });
 
 // --- 配信物どうしの整合 ---
-// scripts/test.js が本番データで確認している不変条件を、小さなフィクスチャで先に潰す。
+// scripts/validate-api.js が本番データで確認している不変条件を、小さなフィクスチャで先に潰す。
 // 実際に metadata.stats.points（タイル基準）と CSV の座標あり件数がズレて
 // クロールが失敗したことがある（タイルだけ重複除去前の配列から作っていた）。
 await test('配信物: metadata.stats が CSV の件数と一致する', async () => {

--- a/scripts/fetch-i2fas.js
+++ b/scripts/fetch-i2fas.js
@@ -14,9 +14,9 @@
 // 逐次・低レート・キャッシュ（レジューム）で節度をもって取得する。
 //
 // 使い方:
-//   node scripts/fetch-i2fas.mjs             全自治体を取得（キャッシュ済みはスキップ）
-//   node scripts/fetch-i2fas.mjs --limit=5   先頭5自治体だけ（動作確認）
-//   node scripts/fetch-i2fas.mjs --force     キャッシュを無視して再取得
+//   node scripts/fetch-i2fas.js             全自治体を取得（キャッシュ済みはスキップ）
+//   node scripts/fetch-i2fas.js --limit=5   先頭5自治体だけ（動作確認）
+//   node scripts/fetch-i2fas.js --force     キャッシュを無視して再取得
 
 import { chromium } from 'playwright';
 import fs from 'node:fs';

--- a/scripts/gen-bodik-sources.js
+++ b/scripts/gen-bodik-sources.js
@@ -1,7 +1,7 @@
 // data.bodik.jp から食品営業許可データセットを列挙し、自治体(org)ごとに
 // 「全件・許可」に最も近い CSV/XLSX リソースを1つ選び、sources 定義を生成する。
 //
-//   node scripts/gen-bodik-sources.mjs   → config/_bodik-generated.yaml を出力
+//   node scripts/gen-bodik-sources.js   → config/_bodik-generated.yaml を出力
 //   出力された sources エントリを config/sources.yaml の sources: にマージする。
 import * as yaml from 'js-yaml';
 import fs from 'node:fs';
@@ -61,7 +61,7 @@ const entries = list.map((x) => ({
   ...(x.license ? { license: x.license } : {}),
 }));
 const header = `# 自動生成: data.bodik.jp の食品営業許可データセット（自治体ごとに全件・許可の代表リソース1件）\n` +
-  `# 生成: node scripts/gen-bodik-sources.mjs 。この内容を config/sources.yaml の sources: にマージする。\n\n`;
+  `# 生成: node scripts/gen-bodik-sources.js 。この内容を config/sources.yaml の sources: にマージする。\n\n`;
 fs.writeFileSync('config/_bodik-generated.yaml', header + yaml.dump(entries, { lineWidth: -1, noRefs: true, quotingType: '"' }));
 console.log(`\nconfig/_bodik-generated.yaml に ${entries.length} 件を出力。config/sources.yaml の sources: にマージしてください。`);
 console.log('sample:', list.slice(0, 12).map((x) => x.org + ' / ' + x.title + ' [' + x.fmt + ' sc' + x.sc + ']'));

--- a/scripts/lib/acquire.js
+++ b/scripts/lib/acquire.js
@@ -132,10 +132,10 @@ async function extractFromZip(zipBuf, entryPattern) {
 export async function acquire(source, { cacheDir, dryRun = false } = {}) {
   const a = source.acquire;
 
-  // i2fasglob: scripts/fetch-i2fas.mjs が取得した .cache/i2fas/*.csv をまとめて読む。
+  // i2fasglob: scripts/fetch-i2fas.js が取得した .cache/i2fas/*.csv をまとめて読む。
   if (a.type === 'i2fasglob') {
     const dir = path.join(cacheDir, 'i2fas');
-    if (!fs.existsSync(dir)) throw new Error(`.cache/i2fas がありません（先に node scripts/fetch-i2fas.mjs を実行）`);
+    if (!fs.existsSync(dir)) throw new Error(`.cache/i2fas がありません（先に node scripts/fetch-i2fas.js を実行）`);
     const files = fs.readdirSync(dir).filter((f) => f.endsWith('.csv')).sort();
     if (files.length === 0) throw new Error('.cache/i2fas に CSV がありません');
     console.log(`  i2fas キャッシュ ${files.length} ファイルを使用`);

--- a/scripts/validate-api.js
+++ b/scripts/validate-api.js
@@ -1,11 +1,15 @@
-// 生成した配信物が正しいことを確認するバリデーションスクリプト。
+// 生成した配信物（api/）が正しいことを確認するバリデーションスクリプト。
+//
+// 隣にある scripts/*.test.js とは別物で、純粋関数のユニットテストではない。
+// クロール後の api/ が存在していないと動かないため、`npm run test:unit` には含めず
+// `npm run test:api`（`npm test` の後半）で実行する。
 //
 // 検証対象は配信する3形式だけ:
 //   api/facilities-all.csv[.gz]   全件の結合CSV
 //   api/prefectures/*.csv         都道府県別CSV + index.json
 //   api/tiles/{z}/{x}/{y}.pbf     ベクトルタイル + metadata.json（TileJSON）
 //
-//   node scripts/test.js
+//   node scripts/validate-api.js
 
 import fs from 'node:fs';
 import path from 'node:path';


### PR DESCRIPTION
> [!IMPORTANT]
> **スタックPRです。** ベースは #85（`chore/add-contributing-license`）。#85 のマージ後、ベースが自動で `main` に切り替わります。

## `scripts/test.js` → `scripts/validate-api.js`

このファイルは名前に反して**ユニットテストではありません**。クロール後の `api/`（結合CSV・都道府県別CSV・ベクトルタイル）を読んで不変条件を検証するスクリプトで、`api/` が無いと起動して即 `process.exit(1)` します。

それが `scripts/*.test.js` 11本と同じディレクトリに `test.js` という名前で並んでいるため、初見では「テストの一種」に見えます。実際 `npm run test:unit` にも含まれていません（含められない）。

実態どおりの名前にして、ファイル冒頭にも「ユニットテストではない・`api/` が要る」旨を明記しました。

あわせて `npm run test:api` を追加し、`npm test` を `test:unit && test:api` の対称な形にしています。

```
npm run test:unit   # 純粋関数のユニットテスト（CI で走るのはこれ）
npm run test:api    # 生成済み api/ のバリデーション（クロール後のみ）
npm test            # 両方
```

## `.mjs` → `.js`

`package.json` に `"type": "module"` があるため `.mjs` は不要です。3ファイルだけ `.mjs` で、残り20ファイルは `.js` という状態でした。

| 変更前 | 変更後 |
| --- | --- |
| `scripts/fetch-i2fas.mjs` | `scripts/fetch-i2fas.js` |
| `scripts/gen-bodik-sources.mjs` | `scripts/gen-bodik-sources.js` |
| `scripts/analyze-geocoding.mjs` | `scripts/analyze-geocoding.js` |

## 追随した参照

リネームで壊れる参照はすべて洗い出して直しました。

- `package.json`（`fetch:i2fas` / `test`）
- `config/sources.yaml:34`（BODIK の再生成手順コメント）
- `scripts/lib/acquire.js:135,138` — **エラーメッセージ内の実行コマンド**。`.cache/i2fas` が無いときに案内するコマンドなので、間違っていると詰まる
- `scripts/build-merged-csv.test.js:74` — 「配信物まわりが `lib/config.js` に到達しない」ことを固定しているテストのエントリポイント指定。ここが古いパスのままだと**存在しないファイルを解析して検査が素通り**する（クロールが実際に停止した事故の再発防止テスト）
- 各スクリプトの doc コメント内の実行例
- `AGENTS.md` / `CONTRIBUTING.md` の開発コマンド一覧

`grep -rn "\.mjs\|scripts/test\.js"` の残り0件を確認済みです。

## 確認

`npm run test:unit` 全11本通過。