### PR TITLE
代表点を「1施設」と誤解させる地図の表示を直す

### DIFF
--- a/scripts/preview-map.test.js
+++ b/scripts/preview-map.test.js
@@ -148,4 +148,25 @@ await test('廃止した配信形式を参照していない', async () => {
   }
 });
 
+await test('代表点の表示が「1施設」と誤解されない文言になっている', async () => {
+  // 最大ズーム未満のタイルは代表点（name を持たず count に件数が入る）。
+  // 「各点＝1施設」「（名称なし）」のままだと、点の数を施設数と読まれたり、
+  // 元データに名前が無い施設と区別がつかなくなる。
+  const fc = buildFeatureCollection(FACILITIES);
+  const thinned = thinFeatures(fc.features, 6);
+  assert.ok(thinned.length >= 1, '間引き後も点が残る');
+  for (const f of thinned) {
+    assert.ok(!('name' in f.properties), '代表点に name は載らない');
+    assert.ok(Number.isInteger(f.properties.count), 'count に件数が入る');
+  }
+
+  // 凡例をズームで出し分ける（要素と、間引き中の文言の両方を固定する）
+  assert.ok(/id="legend-text"/.test(HTML), '凡例を差し替える要素がある');
+  assert.ok(HTML.includes('各点＝付近の施設をまとめた代表'), '間引き中の凡例文言がある');
+
+  // ポップアップは count の有無で代表点を判定し、件数を見出しに出す
+  assert.ok(/props\.count !== undefined/.test(HTML), '代表点かどうかを count の有無で判定する');
+  assert.ok(HTML.includes('この付近に '), '代表点のポップアップは件数を見出しに出す');
+});
+
 console.log(`\n✅ preview-map 整合性テスト: ${passed}件すべて合格`);

--- a/site/map.html
+++ b/site/map.html
@@ -186,7 +186,7 @@
     </div>
 
     <p class="meta-line">
-      <span class="legend-dot"></span>各点＝1施設
+      <span class="legend-dot"></span><span id="legend-text">各点＝1施設</span>
       <span id="updated"></span><br>
       <a href="./">トップ</a> ·
       <a href="https://github.com/gl20percentclub/japan-food-facilities">GitHub</a> ·
@@ -420,6 +420,19 @@
     map.on('zoom', updateHint);
     map.on('load', updateHint);
 
+    // --- 凡例の表示制御 ---
+    // 最大ズーム未満のタイルは、重なって区別できない施設を 1 点にまとめた代表点で
+    // 構成される（scripts/build/tiles.js の間引き）。「各点＝1施設」と出したままだと
+    // 点の数を施設数として読まれてしまうため、ズームで文言を出し分ける。
+    const legendEl = $('legend-text');
+    /** 現在のズームが間引きの対象かどうかで凡例の文言を切り替える。 */
+    function updateLegend() {
+      legendEl.textContent =
+        map.getZoom() >= TILE_MAX_ZOOM ? '各点＝1施設' : '各点＝付近の施設をまとめた代表';
+    }
+    map.on('zoom', updateLegend);
+    map.on('load', updateLegend);
+
     // ================= 業種フィルター =================
     /** business_type にキーワードを含むかどうかの式（部分一致）。 */
     const contains = (keyword) => ['in', keyword, ['get', 'business_type']];
@@ -527,16 +540,32 @@
     /**
      * 属性オブジェクトからポップアップの HTML を組み立てる（純粋な文字列生成）。
      * `name` は見出しに使い、それ以外の値のある属性をラベル付きの行にする。
+     *
+     * 最大ズーム未満のタイルは、同じ地点・同じ業種・同じ自治体の施設が 1 点に
+     * まとめられている（代表点。`name` を持たず、まとめた件数が `count` に入る）。
+     * 代表点は件数を見出しにし、名前が見られる条件を添える。ここで「（名称なし）」と
+     * 出すと、元データに名前が無い施設（最大ズームで実在する）と区別がつかなくなる。
+     * `count` の有無で代表点かどうかを判定する（件数が 1 でも代表点は代表点）。
      */
     function popupHtml(props, labels) {
       const rows = [];
+      const isRepresentative = !props.name && props.count !== undefined && props.count !== null;
       for (const [key, value] of Object.entries(props)) {
         // 見出しに使う name と、空文字・null・undefined の属性は行にしない。
         if (key === 'name') continue;
+        // 代表点では件数を見出しに出すので、行としては重複させない。
+        if (key === 'count' && isRepresentative) continue;
         if (value === null || value === undefined || value === '') continue;
         rows.push(`<p class="fac-row"><span class="k">${esc(labels[key] || key)}</span>${esc(value)}</p>`);
       }
-      const title = props.name ? esc(props.name) : '（名称なし）';
+      if (isRepresentative) {
+        rows.push('<p class="fac-row">施設名はズームを上げると表示されます</p>');
+      }
+      const title = props.name
+        ? esc(props.name)
+        : isRepresentative
+          ? `この付近に ${Number(props.count).toLocaleString('ja-JP')} 件`
+          : '（名称なし）';
       return `<p class="fac-name">${title}</p>${rows.join('')}`;
     }
 


### PR DESCRIPTION
## 問題

#96 で低ズームのタイルが間引き済みになり、z3〜z11 の点は「同じ地点・同じ業種・同じ自治体の施設をまとめた**代表点**」になった。ところが `site/map.html` 側の文言が追従しておらず、**配信データと表示が食い違っている**。

手動クロールを回して新しいタイルが配信された今、公開中の地図で実際に起きている:

| 箇所 | 現在の表示 | 実際 |
|---|---|---|
| 凡例 | 「各点＝1施設」（ハードコード） | z3〜z11 は代表点。点の数 ≠ 施設数 |
| ポップアップ | 「（名称なし）」 | 代表点なので `name` が無いだけ |

配信中の z4 タイルを解凍して確認したところ、属性に `name` は含まれず `count` が入っている（間引きの設計どおり）。表示だけが古い。

「（名称なし）」は特に紛らわしく、**元データに名前が無い施設**（最大ズームで実在する）と区別がつかない。

## 変更

- 凡例に `id="legend-text"` を付け、ズームで文言を出し分ける
  - `z12以上` → 「各点＝1施設」
  - それ未満 → 「各点＝付近の施設をまとめた代表」
- ポップアップは `count` の有無で代表点を判定し、「この付近に N 件」を見出しにする
  - 件数は見出しに出すので行としては重複させない
  - 「施設名はズームを上げると表示されます」を添える
  - 件数が 1 でも代表点は代表点（`count` の有無で判定し、値では判定しない）

## テスト

`scripts/preview-map.test.js` に、間引き後の feature の形（`name` なし・`count` あり）と地図側の文言が対応していることの検査を追加。生成物と HTML を突き合わせるので、片方だけ変えると落ちる。

`npm run test:unit` 全通（preview-map 8件、build/tiles 21件ほか全12スイート）。

## 実物での確認

**配信中の本物のタイル**（手動クロール後、z3-12・間引き済み・gzip）に対して、この変更を入れた map.html をローカルから読ませて確認した:

- z4（初期表示）で凡例が「**各点＝付近の施設をまとめた代表**」に切り替わる
- 代表点をクリックすると:
  ```
  この付近に 1 件
  業種      ㉕ そうざい製造業
  都道府県  長野県
  市区町村  松本市
  施設名はズームを上げると表示されます
  ```
  「（名称なし）」が出なくなった

## 関連

- #96（間引きと gzip）
- #98（最小ズームを z3 に）