### PR TITLE
ベクトルタイルの最小ズームを z3 に下げ、地図の初期表示を全国にする

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ AI コーディングエージェント（Claude Code / Codex 等）向けのガ
   - 例 `13.csv`（東京都）/ `01.csv`（北海道）。47都道府県すべて存在し、列・内容は全件CSV と同じ。
     ファイル一覧と件数は `api/prefectures/index.json`。1県だけ必要ならこちらを使う
 - ベクトルタイル（MVT）: `https://food.japan-facilities.com/api/tiles/{z}/{x}/{y}.pbf`
-  - レイヤ名 `facilities`、z6–12、属性 `name` / `business_type` / `pref` / `city`
+  - レイヤ名 `facilities`、z3–12、属性 `name` / `business_type` / `pref` / `city`
 - 市区町村別 CSV/JSON や検索 API は**このリポジトリからは配信していない**。データ抽出は
   CSV（DuckDB 推奨）、地図表示はタイルを使う。ブラウザから非圧縮 CSV を直接 fetch しない
 - `map.html` は統計表示と業種フィルターだけの最小構成のプレビュー地図。業種の分類は

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ https://food.japan-facilities.com/api/facilities-all.csv
 | ------------- | ------------------------------------------------------------- |
 | タイルURL        | `https://food.japan-facilities.com/api/tiles/{z}/{x}/{y}.pbf` |
 | Source layer名 | `facilities`                                                  |
-| 対応ズーム         | `6`〜`12`                                                      |
+| 対応ズーム         | `3`〜`12`                                                      |
 | 属性          | `name`（施設名） / `business_type`（営業許可・届出の業種） / `pref`（都道府県名） / `city`（市区町村名）                    |
 
 ※ ベクトルタイルは軽量化のため上記の属性に絞って配信しています
@@ -72,7 +72,7 @@ map.addSource("facilities", {
   tiles: [
     "https://food.japan-facilities.com/api/tiles/{z}/{x}/{y}.pbf",
   ],
-  minzoom: 6,
+  minzoom: 3,
   maxzoom: 12,
   attribution:
     '出典：<a href="https://gl20percentclub.github.io/japan-food-facilities/">Japan Food Facilities</a>（<a href="https://gl20percentclub.github.io/japan-food-facilities/attribution.html" target=">自治体・厚生労働省が公開する食品営業許可オープンデータを加工して作成</a>）',

--- a/scripts/build/tiles.js
+++ b/scripts/build/tiles.js
@@ -31,7 +31,12 @@ const ROOT = path.resolve(__dirname, '..', '..');
 const TILES_DIR = path.join(ROOT, 'api', 'tiles');
 const LAYER = 'facilities';
 
-const MIN_ZOOM = Number(process.env.TILES_MIN_ZOOM ?? 6);
+// 最小ズーム。プレビュー地図（site/map.html）が地図自体の下限を z3 にしているため、
+// z3 まで焼いておけば「引くと点が消える」ズームが無くなる。
+// 間引き後は低ズームのコストがほぼ無い（z3〜z5 の 3 ズームを足しても gzip 前で +5.7MB。
+// タイル数が 3/3/6 枚しかないため）ので、下限を上げて節約する意味がない。
+// 逆に z6 開始だと初期表示で日本全体が入らず、狭い範囲を密なタイルで埋めることになる。
+const MIN_ZOOM = Number(process.env.TILES_MIN_ZOOM ?? 3);
 const MAX_ZOOM = Number(process.env.TILES_MAX_ZOOM ?? 12);
 // gzip の圧縮レベル。9 にしても縮むのは 1% 未満で、タイル数が数万枚あるぶん
 // 生成時間だけが伸びるため既定の 6 を使う。

--- a/scripts/preview-map.test.js
+++ b/scripts/preview-map.test.js
@@ -51,7 +51,7 @@ async function withTiles(opts, fn) {
 
 await test('source-layer が タイル生成の出力レイヤ名(metadata.vector_layers[0].id)と一致する', async () => {
   const sourceLayer = htmlValue(/'source-layer':\s*'([^']+)'/, 'source-layer');
-  await withTiles({ minZoom: 6, maxZoom: 12 }, (meta) => {
+  await withTiles({ minZoom: 3, maxZoom: 12 }, (meta) => {
     assert.equal(sourceLayer, meta.vector_layers[0].id, `source-layer(${sourceLayer}) == 生成レイヤ(${meta.vector_layers[0].id})`);
   });
 });
@@ -67,14 +67,19 @@ await test('TILE_MIN_ZOOM / TILE_MAX_ZOOM が タイル生成の既定ズーム�
 });
 
 await test('初期ズームがタイルの最小ズーム以上で、開いた直後から点が出る', async () => {
-  // fitBounds で全国を収めると z5 以下になり、タイルが無くて点が1つも出ない。
-  // 初期ズームはタイルの最小ズームに合わせる（定数を直接使っていることも確認する）。
-  assert.ok(/zoom: TILE_MIN_ZOOM/.test(HTML), '初期ズームに TILE_MIN_ZOOM を使う');
+  // タイルが無いズームで開くと点が1つも出ない。初期ズームは必ずタイルの
+  // 最小ズーム以上にする（定数を直接使っていることも確認する）。
+  assert.ok(/zoom: INITIAL_ZOOM/.test(HTML), '初期ズームに INITIAL_ZOOM を使う');
   assert.ok(!/fitBoundsOptions/.test(HTML), '全国 fitBounds で初期表示していない');
   await withTiles({}, (meta) => {
-    const minZoom = Number(htmlValue(/TILE_MIN_ZOOM\s*=\s*(\d+)/, 'TILE_MIN_ZOOM'));
-    assert.ok(minZoom >= meta.minzoom, `初期ズーム(${minZoom}) がタイルの最小ズーム(${meta.minzoom})以上`);
+    const initialZoom = Number(htmlValue(/INITIAL_ZOOM\s*=\s*(\d+)/, 'INITIAL_ZOOM'));
+    assert.ok(
+      initialZoom >= meta.minzoom,
+      `初期ズーム(${initialZoom}) がタイルの最小ズーム(${meta.minzoom})以上`,
+    );
   });
+  // 地図の下限がタイルの最小ズームより下だと、引いたときに点が消えるズームに到達できる。
+  assert.ok(/minZoom: TILE_MIN_ZOOM/.test(HTML), '地図の下限をタイルの最小ズームに揃える');
   // 初期中心が日本の範囲（タイルの bounds）に収まっていること。
   const center = htmlValue(/INITIAL_CENTER = \[([^\]]+)\]/, 'INITIAL_CENTER')
     .split(',').map((v) => Number(v.trim()));
@@ -89,7 +94,7 @@ await test('タイルURLテンプレートが「api/tiles/ + metadata.tiles[0]�
   // API_BASE と組み立て後のパスを突き合わせ、配信物の配置と一致するか検証する。
   const apiBase = htmlValue(/API_BASE\s*=\s*'([^']+)'/, 'API_BASE');
   assert.ok(apiBase.endsWith('/api'), `API_BASE(${apiBase}) が api/ を指す`);
-  await withTiles({ minZoom: 6, maxZoom: 12 }, (meta) => {
+  await withTiles({ minZoom: 3, maxZoom: 12 }, (meta) => {
     const expectedPath = `\${API_BASE}/tiles/${meta.tiles[0]}`; // = ${API_BASE}/tiles/{z}/{x}/{y}.pbf
     assert.ok(HTML.includes(expectedPath), `map.html がタイルパス ${expectedPath} を参照する`);
     // 組み立て結果が生成物の配置（api/tiles/{z}/{x}/{y}.pbf）と一致することを確認する。
@@ -127,7 +132,7 @@ await test('ヘッダーの統計が参照する metadata.stats のキーがす�
   // 統計用の JSON は配信しないため、件数は metadata.json（TileJSON）から読む。
   const referenced = new Set([...HTML.matchAll(/\bstats\.([a-z_]+)\b/g)].map((m) => m[1]));
   assert.ok(referenced.size >= 1, `map.html が metadata.stats を参照している (${[...referenced].join(',')})`);
-  await withTiles({ minZoom: 6, maxZoom: 12 }, (meta) => {
+  await withTiles({ minZoom: 3, maxZoom: 12 }, (meta) => {
     for (const key of referenced) {
       assert.ok(key in meta.stats, `metadata.stats.${key} が生成される`);
     }

--- a/site/llms-full.txt
+++ b/site/llms-full.txt
@@ -50,7 +50,7 @@ https://food.japan-facilities.com/api/facilities-all.csv
 | ------------- | ------------------------------------------------------------- |
 | タイルURL        | `https://food.japan-facilities.com/api/tiles/{z}/{x}/{y}.pbf` |
 | Source layer名 | `facilities`                                                  |
-| 対応ズーム         | `6`〜`12`                                                      |
+| 対応ズーム         | `3`〜`12`                                                      |
 | 属性          | `name`（施設名） / `business_type`（営業許可・届出の業種） / `pref`（都道府県名） / `city`（市区町村名）                    |
 
 ※ ベクトルタイルは軽量化のため上記の属性に絞って配信しています
@@ -65,7 +65,7 @@ map.addSource("facilities", {
   tiles: [
     "https://food.japan-facilities.com/api/tiles/{z}/{x}/{y}.pbf",
   ],
-  minzoom: 6,
+  minzoom: 3,
   maxzoom: 12,
   attribution:
     '出典：<a href="https://gl20percentclub.github.io/japan-food-facilities/">Japan Food Facilities</a>（<a href="https://gl20percentclub.github.io/japan-food-facilities/attribution.html" target=">自治体・厚生労働省が公開する食品営業許可オープンデータを加工して作成</a>）',

--- a/site/map.html
+++ b/site/map.html
@@ -205,13 +205,15 @@
     // CORS は全オリジン許可済みなので、ローカルで開いた場合もそのまま読める。
     const API_BASE = 'https://food.japan-facilities.com/api';
     // ベクトルタイルのズーム範囲（scripts/build/tiles.js の設定と一致させる）
-    const TILE_MIN_ZOOM = 6;
+    const TILE_MIN_ZOOM = 3;
     const TILE_MAX_ZOOM = 12;
     // 日本のおおよその範囲 [west, south, east, north]
     const JAPAN_BOUNDS = [122, 20, 154, 46];
-    // 初期表示の中心（本州中央部あたり）。ズームはタイルの最小ズームに合わせるため、
-    // 全国を収める fitBounds ではなく中心＋ズーム指定で開く。
+    // 初期表示の中心（本州中央部あたり）。
     const INITIAL_CENTER = [138.2, 36.4];
+    // 初期表示のズーム。z4 で北海道から沖縄までが1画面に収まる。
+    // タイルの最小ズーム（z3）まで焼いてあるので、最小ズームと揃える必要はない。
+    const INITIAL_ZOOM = 4;
 
     // 業種の分類は食品衛生法の定義に合わせる。
     //   営業許可 32業種（食品衛生法施行令 第35条。2021年6月施行）を法令の区分
@@ -389,11 +391,12 @@
           },
         ],
       },
-      // 開いた直後から施設の点が見えるよう、初期ズームをタイルの最小ズームに合わせる
-      // （全国を収める fitBounds だと z5 以下になり、タイルが無くて点が出ない）。
+      // 開いた直後から全国の点が見えるズームで開く（INITIAL_ZOOM の定義を参照）。
       center: INITIAL_CENTER,
-      zoom: TILE_MIN_ZOOM,
-      minZoom: 3,
+      zoom: INITIAL_ZOOM,
+      // 地図の下限はタイルの最小ズームと揃える。これより引けるようにすると
+      // タイルが無いズームに到達でき、点が消えて見える。
+      minZoom: TILE_MIN_ZOOM,
       maxZoom: 18,
       attributionControl: false,
     });


### PR DESCRIPTION
## 背景

低ズームのグリッド間引き（#96）が入って、低ズームのタイルが劇的に軽くなった。
下限を z6 に留める理由が無くなったので、z3 まで焼いて「引くと点が消える」状態を無くす。

もともと `site/map.html` は地図の下限が `minZoom: 3` なのにタイルの下限は z6 で、
**z3〜z5 では点が1つも出ない**状態だった（初期ズームを z6 に縛ることで隠していた）。

## 変更

- タイル生成の最小ズームを z6 → z3
- 地図の初期ズームを `INITIAL_ZOOM`(=4) として最小ズームから独立させる。z4 で北海道から沖縄までが1画面に収まる
- 地図の下限 `minZoom` をタイルの最小ズームに揃える（ずれを構造的に無くす）
- README / AGENTS.md / llms-full.txt の対応ズームを z3〜z12 に更新

## 低ズームは実質無料

配信中の全件CSV（1,263,141点）から生成した実測値:

| z | 枚数 | 合計(gzip前) | 最大タイル |
|---|---:|---:|---:|
| z3 | 3 | 1.7 MB | 1.07 MB |
| z4 | 3 | 1.8 MB | 1.16 MB |
| z5 | 6 | 2.2 MB | 1.38 MB |
| z6（従来の下限） | 17 | 3.1 MB | 1.40 MB |

**追加コストは +5.7MB（全体 119MB の 5%）だけ。** 低ズームはタイル数が指数的に少ないため。

## 初期表示は範囲が広がって転送量が減る

| | 表示範囲 | 転送量 |
|---|---|---:|
| z6 開始（従来） | 関東〜近畿のみ | 2.09 MB |
| **z4 開始** | **北海道〜沖縄 全国** | **1.82 MB**（gzip 後 0.50MB） |

z6 開始のほうが重いのは、狭い範囲を密なタイルで何枚も埋めるため。

## 確認

- `npm run test:unit` 全通（build/tiles 21件、preview-map 7件ほか全12スイート）
- ローカルに配信中の全件CSV からタイルを生成し、`site/map.html` を実ブラウザ（Playwright）で表示
  - z2 / z3 / z4 / z6 / z10 / z13 で MapLibre のエラー **0件**
  - z4 で全国 64,977点、z10 東京で 53,276点を描画
  - z3〜z11 は `count` あり・`name` なし、z13（z12のoverzoom）は `name` あり・`count` なし＝間引きの設計どおり
- `scripts/preview-map.test.js` に「地図の下限とタイルの最小ズームが一致する」検査を追加し、再発を防いだ

## 関連

- #96（間引きと gzip。本PRの前提）