### PR TITLE
refactor: scripts/ を役割ごとのディレクトリに分割する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 # PR と main への push でユニットテストを走らせる。
-# ここで走る scripts/*.test.js には「attribution.html が config/sources.yaml と
+# ここで走る scripts/**/*.test.js には「attribution.html が config/sources.yaml と
 # 同期しているか」「llms.txt が README と同期しているか」の検査も含まれるため、
 # 生成物のコミット漏れ・古い生成物の混入は PR の時点で落ちる。
 # （テスト自体は前からあったが、実行するワークフローが無く機能していなかった）

--- a/.github/workflows/generated-docs.yml
+++ b/.github/workflows/generated-docs.yml
@@ -17,8 +17,8 @@ on:
     paths:
       - 'README.md'
       - 'config/sources.yaml'
-      - 'scripts/gen-attribution.js'
-      - 'scripts/gen-llms.js'
+      - 'scripts/generate/attribution.js'
+      - 'scripts/generate/llms.js'
       # 生成物そのものへの push も対象にする（外部の自動コミットで古い内容が
       # 入ったときに、その push で即座に巻き戻せるようにするため）。
       # 自己修復コミットは GITHUB_TOKEN による push でワークフローを再発火しないため

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,8 +23,8 @@ on:
       - '_headers'
       - 'README.md'
       - 'config/sources.yaml'
-      - 'scripts/gen-attribution.js'
-      - 'scripts/gen-llms.js'
+      - 'scripts/generate/attribution.js'
+      - 'scripts/generate/llms.js'
       - '.github/workflows/pages.yml'
   workflow_dispatch:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,8 +55,12 @@ npm run build:attribution  # attribution.html を config/sources.yaml から再�
 ```
 config/sources.yaml     # データソース定義（単一の情報源）。自治体の追加はここ
 scripts/crawl.js        # クローラー本体（取得→正規化→CSV・タイル生成のオーケストレーター）
+scripts/validate-api.js # 生成済み api/ のバリデーション（ユニットテストではない）
 scripts/lib/            # 取得・パース・正規化・ジオコーディング・名寄せの各実装
-scripts/*.test.js       # ユニットテスト（自前 assert、純粋関数を固定入力で検証）
+scripts/build/          # 配信物の生成（結合CSV・都道府県別CSV・ベクトルタイル）
+scripts/generate/       # ドキュメントの生成（attribution.html・llms*.txt・README統計）
+scripts/tools/          # 単発・保守用スクリプト（本番パイプラインからは呼ばれない）
+scripts/**/*.test.js    # ユニットテスト（自前 assert、純粋関数を固定入力で検証）
 docs/COVERAGE.md        # 自治体ごとの収録状況（自動生成）
 api/                    # 生成物（.gitignore 対象。Git 管理しない）
 llms.txt / llms-full.txt  # AI向けドキュメント（README から自動生成。直接編集しない）
@@ -66,7 +70,7 @@ attribution.html        # 出典表示ページ（sources.yaml から自動生�
 ## 規約と注意点
 
 - コード・コメントは日本語。すべての関数に doc コメント、非自明なロジックにインラインコメントを書く
-- テストは `scripts/*.test.js` に自前 assert で書き、`package.json` の `test:unit` チェーンに追加する
+- テストは実装と同じディレクトリに `*.test.js` として自前 assert で書き、`package.json` の `test:unit` チェーンに追加する
 - 整形・生成ロジックは純粋関数として export し、テストは固定入力で検証する（既存テストの流儀に従う）
 - `llms.txt` / `llms-full.txt` / `attribution.html` / README の STATS ブロックは自動生成。
   内容を変えたいときは生成元（README 本文・テンプレート・`config/sources.yaml`）を変更する
@@ -101,7 +105,7 @@ attribution.html        # 出典表示ページ（sources.yaml から自動生�
 
 - `pages.yml` は配信前に必ず生成物を作り直すため、公開ページは常に main の生成元と一致する
 - `generated-docs.yml` は main 上の生成物がずれていたら再生成してコミットする（自己修復）
-- `ci.yml` は PR でユニットテストを走らせる。生成物の同期テスト（`gen-attribution.test.js` 等）が
+- `ci.yml` は PR でユニットテストを走らせる。生成物の同期テスト（`scripts/generate/attribution.test.js` 等）が
   含まれるため、生成元だけ直して生成物を再生成し忘れた PR はここで落ちる
 - 過去の事故: クローラーが自リポジトリに持っていた古い `config/sources.yaml` の
   スナップショットから `attribution.html` を生成して main に push し、旧リポジトリ名と

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ sources:
 node scripts/crawl.js --only=osaka-city
 ```
 
-BODIK に掲載されているデータは、`scripts/gen-bodik-sources.js` でエントリを生成して
+BODIK に掲載されているデータは、`scripts/tools/gen-bodik-sources.js` でエントリを生成して
 手動マージできます。
 
 ---
@@ -114,7 +114,7 @@ npm ci
 - **コード・コメントは日本語**で書きます。
 - すべての関数に doc コメント、非自明なロジックにインラインコメントを付けます。
 - 整形・生成ロジックは**純粋関数として export** し、固定入力でテストできる形にします。
-- テストは `scripts/*.test.js` に、外部ライブラリを使わない自前の `assert` で書きます。
+- テストは実装と同じディレクトリに `*.test.js` として置き、外部ライブラリを使わない自前の `assert` で書きます。
   追加したら `package.json` の `test:unit` チェーンにも追加してください。
 
 ---

--- a/attribution.html
+++ b/attribution.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-  このファイルは scripts/gen-attribution.js が config/sources.yaml から自動生成しています。
+  このファイルは scripts/generate/attribution.js が config/sources.yaml から自動生成しています。
   直接編集せず、config/sources.yaml を更新して `npm run build:attribution` を実行してください。
 -->
 <html lang="ja">
@@ -1340,7 +1340,7 @@
     <footer>
       <p>
         このページは <a href="https://github.com/gl20percentclub/japan-food-facilities/blob/main/config/sources.yaml">config/sources.yaml</a> から
-        <a href="https://github.com/gl20percentclub/japan-food-facilities/blob/main/scripts/gen-attribution.js">scripts/gen-attribution.js</a> が自動生成しています。
+        <a href="https://github.com/gl20percentclub/japan-food-facilities/blob/main/scripts/generate/attribution.js">scripts/generate/attribution.js</a> が自動生成しています。
         誤りを見つけた場合は <a href="https://github.com/gl20percentclub/japan-food-facilities/issues">Issue</a> でお知らせください。
       </p>
       <p>

--- a/config/sources.yaml
+++ b/config/sources.yaml
@@ -31,7 +31,7 @@
 #   allSheets      Excel全シートを結合（京都市: 区ごとシート）
 #   locateByAddress 市区町村カラムを信用せず施設住所から導出（i2fas: カラムは管轄自治体）
 #
-# BODIK 掲載分は scripts/gen-bodik-sources.js で sources へ追記再生成できる。
+# BODIK 掲載分は scripts/tools/gen-bodik-sources.js で sources へ追記再生成できる。
 
 columns:
   city_code:

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,4 +1,4 @@
-<!-- このファイルは README.md から自動生成されています（scripts/gen-llms.js）。直接編集しないでください。 -->
+<!-- このファイルは README.md から自動生成されています（scripts/generate/llms.js）。直接編集しないでください。 -->
 
 # 🍽️ Japan Food Facilities Data
 

--- a/map.html
+++ b/map.html
@@ -204,7 +204,7 @@
     // S3 + CloudFront から配信されるため、相対参照ではなく絶対 URL を指す。
     // CORS は全オリジン許可済みなので、ローカルで開いた場合もそのまま読める。
     const API_BASE = 'https://food.japan-facilities.com/api';
-    // ベクトルタイルのズーム範囲（scripts/gen-tiles.js の設定と一致させる）
+    // ベクトルタイルのズーム範囲（scripts/build/tiles.js の設定と一致させる）
     const TILE_MIN_ZOOM = 6;
     const TILE_MAX_ZOOM = 12;
     // 日本のおおよその範囲 [west, south, east, north]
@@ -510,7 +510,7 @@
     // ラベルが未定義のキーが増えたときは、キー名をそのまま見出しに使って必ず表示する。
 
     // ベクトルタイル(facilities レイヤ)が持つ属性のラベル。
-    // scripts/gen-tiles.js の buildFeatureCollection が作る properties と対応させる。
+    // scripts/build/tiles.js の buildFeatureCollection が作る properties と対応させる。
     const TILE_PROP_LABELS = {
       name: '名称',
       business_type: '業種',

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "scripts": {
     "build": "node scripts/crawl.js",
     "build:dry": "node scripts/crawl.js --dry-run",
-    "build:attribution": "node scripts/gen-attribution.js",
-    "build:llms": "node scripts/gen-llms.js",
-    "fetch:i2fas": "node scripts/fetch-i2fas.js",
-    "test:unit": "node scripts/crawl.test.js && node scripts/lib/config.test.js && node scripts/build-merged-csv.test.js && node scripts/build-prefecture-csv.test.js && node scripts/gen-tiles.test.js && node scripts/preview-map.test.js && node scripts/map-filter.test.js && node scripts/gen-readme-stats.test.js && node scripts/gen-llms.test.js && node scripts/gen-attribution.test.js && node scripts/workflows.test.js",
+    "build:attribution": "node scripts/generate/attribution.js",
+    "build:llms": "node scripts/generate/llms.js",
+    "fetch:i2fas": "node scripts/tools/fetch-i2fas.js",
+    "test:unit": "node scripts/crawl.test.js && node scripts/lib/config.test.js && node scripts/build/merged-csv.test.js && node scripts/build/prefecture-csv.test.js && node scripts/build/tiles.test.js && node scripts/preview-map.test.js && node scripts/map-filter.test.js && node scripts/generate/readme-stats.test.js && node scripts/generate/llms.test.js && node scripts/generate/attribution.test.js && node scripts/workflows.test.js",
     "test:api": "node scripts/validate-api.js",
     "test": "npm run test:unit && npm run test:api"
   },

--- a/scripts/build/merged-csv.js
+++ b/scripts/build/merged-csv.js
@@ -17,7 +17,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { PREFECTURE_NAMES } from './lib/prefectures.js';
+import { PREFECTURE_NAMES } from '../lib/prefectures.js';
 
 // 「都道府県／市区町村の異なり数」に数えてよい値かを判定するための集合。
 // 元データには '不明'（解決できなかった）や '県外'（管轄外を表す独自の値）が混ざる。

--- a/scripts/build/merged-csv.test.js
+++ b/scripts/build/merged-csv.test.js
@@ -1,5 +1,5 @@
 // 結合CSV の書き出しと、バリデーションで使う CSV リーダーの往復テスト。
-//   node scripts/build-merged-csv.test.js
+//   node scripts/build/merged-csv.test.js
 //
 // 引用符・改行・カンマを含むセルが、書き出し → 読み戻しで元の値に戻ることを確認する
 // （ここが崩れると配布CSV が壊れ、バリデーションもすり抜ける）。
@@ -8,9 +8,9 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { buildMergedCsv, CSV_COLUMNS, csvCell } from './build-merged-csv.js';
-import { generateTiles } from './gen-tiles.js';
-import { readCsvRows } from './lib/csv-read.js';
+import { buildMergedCsv, CSV_COLUMNS, csvCell } from './merged-csv.js';
+import { generateTiles } from './tiles.js';
+import { readCsvRows } from '../lib/csv-read.js';
 import {
   resolvePrefCity,
   applyPrefCity,
@@ -19,7 +19,7 @@ import {
   stripCountyPrefix,
   toMunicipality,
   isResolvablePair,
-} from './lib/city-normmap.js';
+} from '../lib/city-normmap.js';
 
 /**
  * `entry` から相対 import をたどって到達できるモジュールの絶対パス集合を返す。
@@ -69,10 +69,10 @@ async function writeCsv(facilities, opts = {}) {
 // クローラー（別リポジトリ）は sources.yaml をコミットせず、クロール実行時だけ
 // CONFIG_PATH で公開リポのクローンを指す。配信物バリデーション（scripts/validate-api.js）は
 // その環境変数なしで走るため、ここから config.js に到達すると起動時に落ちる。
-// 実際に「build-merged-csv.js → lib/normalize.js → loadConfig()」の連鎖でクロールが
+// 実際に「build/merged-csv.js → lib/normalize.js → loadConfig()」の連鎖でクロールが
 // 停止したことがあるので、到達不可であることを固定する。
 await test('依存関係: 配信物まわりのモジュールが lib/config.js に依存しない', () => {
-  for (const entry of ['./scripts/validate-api.js', './scripts/build-merged-csv.js']) {
+  for (const entry of ['./scripts/validate-api.js', './scripts/build/merged-csv.js']) {
     const reached = [...reachableModules(entry)];
     const config = reached.find((p) => p.endsWith(`${path.sep}lib${path.sep}config.js`));
     assert.equal(config, undefined, `${entry} から lib/config.js に到達してはいけない`);

--- a/scripts/build/prefecture-csv.js
+++ b/scripts/build/prefecture-csv.js
@@ -17,7 +17,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { CSV_COLUMNS, csvCell, toRow } from './build-merged-csv.js';
+import { CSV_COLUMNS, csvCell, toRow } from './merged-csv.js';
 
 /**
  * JIS都道府県コード順の都道府県定義。

--- a/scripts/build/prefecture-csv.test.js
+++ b/scripts/build/prefecture-csv.test.js
@@ -1,5 +1,5 @@
 // 都道府県別CSV の生成ロジックを検証する。
-//   node scripts/build-prefecture-csv.test.js
+//   node scripts/build/prefecture-csv.test.js
 //
 // 見るのは3点:
 //   - 47都道府県ぶんのファイルが必ず出る（0件の県もヘッダーだけ出す）
@@ -10,7 +10,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { CSV_COLUMNS } from './build-merged-csv.js';
+import { CSV_COLUMNS } from './merged-csv.js';
 import {
   PREFECTURES,
   INDEX_FILENAME,
@@ -18,8 +18,8 @@ import {
   groupByPrefecture,
   prefectureFileName,
   renderIndex,
-} from './build-prefecture-csv.js';
-import { readCsvRows } from './lib/csv-read.js';
+} from './prefecture-csv.js';
+import { readCsvRows } from '../lib/csv-read.js';
 
 let passed = 0;
 async function test(name, fn) {
@@ -28,7 +28,7 @@ async function test(name, fn) {
   console.log(`  ✓ ${name}`);
 }
 
-console.log('build-prefecture-csv テスト\n');
+console.log('都道府県別CSV テスト\n');
 
 const col = Object.fromEntries(CSV_COLUMNS.map((c, i) => [c, i]));
 
@@ -183,4 +183,4 @@ await test('CSV は BOM なし UTF-8 で書き出す', async () => {
   assert.notEqual(head, '﻿');
 });
 
-console.log(`\n✅ build-prefecture-csv テスト ${passed}件に合格`);
+console.log(`\n✅ 都道府県別CSV テスト ${passed}件に合格`);

--- a/scripts/build/tiles.js
+++ b/scripts/build/tiles.js
@@ -21,7 +21,7 @@ const vtpbf = vtpbfNs.default || vtpbfNs;
 const fromGeojsonVt = vtpbf.fromGeojsonVt || vtpbfNs.fromGeojsonVt;
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const ROOT = path.resolve(__dirname, '..');
+const ROOT = path.resolve(__dirname, '..', '..');
 const TILES_DIR = path.join(ROOT, 'api', 'tiles');
 const LAYER = 'facilities';
 

--- a/scripts/build/tiles.test.js
+++ b/scripts/build/tiles.test.js
@@ -1,12 +1,12 @@
 // gen-tiles.js のユニットテスト。
-//   node scripts/gen-tiles.test.js
+//   node scripts/build/tiles.test.js
 // タイル座標計算(lonLatToTile)と、一時ディレクトリに対する generateTiles の生成結果を検証する。
 
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { lonLatToTile, buildFeatureCollection, generateTiles } from './gen-tiles.js';
+import { lonLatToTile, buildFeatureCollection, generateTiles } from './tiles.js';
 
 let passed = 0;
 function test(name, fn) {
@@ -116,4 +116,4 @@ test('generateTiles: metadata.json と、各点に対応する非空 pbf タイ�
   }
 });
 
-console.log(`\n✅ gen-tiles ユニットテスト: ${passed}件すべて合格`);
+console.log(`\n✅ ベクトルタイル生成 ユニットテスト: ${passed}件すべて合格`);

--- a/scripts/crawl.js
+++ b/scripts/crawl.js
@@ -35,11 +35,11 @@ import {
 } from './lib/normalize.js';
 import { enrichWithGeocoding } from './lib/geocode.js';
 import { buildCityNormMap, applyPrefCity } from './lib/city-normmap.js';
-import { buildMergedCsv } from './build-merged-csv.js';
-import { buildPrefectureCsvs } from './build-prefecture-csv.js';
-import { generateTiles } from './gen-tiles.js';
-import { generateReadmeStats } from './gen-readme-stats.js';
-import { generateLlmsFiles } from './gen-llms.js';
+import { buildMergedCsv } from './build/merged-csv.js';
+import { buildPrefectureCsvs } from './build/prefecture-csv.js';
+import { generateTiles } from './build/tiles.js';
+import { generateReadmeStats } from './generate/readme-stats.js';
+import { generateLlmsFiles } from './generate/llms.js';
 
 const CACHE_DIR = path.join(ROOT, '.cache');
 const API_DIR = path.join(ROOT, 'api');

--- a/scripts/generate/attribution.js
+++ b/scripts/generate/attribution.js
@@ -10,14 +10,14 @@
 // 変更したら本スクリプトを実行して再生成すること（`npm test` で同期を検証する）。
 //
 // 使い方:
-//   node scripts/gen-attribution.js           attribution.html を再生成
-//   node scripts/gen-attribution.js --check   再生成せず、内容が最新かだけを検証
+//   node scripts/generate/attribution.js           attribution.html を再生成
+//   node scripts/generate/attribution.js --check   再生成せず、内容が最新かだけを検証
 // ---------------------------------------------------------------------------
 
 import fs from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { loadConfig, ROOT } from './lib/config.js';
+import { loadConfig, ROOT } from '../lib/config.js';
 
 /** 生成先。gh-pages のルートに配置され https://…/attribution.html で公開される。 */
 export const OUTPUT_PATH = path.join(ROOT, 'attribution.html');
@@ -344,7 +344,7 @@ export function renderHtml(entries) {
 
   return `<!DOCTYPE html>
 <!--
-  このファイルは scripts/gen-attribution.js が config/sources.yaml から自動生成しています。
+  このファイルは scripts/generate/attribution.js が config/sources.yaml から自動生成しています。
   直接編集せず、config/sources.yaml を更新して \`npm run build:attribution\` を実行してください。
 -->
 <html lang="ja">
@@ -517,7 +517,7 @@ ${sections.map(renderSection).join('\n')}
     <footer>
       <p>
         このページは <a href="${REPO_URL}/blob/main/config/sources.yaml">config/sources.yaml</a> から
-        <a href="${REPO_URL}/blob/main/scripts/gen-attribution.js">scripts/gen-attribution.js</a> が自動生成しています。
+        <a href="${REPO_URL}/blob/main/scripts/generate/attribution.js">scripts/generate/attribution.js</a> が自動生成しています。
         誤りを見つけた場合は <a href="${REPO_URL}/issues">Issue</a> でお知らせください。
       </p>
       <p>

--- a/scripts/generate/attribution.test.js
+++ b/scripts/generate/attribution.test.js
@@ -1,6 +1,6 @@
 // gen-attribution.js の分類・整形ロジックと、生成物 attribution.html の同期を検証する。
 //
-//   node scripts/gen-attribution.test.js
+//   node scripts/generate/attribution.test.js
 
 import fs from 'node:fs';
 import {
@@ -12,8 +12,8 @@ import {
   derivePublisher,
   generate,
   groupByLicense,
-} from './gen-attribution.js';
-import { loadConfig } from './lib/config.js';
+} from './attribution.js';
+import { loadConfig } from '../lib/config.js';
 
 let failures = 0;
 /** 条件を検証して結果を出力する（失敗数を数える）。 */
@@ -26,7 +26,7 @@ function assert(cond, msg) {
   }
 }
 
-console.log('gen-attribution テスト\n');
+console.log('attribution.html 生成 テスト\n');
 
 // --- classifyLicense: 表記ゆれを同じ区分にまとめる ---
 assert(
@@ -133,7 +133,7 @@ assert(
 
 // --- LP（index.html）に書いたソース数が config と一致しているか ---
 // LP は静的に「98 データソース」と表示するため、ソースを増減したら書き換えが要る。
-const lp = fs.readFileSync(new URL('../index.html', import.meta.url), 'utf-8');
+const lp = fs.readFileSync(new URL('../../index.html', import.meta.url), 'utf-8');
 const lpCounts = [...lp.matchAll(/data-source-count>(\d[\d,]*)</g)].map((m) => Number(m[1].replaceAll(',', '')));
 assert(lpCounts.length > 0, 'LP にソース数の記載（data-source-count）がある');
 assert(
@@ -145,4 +145,4 @@ if (failures > 0) {
   console.error(`\n❌ ${failures}件のチェックに失敗`);
   process.exit(1);
 }
-console.log('\n✅ gen-attribution テストに合格');
+console.log('\n✅ attribution.html 生成 テストに合格');

--- a/scripts/generate/llms.js
+++ b/scripts/generate/llms.js
@@ -12,7 +12,7 @@
 // 最新の統計へ追従する。生成物はリポジトリ直下に置かれ、gh-pages 配信で
 // サイトルート（/llms.txt /llms-full.txt）から取得できる。
 //
-//   node scripts/gen-llms.js   単体実行（README.md を読んで2ファイルを書き出す）
+//   node scripts/generate/llms.js   単体実行（README.md を読んで2ファイルを書き出す）
 // ---------------------------------------------------------------------------
 
 import fs from 'node:fs';
@@ -20,7 +20,7 @@ import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const ROOT = path.resolve(__dirname, '..');
+const ROOT = path.resolve(__dirname, '..', '..');
 const README_PATH = path.join(ROOT, 'README.md');
 
 // 配信 URL の基点。静的ページは GitHub Pages、データ（api/）は S3 + CloudFront
@@ -132,7 +132,7 @@ ${stats}
  */
 export function renderLlmsFullTxt(readme) {
   const body = absolutizeLinks(stripHtmlNoise(readme)).trim();
-  return `<!-- このファイルは README.md から自動生成されています（scripts/gen-llms.js）。直接編集しないでください。 -->
+  return `<!-- このファイルは README.md から自動生成されています（scripts/generate/llms.js）。直接編集しないでください。 -->
 
 ${body}
 
@@ -250,7 +250,7 @@ export function generateLlmsFiles() {
   return written;
 }
 
-// 単体実行（node scripts/gen-llms.js）されたときだけ生成を走らせる
+// 単体実行（node scripts/generate/llms.js）されたときだけ生成を走らせる
 if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   console.log('llms.txt / llms-full.txt を生成');
   generateLlmsFiles();

--- a/scripts/generate/llms.test.js
+++ b/scripts/generate/llms.test.js
@@ -2,7 +2,7 @@
 // renderLlmsTxt() / renderLlmsFullTxt() / extractStats() / absolutizeLinks() は
 // 純粋関数なので固定入力で検証する。
 //
-//   node scripts/gen-llms.test.js
+//   node scripts/generate/llms.test.js
 
 import {
   extractStats,
@@ -10,7 +10,7 @@ import {
   stripHtmlNoise,
   renderLlmsTxt,
   renderLlmsFullTxt,
-} from './gen-llms.js';
+} from './llms.js';
 
 let failures = 0;
 /** 条件を検証して結果を出力する（失敗数を数える）。 */
@@ -23,7 +23,7 @@ function assert(cond, msg) {
   }
 }
 
-console.log('gen-llms テスト\n');
+console.log('llms.txt 生成 テスト\n');
 
 // テスト用の README（統計ブロック・相対リンク・バッジを含む最小構成）
 const readme = `<div align="center">
@@ -105,4 +105,4 @@ if (failures > 0) {
   console.error(`\n❌ ${failures}件のチェックに失敗`);
   process.exit(1);
 }
-console.log('\n✅ gen-llms テストに合格');
+console.log('\n✅ llms.txt 生成 テストに合格');

--- a/scripts/generate/readme-stats.js
+++ b/scripts/generate/readme-stats.js
@@ -11,7 +11,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const ROOT = path.resolve(__dirname, '..');
+const ROOT = path.resolve(__dirname, '..', '..');
 const README_PATH = path.join(ROOT, 'README.md');
 
 const START = '<!-- STATS:START -->';

--- a/scripts/generate/readme-stats.test.js
+++ b/scripts/generate/readme-stats.test.js
@@ -1,9 +1,9 @@
 // gen-readme-stats.js の整形ロジックを検証する。
 // renderStats() は純粋関数なので固定入力で検証する。
 //
-//   node scripts/gen-readme-stats.test.js
+//   node scripts/generate/readme-stats.test.js
 
-import { renderStats } from './gen-readme-stats.js';
+import { renderStats } from './readme-stats.js';
 
 let failures = 0;
 function assert(cond, msg) {
@@ -15,7 +15,7 @@ function assert(cond, msg) {
   }
 }
 
-console.log('gen-readme-stats テスト\n');
+console.log('README統計 生成 テスト\n');
 
 const fixed = {
   updated: 1783366001, // 2026-07-06
@@ -60,4 +60,4 @@ if (failures > 0) {
   console.error(`\n❌ ${failures}件のチェックに失敗`);
   process.exit(1);
 }
-console.log('\n✅ gen-readme-stats テストに合格');
+console.log('\n✅ README統計 生成 テストに合格');

--- a/scripts/lib/acquire.js
+++ b/scripts/lib/acquire.js
@@ -132,10 +132,10 @@ async function extractFromZip(zipBuf, entryPattern) {
 export async function acquire(source, { cacheDir, dryRun = false } = {}) {
   const a = source.acquire;
 
-  // i2fasglob: scripts/fetch-i2fas.js が取得した .cache/i2fas/*.csv をまとめて読む。
+  // i2fasglob: scripts/tools/fetch-i2fas.js が取得した .cache/i2fas/*.csv をまとめて読む。
   if (a.type === 'i2fasglob') {
     const dir = path.join(cacheDir, 'i2fas');
-    if (!fs.existsSync(dir)) throw new Error(`.cache/i2fas がありません（先に node scripts/fetch-i2fas.js を実行）`);
+    if (!fs.existsSync(dir)) throw new Error(`.cache/i2fas がありません（先に node scripts/tools/fetch-i2fas.js を実行）`);
     const files = fs.readdirSync(dir).filter((f) => f.endsWith('.csv')).sort();
     if (files.length === 0) throw new Error('.cache/i2fas に CSV がありません');
     console.log(`  i2fas キャッシュ ${files.length} ファイルを使用`);

--- a/scripts/preview-map.test.js
+++ b/scripts/preview-map.test.js
@@ -1,9 +1,9 @@
-// 地図・検索ページ(map.html)と gen-tiles.js の生成物との整合性テスト。
-// 検索機能そのものの整合性は scripts/map-search.test.js が見る。
+// 地図ページ(map.html)と build/tiles.js の生成物との整合性テスト。
+// 業種フィルターの整合性は scripts/map-filter.test.js が見る。
 //   node scripts/preview-map.test.js
 //
 // map.html はベクトルタイル(api/tiles)を直接読むため、レイヤ名・ズーム範囲・
-// タイルパス・利用する属性・metadata.json の統計フィールドが gen-tiles.js の出力と
+// タイルパス・利用する属性・metadata.json の統計フィールドが build/tiles.js の出力と
 // ズレると地図が黙って壊れる。ここでは実際に generateTiles を走らせた生成物と
 // map.html の記述を突き合わせ、両者が食い違ったら失敗させる。
 
@@ -12,7 +12,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { buildFeatureCollection, generateTiles } from './gen-tiles.js';
+import { buildFeatureCollection, generateTiles } from './build/tiles.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -49,17 +49,17 @@ function withTiles(opts, fn) {
   }
 }
 
-test('source-layer が gen-tiles の出力レイヤ名(metadata.vector_layers[0].id)と一致する', () => {
+test('source-layer が タイル生成の出力レイヤ名(metadata.vector_layers[0].id)と一致する', () => {
   const sourceLayer = htmlValue(/'source-layer':\s*'([^']+)'/, 'source-layer');
   withTiles({ minZoom: 6, maxZoom: 12 }, (meta) => {
     assert.equal(sourceLayer, meta.vector_layers[0].id, `source-layer(${sourceLayer}) == 生成レイヤ(${meta.vector_layers[0].id})`);
   });
 });
 
-test('TILE_MIN_ZOOM / TILE_MAX_ZOOM が gen-tiles の既定ズーム範囲と一致する', () => {
+test('TILE_MIN_ZOOM / TILE_MAX_ZOOM が タイル生成の既定ズーム範囲と一致する', () => {
   const minZoom = Number(htmlValue(/TILE_MIN_ZOOM\s*=\s*(\d+)/, 'TILE_MIN_ZOOM'));
   const maxZoom = Number(htmlValue(/TILE_MAX_ZOOM\s*=\s*(\d+)/, 'TILE_MAX_ZOOM'));
-  // 既定のズーム範囲(scripts/gen-tiles.js の MIN_ZOOM/MAX_ZOOM)で生成する。
+  // 既定のズーム範囲(scripts/build/tiles.js の MIN_ZOOM/MAX_ZOOM)で生成する。
   withTiles({}, (meta) => {
     assert.equal(minZoom, meta.minzoom, `TILE_MIN_ZOOM(${minZoom}) == metadata.minzoom(${meta.minzoom})`);
     assert.equal(maxZoom, meta.maxzoom, `TILE_MAX_ZOOM(${maxZoom}) == metadata.maxzoom(${meta.maxzoom})`);

--- a/scripts/tools/analyze-geocoding.js
+++ b/scripts/tools/analyze-geocoding.js
@@ -9,18 +9,18 @@
 //   analysis/no-coord.csv   座標を付与できなかった住所だけ（原因分析用・reason 付き）
 //
 // 使い方:
-//   node scripts/analyze-geocoding.js                全ソース
-//   node scripts/analyze-geocoding.js --only=osaka-city,okinawa-bodik   指定ソースのみ
-//   node scripts/analyze-geocoding.js --concurrency=8
+//   node scripts/tools/analyze-geocoding.js                全ソース
+//   node scripts/tools/analyze-geocoding.js --only=osaka-city,okinawa-bodik   指定ソースのみ
+//   node scripts/tools/analyze-geocoding.js --concurrency=8
 
 import fs from 'node:fs';
 import path from 'node:path';
 import { normalize, config as njaConfig } from '@geolonia/normalize-japanese-addresses';
-import { loadConfig, ROOT } from './lib/config.js';
-import { acquire } from './lib/acquire.js';
-import { parseSource } from './lib/parse.js';
-import { mapRecord, toFacility, resolvePrefecture, resolveCity } from './lib/normalize.js';
-import { geocodeQuery } from './lib/geocode.js';
+import { loadConfig, ROOT } from '../lib/config.js';
+import { acquire } from '../lib/acquire.js';
+import { parseSource } from '../lib/parse.js';
+import { mapRecord, toFacility, resolvePrefecture, resolveCity } from '../lib/normalize.js';
+import { geocodeQuery } from '../lib/geocode.js';
 
 const CACHE_DIR = path.join(ROOT, '.cache');
 const OUT_DIR = path.join(ROOT, 'analysis');

--- a/scripts/tools/fetch-i2fas.js
+++ b/scripts/tools/fetch-i2fas.js
@@ -14,9 +14,9 @@
 // 逐次・低レート・キャッシュ（レジューム）で節度をもって取得する。
 //
 // 使い方:
-//   node scripts/fetch-i2fas.js             全自治体を取得（キャッシュ済みはスキップ）
-//   node scripts/fetch-i2fas.js --limit=5   先頭5自治体だけ（動作確認）
-//   node scripts/fetch-i2fas.js --force     キャッシュを無視して再取得
+//   node scripts/tools/fetch-i2fas.js             全自治体を取得（キャッシュ済みはスキップ）
+//   node scripts/tools/fetch-i2fas.js --limit=5   先頭5自治体だけ（動作確認）
+//   node scripts/tools/fetch-i2fas.js --force     キャッシュを無視して再取得
 
 import { chromium } from 'playwright';
 import fs from 'node:fs';
@@ -24,7 +24,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const ROOT = path.resolve(__dirname, '..');
+const ROOT = path.resolve(__dirname, '..', '..');
 const OUT = path.join(ROOT, '.cache', 'i2fas');
 const PUB = 'https://i2fas.mhlw.go.jp/faspub/IO_S010303.do?method=a_menu_o01Action';
 

--- a/scripts/tools/gen-bodik-sources.js
+++ b/scripts/tools/gen-bodik-sources.js
@@ -1,7 +1,7 @@
 // data.bodik.jp から食品営業許可データセットを列挙し、自治体(org)ごとに
 // 「全件・許可」に最も近い CSV/XLSX リソースを1つ選び、sources 定義を生成する。
 //
-//   node scripts/gen-bodik-sources.js   → config/_bodik-generated.yaml を出力
+//   node scripts/tools/gen-bodik-sources.js   → config/_bodik-generated.yaml を出力
 //   出力された sources エントリを config/sources.yaml の sources: にマージする。
 import * as yaml from 'js-yaml';
 import fs from 'node:fs';
@@ -61,7 +61,7 @@ const entries = list.map((x) => ({
   ...(x.license ? { license: x.license } : {}),
 }));
 const header = `# 自動生成: data.bodik.jp の食品営業許可データセット（自治体ごとに全件・許可の代表リソース1件）\n` +
-  `# 生成: node scripts/gen-bodik-sources.js 。この内容を config/sources.yaml の sources: にマージする。\n\n`;
+  `# 生成: node scripts/tools/gen-bodik-sources.js 。この内容を config/sources.yaml の sources: にマージする。\n\n`;
 fs.writeFileSync('config/_bodik-generated.yaml', header + yaml.dump(entries, { lineWidth: -1, noRefs: true, quotingType: '"' }));
 console.log(`\nconfig/_bodik-generated.yaml に ${entries.length} 件を出力。config/sources.yaml の sources: にマージしてください。`);
 console.log('sample:', list.slice(0, 12).map((x) => x.org + ' / ' + x.title + ' [' + x.fmt + ' sc' + x.sc + ']'));

--- a/scripts/validate-api.js
+++ b/scripts/validate-api.js
@@ -14,8 +14,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { CSV_COLUMNS } from './build-merged-csv.js';
-import { INDEX_FILENAME, PREFECTURES } from './build-prefecture-csv.js';
+import { CSV_COLUMNS } from './build/merged-csv.js';
+import { INDEX_FILENAME, PREFECTURES } from './build/prefecture-csv.js';
 import { readCsvRows } from './lib/csv-read.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
> [!IMPORTANT]
> **スタックPRです。** ベースは #86 → #85 → `main`。下から順にマージしてください。

## 背景

`scripts/` 直下に30ファイルがフラットに並び、**役割の異なる4種類が混在**していました。

とくに紛らわしいのが `gen-` 接頭辞です。`gen-tiles.js`（公開データを作る）と `gen-llms.js`（ドキュメントを作る）が同じ名前空間にいるため、**どちらが配信物を生む側なのか名前から判断できません**。

## 変更

ディレクトリで役割を表し、接頭辞をディレクトリ名に吸収します。

```
scripts/
├── crawl.js               # エントリポイント（クロール → 配信物）
├── validate-api.js        # エントリポイント（生成済み api/ の検証）
├── lib/                   # 取得・パース・正規化・ジオコーディング（変更なし）
├── build/                 # ★ 配信物の生成
│   ├── merged-csv.js      #   ← build-merged-csv.js
│   ├── prefecture-csv.js  #   ← build-prefecture-csv.js
│   └── tiles.js           #   ← gen-tiles.js
├── generate/              # ★ ドキュメントの生成
│   ├── attribution.js     #   ← gen-attribution.js
│   ├── llms.js            #   ← gen-llms.js
│   └── readme-stats.js    #   ← gen-readme-stats.js
├── tools/                 # ★ 単発・保守用（本番パイプラインからは呼ばれない）
│   ├── fetch-i2fas.js
│   ├── gen-bodik-sources.js
│   └── analyze-geocoding.js
├── crawl.test.js
├── preview-map.test.js
├── map-filter.test.js
└── workflows.test.js
```

- テストは**従来どおり実装と同じディレクトリ**に置いています（`test/` へは分離していません）
- エントリポイント2本と、特定の実装に紐づかないテスト（ワークフロー設定・静的ページの整合性）は `scripts/` 直下に残しました

## 追随させたもの

- 相対 import すべて（`./lib/` → `../lib/` 等）
- **`ROOT` のパス深さ** — `path.resolve(__dirname, '..')` → `'..', '..'`。4ファイル（`build/tiles.js` / `generate/llms.js` / `generate/readme-stats.js` / `tools/fetch-i2fas.js`）。ここを外すと出力先が `scripts/` 配下になり、**エラーにならず静かに間違った場所へ書く**ため要注意箇所です
- `generate/attribution.test.js` が読む `index.html` の相対パス
- `package.json`（`test:unit` チェーン11本・`build:*`・`fetch:i2fas`）
- `.github/workflows/pages.yml` / `generated-docs.yml` の `paths` フィルター（`scripts/gen-attribution.js` → `scripts/generate/attribution.js`）。**ここが古いままだと生成元を変えても配信・自己修復が発火しません**
- `map.html` / `config/sources.yaml` / `AGENTS.md` / `CONTRIBUTING.md` / `lib/acquire.js` のエラーメッセージ内のパス
- 実態と合わなくなっていたテストの表示名（`gen-tiles ユニットテスト` → `ベクトルタイル生成 ユニットテスト` 等）
- `preview-map.test.js` の冒頭コメントが**存在しない `scripts/map-search.test.js`** を指していたので修正

## 生成物の再生成

`attribution.html` と `llms-full.txt` は**生成元スクリプトのパスを本文に埋め込んでいる**ため、再生成して差分を同梱しています（`npm run build:attribution` / `npm run build:llms`）。

## 確認

- `npm run test:unit` — 196アサーション全通過
- 全30スクリプトの相対 import 先が実在することを機械的に確認（移動漏れ検出）
- `node scripts/validate-api.js` が module 解決に失敗せず、想定どおり「`api/` が無い」で止まることを確認