### PR TITLE
docs: リネーム後の実ファイル名にコメントと契約テストを合わせる

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,8 +121,7 @@ main を clone し、`npm ci --omit=dev` で依存を入れて `node scripts/cra
   クロール処理・正規化・生成ロジックはこのリポジトリが単一の情報源
 - クローラーは clone をそのまま作業ディレクトリにするため、`config/sources.yaml` も
   `README.md` も `api/` も既定の相対パスで解決される（環境変数での場所指定はしていない）
-- したがって `scripts/crawl.js` / `scripts/validate-api.js` /
-  `scripts/generate/attribution.js` / `scripts/tools/fetch-i2fas.js` の
+- したがって `scripts/crawl.js` / `scripts/validate-api.js` / `scripts/tools/fetch-i2fas.js` の
   リネーム・移動、`dependencies` の削除は**本番の週次クロールを直接壊す**。
   `scripts/crawler-contract.test.js` がこの契約を固定している。
   入口の名前を変えるときはクローラー側の `docker/entrypoint.sh` を同じタイミングで直す

--- a/scripts/build/tiles.test.js
+++ b/scripts/build/tiles.test.js
@@ -1,4 +1,4 @@
-// gen-tiles.js のユニットテスト。
+// build/tiles.js のユニットテスト。
 //   node scripts/build/tiles.test.js
 // タイル座標計算(lonLatToTile)と、一時ディレクトリに対する generateTiles の生成結果を検証する。
 

--- a/scripts/crawl.js
+++ b/scripts/crawl.js
@@ -10,9 +10,9 @@
 //   lib/city-normmap.js  市区町村名の名寄せ（表記ゆれ→公式名）
 //
 // 配信物は3種類だけ（用途が無い階層JSONは配信しない）:
-//   api/facilities-all.csv[.gz]   全件の結合CSV（build-merged-csv.js）
-//   api/prefectures/*.csv         都道府県別CSV + index.json（build-prefecture-csv.js）
-//   api/tiles/{z}/{x}/{y}.pbf     地図用ベクトルタイル + metadata.json（gen-tiles.js）
+//   api/facilities-all.csv[.gz]   全件の結合CSV（build/merged-csv.js）
+//   api/prefectures/*.csv         都道府県別CSV + index.json（build/prefecture-csv.js）
+//   api/tiles/{z}/{x}/{y}.pbf     地図用ベクトルタイル + metadata.json（build/tiles.js）
 //
 // 使い方:
 //   node scripts/crawl.js              通常実行（ダウンロード→ジオコーディング→生成）

--- a/scripts/crawler-contract.test.js
+++ b/scripts/crawler-contract.test.js
@@ -11,8 +11,10 @@
 //   npm ci --omit=dev                  ... clone 直下で依存を入れる（package-lock.json が要る）
 //   node scripts/crawl.js              ... クロール本体（api/ を生成し README 統計を更新）
 //   node scripts/validate-api.js       ... 配信物バリデーション（落ちたら配信しない）
-//   node scripts/generate/attribution.js ... 出典ページの生成
 //   node scripts/tools/fetch-i2fas.js  ... 月次の厚労省 i2fas 取得（別タスク）
+//
+// 出典ページ・llms.txt の生成はクローラーからは呼ばれない（生成元を持つこのリポジトリ側の
+// ワークフローが作る）ため、ここでは固定しない。
 
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
@@ -35,7 +37,6 @@ function test(name, fn) {
 const ENTRYPOINTS = [
   ['scripts/crawl.js', '週次クロール本体'],
   ['scripts/validate-api.js', '配信物バリデーション'],
-  ['scripts/generate/attribution.js', '出典ページ生成'],
   ['scripts/tools/fetch-i2fas.js', '月次 i2fas 取得'],
 ];
 

--- a/scripts/generate/attribution.test.js
+++ b/scripts/generate/attribution.test.js
@@ -1,4 +1,4 @@
-// gen-attribution.js の分類・整形ロジックと、生成物 attribution.html の同期を検証する。
+// attribution.js の分類・整形ロジックと、生成物 attribution.html の同期を検証する。
 //
 //   node scripts/generate/attribution.test.js
 

--- a/scripts/generate/llms.test.js
+++ b/scripts/generate/llms.test.js
@@ -1,4 +1,4 @@
-// gen-llms.js の整形ロジックを検証する。
+// llms.js の整形ロジックを検証する。
 // renderLlmsTxt() / renderLlmsFullTxt() / extractStats() / absolutizeLinks() は
 // 純粋関数なので固定入力で検証する。
 //

--- a/scripts/generate/readme-stats.test.js
+++ b/scripts/generate/readme-stats.test.js
@@ -1,4 +1,4 @@
-// gen-readme-stats.js の整形ロジックを検証する。
+// readme-stats.js の整形ロジックを検証する。
 // renderStats() は純粋関数なので固定入力で検証する。
 //
 //   node scripts/generate/readme-stats.test.js

--- a/scripts/map-filter.test.js
+++ b/scripts/map-filter.test.js
@@ -194,7 +194,7 @@ test('業種の記載なしを「その他」と混ぜない', () => {
 });
 
 test('フィルターがタイルの business_type 属性を見ている', () => {
-  // 属性名が gen-tiles の出力とズレると、絞り込みが全件0件になる。
+  // 属性名が build/tiles.js の出力とズレると、絞り込みが全件0件になる。
   assert.ok(/\['get', 'business_type'\]/.test(HTML), "['get', 'business_type'] で属性を読む");
   assert.ok(/setFilter\('facilities-circle'/.test(HTML), 'facilities-circle レイヤに setFilter する');
 });


### PR DESCRIPTION
## 概要

#86 / #88 の `scripts/` 再編後も、各ファイルの冒頭コメントが旧名を指したままだったので実ファイル名に揃える。あわせて #91 で入った `crawler-contract.test.js` の入口一覧を、クローラーが実際に呼ぶものだけに絞る。

## 変更内容

### 旧名のままだったコメントの更新

| 参照していた旧名 | 実ファイル |
|---|---|
| `gen-tiles.js` | `scripts/build/tiles.js` |
| `build-merged-csv.js` / `build-prefecture-csv.js` | `scripts/build/merged-csv.js` / `scripts/build/prefecture-csv.js` |
| `gen-llms.js` / `gen-attribution.js` / `gen-readme-stats.js` | `scripts/generate/` 配下の各ファイル |

対象は `scripts/crawl.js`・`scripts/map-filter.test.js`・`scripts/build/tiles.test.js`・`scripts/generate/*.test.js` の冒頭コメント。動作には影響しない。

### クローラー契約の範囲を実態に合わせる

`crawler-contract.test.js` の入口一覧から `scripts/generate/attribution.js` を外した。出典ページ・llms.txt の生成はクローラーからは呼ばれず、生成元を持つこのリポジトリ側のワークフロー（`pages.yml` / `generated-docs.yml`）が作るため、クローラーとの契約に含めるのは誤り。固定するのは実際に Fargate が実行する `crawl.js` / `validate-api.js` / `tools/fetch-i2fas.js` の3つ。AGENTS.md の該当記述も同じ範囲に揃えた。

## 確認

- `npm run test:unit` 合格（217件）
- クローラー側の追随は gl20percentclub/japan-facilities-crawler#25