### PR TITLE
fix: city 列の都道府県名も自治体を特定しない値として扱う

### DIFF
--- a/scripts/build/merged-csv.test.js
+++ b/scripts/build/merged-csv.test.js
@@ -348,6 +348,45 @@ await test('isResolvablePair: 自治体を特定しないペアは名寄せ対�
   assert.equal(isResolvablePair('三重県', ''), false);
   assert.equal(isResolvablePair('不明', '不明'), false);
   assert.equal(isResolvablePair('9300000', '四日市市'), false, '都道府県が不正なら信用しない');
+  assert.equal(
+    isResolvablePair('富山県', '富山県'),
+    false,
+    '都道府県名は県全域を指すので代表住所1件で代表させない',
+  );
+});
+
+await test('applyPrefCity: city 列に都道府県名が入るバケツで代表住所が焼き付かない', () => {
+  // 列ズレのソース（city 列に県名）は県全域が1バケツになる。名寄せ対象にすると
+  // 代表住所1件の自治体名が県内の全レコードへ焼き付き、列ズレ補正が
+  // レコードごとに正しく求めた自治体名を上書きしてしまう。
+  const facilities = [
+    { _pref: '富山県', _city: '富山県', address: '富山県高岡市広小路7-50' },
+    { _pref: '富山県', _city: '富山県', address: '富山県魚津市釈迦堂1-10-1' },
+  ];
+  applyPrefCity(facilities, { '富山県\t富山県': { pref: '富山県', city: '高岡市' } });
+  assert.equal(facilities[0].city, '高岡市');
+  assert.equal(facilities[1].city, '魚津市', '自分の住所から復元した自治体を保つ');
+});
+
+await test('collectCityPairs: city 列の都道府県名は名寄せ対象にしない', () => {
+  const pairs = collectCityPairs([
+    { _pref: '富山県', _city: '富山県', address: '富山県高岡市広小路7-50' },
+    { _pref: '東京都', _city: '港区', address: '東京都港区赤坂1-1' },
+  ]);
+  assert.deepEqual(
+    pairs.map((p) => p.city),
+    ['港区'],
+  );
+});
+
+await test('resolvePrefCity: 列ズレを復元できなければ都道府県名でなく「不明」を出す', () => {
+  // 住所が県名で始まらないと splitPrefCity が [null, null] を返し、city 列の
+  // 都道府県名がそのまま残る。これを city に出すと build/merged-csv.js の
+  // countableArea が実在する自治体として異なり数に数えてしまう。
+  const r = resolvePrefCity({ _pref: '9300000', _city: '富山県', address: '高岡市広小路7-50' }, {});
+  assert.equal(r.pref, '富山県', '都道府県は city 列から復元できている');
+  assert.equal(r.city, '不明', '都道府県名を市区町村として出さない');
+  assert.equal(r.colFixed, true);
 });
 
 await test('resolvePrefCity: 「不明」ペアには名寄せ表を適用しない', () => {

--- a/scripts/lib/city-normmap.js
+++ b/scripts/lib/city-normmap.js
@@ -65,10 +65,19 @@ export function isResolvablePair(pref, city) {
   return isMeaningfulCity(city);
 }
 
-/** 市区町村名として意味のある値か（'不明'・空文字は自治体を特定しない）。 */
+/**
+ * 市区町村名として意味のある値か（純粋関数）。
+ *
+ * '不明'・空文字はもちろん、都道府県名も自治体を特定しない。pref 列に郵便番号が
+ * 入り city 列に都道府県名が入る列ズレのソース（富山県の数件）では city が
+ * 「富山県」になるが、これは県全域を指すので代表住所1件の結果を全レコードへ
+ * 広げてよい値ではないし、市区町村の異なり数に数えてよい値でもない。
+ * 実在する自治体名（富山市 等）と衝突しないのは、PREFS が「富山県」のように
+ * 接尾辞まで含む正式名だけを持つため。
+ */
 export function isMeaningfulCity(city) {
   const c = String(city || '').trim();
-  return c !== '' && c !== '不明';
+  return c !== '' && c !== '不明' && !PREFS.has(c);
 }
 
 /**
@@ -176,7 +185,13 @@ export function resolvePrefCity(facility, normMap = {}) {
   // 自治体名だった。公式の1,741自治体と突き合わせる仕組みを入れるまでは '不明' のままにする。
 
   // 名寄せできなかった分も同じ整形を通す。表記ゆれは残るが粒度だけは揃う。
-  return { pref, city: toMunicipality(cityRaw), cityRaw, colFixed };
+  // 列ズレ補正で住所から市区町村を復元できなかった場合、cityRaw には都道府県名が
+  // 残ったままになる（住所が県名で始まらないと splitPrefCity が [null, null] を返すため）。
+  // 都道府県名をそのまま city に出すと、build/merged-csv.js の countableArea が
+  // 実在する自治体として異なり数に数え、CSV・タイルにも存在しない市区町村が載る。
+  // 特定できていないので '不明' に倒す。
+  const city = isMeaningfulCity(cityRaw) ? toMunicipality(cityRaw) : '不明';
+  return { pref, city, cityRaw, colFixed };
 }
 
 /**


### PR DESCRIPTION
## 概要

クローラー（`japan-facilities-crawler`）の自前コピーにだけ入っていたデータ修正を、単一の情報源であるこのリポジトリへ移植する。移植元: japan-facilities-crawler の `f991352`（同リポジトリ #22）。

japan-facilities-crawler#23（クロール処理をこのリポジトリから実行時取得する）をマージすると、このリポジトリに無い修正は本番から消えるため、先に入れる必要がある。

## 直す問題

`pref` 列に郵便番号、`city` 列に都道府県名が入る列ズレのソース（富山県の数件）で、`city` の「富山県」が自治体名として扱われていた。県全域を指す値なので、次の2つが起きる。

1. **代表住所の焼き付き**: 名寄せは (都道府県, 市区町村) のバケツごとに代表住所1件を正規化して結果を全レコードへ広げる。`(富山県, 富山県)` は県全域が1バケツになるため、代表1件の自治体名（例: 高岡市）が県内の全レコードへ貼り付き、列ズレ補正がレコードごとに住所から正しく求めた自治体名を上書きしてしまう
2. **実在しない自治体の混入**: 住所が県名で始まらず復元に失敗すると「富山県」がそのまま `city` に出る。`countableArea` が実在する自治体として異なり数に数え、CSV・タイルにも市区町村「富山県」が載る

## 変更内容

- `isMeaningfulCity`: '不明'・空文字に加えて都道府県名も弾く。`PREFS` は「富山県」のように接尾辞まで含む正式名だけを持つため、実在する自治体名（富山市 等）とは衝突しない
- `resolvePrefCity`: 列ズレ補正で市区町村を復元できなかった場合は、都道府県名を出さず '不明' に倒す

## 確認

- `npm run test:unit` 合格。移植元のテスト4件（`isResolvablePair` の追加検証・`applyPrefCity` の焼き付き・`collectCityPairs` の除外・`resolvePrefCity` の '不明' 化）を含む

## 関連

- 同時に必要なもう1件の移植: #96（タイルの gzip 化と低ズーム間引き）
- これらをマージしてから japan-facilities-crawler#25 → #23 の順にマージする