### PR TITLE
CKAN標準URL形状の10ソースを get 型から ckan 型に移行する

### DIFF
--- a/config/sources.yaml
+++ b/config/sources.yaml
@@ -214,10 +214,9 @@ sources:
     defaultCity: 大阪市
   - key: tokyo-minato
     acquire:
-      type: get
-      url: https://opendata.city.minato.tokyo.jp/dataset/54d8c582-00e2-4730-a23f-4a5befec9ae5/resource/c9d0299e-8e05-4317-877f-83055709e41f/download/food_business_all.csv
-      format: csv
-      encoding: utf-8
+      type: ckan
+      ckanBase: https://opendata.city.minato.tokyo.jp
+      resourceId: c9d0299e-8e05-4317-877f-83055709e41f
     source: 東京都港区食品営業許可一覧
     sourceUrl: https://opendata.city.minato.tokyo.jp/dataset/54d8c582-00e2-4730-a23f-4a5befec9ae5
     license: CC BY 4.0
@@ -443,10 +442,9 @@ sources:
     license: Creative Commons Attribution 4.0 International
   - key: sapporo
     acquire:
-      type: get
-      url: https://ckan.pf-sapporo.jp/dataset/be44af14-f135-41b9-acca-08e215d8a540/resource/54618ac4-da90-493c-8a20-8df29be9d435/download/shokuhin260331.csv
-      format: csv
-      encoding: utf-8
+      type: ckan
+      ckanBase: https://ckan.pf-sapporo.jp
+      resourceId: 54618ac4-da90-493c-8a20-8df29be9d435
     source: 札幌市食品営業許可施設一覧
     sourceUrl: https://ckan.pf-sapporo.jp/dataset/be44af14-f135-41b9-acca-08e215d8a540
     license: CC BY 4.0
@@ -529,10 +527,9 @@ sources:
     defaultCity: いわき市
   - key: utsunomiya
     acquire:
-      type: get
-      url: https://catalog.city.utsunomiya.tochigi.jp/dataset/4b5cae93-4640-4b4e-87bb-a5e18042366c/resource/a53500f2-7ba1-4e77-a906-e17dc5b60714/download/092011_seikatsueisei_shokuhin_shokuhin.csv
-      format: csv
-      encoding: utf-8
+      type: ckan
+      ckanBase: https://catalog.city.utsunomiya.tochigi.jp
+      resourceId: a53500f2-7ba1-4e77-a906-e17dc5b60714
     source: 宇都宮市食品営業許可施設一覧
     sourceUrl: https://catalog.city.utsunomiya.tochigi.jp/dataset/4b5cae93-4640-4b4e-87bb-a5e18042366c
     license: CC BY 4.0
@@ -692,9 +689,9 @@ sources:
     defaultPref: 富山県
   - key: toyama-city
     acquire:
-      type: get
-      url: https://opdt.city.toyama.lg.jp/dataset/fb1198c6-3ac2-42fc-ae99-81ea5ba09a2d/resource/fa38003f-accd-4690-b71b-96b1d78e1c45/download/syokuhin.xlsx
-      format: xlsx
+      type: ckan
+      ckanBase: https://opdt.city.toyama.lg.jp
+      resourceId: fa38003f-accd-4690-b71b-96b1d78e1c45
     source: 富山市食品営業許可施設
     sourceUrl: https://opdt.city.toyama.lg.jp/dataset/fb1198c6-3ac2-42fc-ae99-81ea5ba09a2d
     # 富山市オープンデータ利用規約（https://opdt.city.toyama.lg.jp/pages/terms）が表示4.0国際を指定
@@ -773,20 +770,18 @@ sources:
     defaultCity: 松本市
   - key: gifu-pref
     acquire:
-      type: get
-      url: https://gifu-opendata.pref.gifu.lg.jp/dataset/f6bbdb66-1d55-4e55-82cb-15fe1bb24223/resource/3c7d862d-a126-4441-a5b1-4839096b2591/download/20250331syokuhin.csv
-      format: csv
-      encoding: utf-8
+      type: ckan
+      ckanBase: https://gifu-opendata.pref.gifu.lg.jp
+      resourceId: 3c7d862d-a126-4441-a5b1-4839096b2591
     source: 岐阜県食品営業許可施設情報
     sourceUrl: https://gifu-opendata.pref.gifu.lg.jp/dataset/f6bbdb66-1d55-4e55-82cb-15fe1bb24223
     license: CC BY 2.0
     defaultPref: 岐阜県
   - key: gifu-city
     acquire:
-      type: get
-      url: https://gifu-opendata.pref.gifu.lg.jp/dataset/2f9f1b1c-be25-4a27-96c6-47b597f1a0bd/resource/16ef7794-d2b6-4d7d-8353-f55193432530/download/gifushisyokuhinkyokar7.6.1.csv
-      format: csv
-      encoding: utf-8
+      type: ckan
+      ckanBase: https://gifu-opendata.pref.gifu.lg.jp
+      resourceId: 16ef7794-d2b6-4d7d-8353-f55193432530
     source: 岐阜市食品等営業許可一覧
     sourceUrl: https://gifu-opendata.pref.gifu.lg.jp/dataset/2f9f1b1c-be25-4a27-96c6-47b597f1a0bd
     license: CC BY 2.0
@@ -920,10 +915,9 @@ sources:
     defaultCity: 鳥取市
   - key: fukuyama
     acquire:
-      type: get
-      url: https://data.city.fukuyama.hiroshima.jp/dataset/61f415c5-88f7-46d0-8ada-4bb8855685a0/resource/21fec913-dc08-4344-94d1-ffb0068ab147/download/2026_3all.csv
-      format: csv
-      encoding: auto
+      type: ckan
+      ckanBase: https://data.city.fukuyama.hiroshima.jp
+      resourceId: 21fec913-dc08-4344-94d1-ffb0068ab147
     source: 福山市営業許認可等施設一覧
     sourceUrl: https://data.city.fukuyama.hiroshima.jp/dataset/61f415c5-88f7-46d0-8ada-4bb8855685a0
     # 福山市オープンデータカタログサイト利用規約（https://data.city.fukuyama.hiroshima.jp/terms）が PDL1.0 を適用
@@ -932,10 +926,9 @@ sources:
     defaultCity: 福山市
   - key: yamaguchi-pref
     acquire:
-      type: get
-      url: https://yamaguchi-opendata.jp/ckan/dataset/9d0d2325-62b4-447c-8817-a381c968a5cd/resource/44efb857-48c7-4a2e-9e99-61bf38f6f125/download/350001_food_business_all.csv
-      format: csv
-      encoding: utf-8
+      type: ckan
+      ckanBase: https://yamaguchi-opendata.jp/ckan
+      resourceId: 44efb857-48c7-4a2e-9e99-61bf38f6f125
     source: 山口県食品営業許可施設情報一覧
     sourceUrl: https://yamaguchi-opendata.jp/ckan/dataset/9d0d2325-62b4-447c-8817-a381c968a5cd
     # 山口県オープンデータカタログサイト利用規約（https://yamaguchi-opendata.jp/www/terms.html）が CC BY 4.0 での利用を許諾
@@ -943,10 +936,9 @@ sources:
     defaultPref: 山口県
   - key: shimonoseki
     acquire:
-      type: get
-      url: https://yamaguchi-opendata.jp/ckan/dataset/50c21bfa-4ee1-4553-b166-8ed2e625a6f5/resource/f61a61f9-a9ca-448f-8e48-38f647fd2539/download/352012_food_business_map.csv
-      format: csv
-      encoding: utf-8
+      type: ckan
+      ckanBase: https://yamaguchi-opendata.jp/ckan
+      resourceId: f61a61f9-a9ca-448f-8e48-38f647fd2539
     source: 下関市食品営業許可施設一覧（マップ用）
     sourceUrl: https://yamaguchi-opendata.jp/ckan/dataset/50c21bfa-4ee1-4553-b166-8ed2e625a6f5
     # 山口県オープンデータカタログサイト利用規約（https://yamaguchi-opendata.jp/www/terms.html）が CC BY 4.0 での利用を許諾
@@ -1016,10 +1008,9 @@ sources:
     defaultCity: 大分市
   - key: sagamihara
     acquire:
-      type: get
-      url: https://opendata.city.sagamihara.kanagawa.jp/dataset/eigyo_kyoka/resource/1be0eb65-0348-4668-a440-0ce10cad1063/download/04.zip
-      format: zip
-      encoding: auto
+      type: ckan
+      ckanBase: https://opendata.city.sagamihara.kanagawa.jp
+      resourceId: 1be0eb65-0348-4668-a440-0ce10cad1063
     source: 相模原市食品衛生関係施設一覧（営業許可）
     sourceUrl: https://opendata.city.sagamihara.kanagawa.jp/dataset/eigyo_kyoka
     license: CC BY 4.0

--- a/site/attribution.html
+++ b/site/attribution.html
@@ -211,7 +211,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://catalog.city.utsunomiya.tochigi.jp/dataset/4b5cae93-4640-4b4e-87bb-a5e18042366c" target="_blank" rel="noopener">https://catalog.city.utsunomiya.tochigi.jp/dataset/4b5cae93-4640-4b4e-87bb-a5e18042366c</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://catalog.city.utsunomiya.tochigi.jp/dataset/4b5cae93-4640-4b4e-87bb-a5e18042366c/resource/a53500f2-7ba1-4e77-a906-e17dc5b60714/download/092011_seikatsueisei_shokuhin_shokuhin.csv" target="_blank" rel="noopener">https://catalog.city.utsunomiya.tochigi.jp/dataset/4b5cae93-4640-4b4e-8…</a></dd>
+          <dd><a href="https://catalog.city.utsunomiya.tochigi.jp/api/3/action/resource_show?id=a53500f2-7ba1-4e77-a906-e17dc5b60714" target="_blank" rel="noopener">https://catalog.city.utsunomiya.tochigi.jp/api/3/action/resource_show?i…</a></dd>
         </dl>
         
         <div class="attr">
@@ -267,7 +267,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://yamaguchi-opendata.jp/ckan/dataset/50c21bfa-4ee1-4553-b166-8ed2e625a6f5" target="_blank" rel="noopener">https://yamaguchi-opendata.jp/ckan/dataset/50c21bfa-4ee1-4553-b166-8ed2e625a6f5</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://yamaguchi-opendata.jp/ckan/dataset/50c21bfa-4ee1-4553-b166-8ed2e625a6f5/resource/f61a61f9-a9ca-448f-8e48-38f647fd2539/download/352012_food_business_map.csv" target="_blank" rel="noopener">https://yamaguchi-opendata.jp/ckan/dataset/50c21bfa-4ee1-4553-b166-8ed2…</a></dd>
+          <dd><a href="https://yamaguchi-opendata.jp/ckan/api/3/action/resource_show?id=f61a61f9-a9ca-448f-8e48-38f647fd2539" target="_blank" rel="noopener">https://yamaguchi-opendata.jp/ckan/api/3/action/resource_show?id=f61a61…</a></dd>
         </dl>
         
         <div class="attr">
@@ -351,7 +351,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://opendata.city.minato.tokyo.jp/dataset/54d8c582-00e2-4730-a23f-4a5befec9ae5" target="_blank" rel="noopener">https://opendata.city.minato.tokyo.jp/dataset/54d8c582-00e2-4730-a23f-4a5befec9ae5</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://opendata.city.minato.tokyo.jp/dataset/54d8c582-00e2-4730-a23f-4a5befec9ae5/resource/c9d0299e-8e05-4317-877f-83055709e41f/download/food_business_all.csv" target="_blank" rel="noopener">https://opendata.city.minato.tokyo.jp/dataset/54d8c582-00e2-4730-a23f-4…</a></dd>
+          <dd><a href="https://opendata.city.minato.tokyo.jp/api/3/action/resource_show?id=c9d0299e-8e05-4317-877f-83055709e41f" target="_blank" rel="noopener">https://opendata.city.minato.tokyo.jp/api/3/action/resource_show?id=c9d…</a></dd>
         </dl>
         
         <div class="attr">
@@ -421,7 +421,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://ckan.pf-sapporo.jp/dataset/be44af14-f135-41b9-acca-08e215d8a540" target="_blank" rel="noopener">https://ckan.pf-sapporo.jp/dataset/be44af14-f135-41b9-acca-08e215d8a540</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://ckan.pf-sapporo.jp/dataset/be44af14-f135-41b9-acca-08e215d8a540/resource/54618ac4-da90-493c-8a20-8df29be9d435/download/shokuhin260331.csv" target="_blank" rel="noopener">https://ckan.pf-sapporo.jp/dataset/be44af14-f135-41b9-acca-08e215d8a540…</a></dd>
+          <dd><a href="https://ckan.pf-sapporo.jp/api/3/action/resource_show?id=54618ac4-da90-493c-8a20-8df29be9d435" target="_blank" rel="noopener">https://ckan.pf-sapporo.jp/api/3/action/resource_show?id=54618ac4-da90-…</a></dd>
         </dl>
         
         <div class="attr">
@@ -463,7 +463,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://yamaguchi-opendata.jp/ckan/dataset/9d0d2325-62b4-447c-8817-a381c968a5cd" target="_blank" rel="noopener">https://yamaguchi-opendata.jp/ckan/dataset/9d0d2325-62b4-447c-8817-a381c968a5cd</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://yamaguchi-opendata.jp/ckan/dataset/9d0d2325-62b4-447c-8817-a381c968a5cd/resource/44efb857-48c7-4a2e-9e99-61bf38f6f125/download/350001_food_business_all.csv" target="_blank" rel="noopener">https://yamaguchi-opendata.jp/ckan/dataset/9d0d2325-62b4-447c-8817-a381…</a></dd>
+          <dd><a href="https://yamaguchi-opendata.jp/ckan/api/3/action/resource_show?id=44efb857-48c7-4a2e-9e99-61bf38f6f125" target="_blank" rel="noopener">https://yamaguchi-opendata.jp/ckan/api/3/action/resource_show?id=44efb8…</a></dd>
         </dl>
         
         <div class="attr">
@@ -673,7 +673,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://opendata.city.sagamihara.kanagawa.jp/dataset/eigyo_kyoka" target="_blank" rel="noopener">https://opendata.city.sagamihara.kanagawa.jp/dataset/eigyo_kyoka</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://opendata.city.sagamihara.kanagawa.jp/dataset/eigyo_kyoka/resource/1be0eb65-0348-4668-a440-0ce10cad1063/download/04.zip" target="_blank" rel="noopener">https://opendata.city.sagamihara.kanagawa.jp/dataset/eigyo_kyoka/resour…</a></dd>
+          <dd><a href="https://opendata.city.sagamihara.kanagawa.jp/api/3/action/resource_show?id=1be0eb65-0348-4668-a440-0ce10cad1063" target="_blank" rel="noopener">https://opendata.city.sagamihara.kanagawa.jp/api/3/action/resource_show…</a></dd>
         </dl>
         
         <div class="attr">
@@ -925,7 +925,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://opdt.city.toyama.lg.jp/dataset/fb1198c6-3ac2-42fc-ae99-81ea5ba09a2d" target="_blank" rel="noopener">https://opdt.city.toyama.lg.jp/dataset/fb1198c6-3ac2-42fc-ae99-81ea5ba09a2d</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://opdt.city.toyama.lg.jp/dataset/fb1198c6-3ac2-42fc-ae99-81ea5ba09a2d/resource/fa38003f-accd-4690-b71b-96b1d78e1c45/download/syokuhin.xlsx" target="_blank" rel="noopener">https://opdt.city.toyama.lg.jp/dataset/fb1198c6-3ac2-42fc-ae99-81ea5ba0…</a></dd>
+          <dd><a href="https://opdt.city.toyama.lg.jp/api/3/action/resource_show?id=fa38003f-accd-4690-b71b-96b1d78e1c45" target="_blank" rel="noopener">https://opdt.city.toyama.lg.jp/api/3/action/resource_show?id=fa38003f-a…</a></dd>
         </dl>
         
         <div class="attr">
@@ -1217,7 +1217,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://gifu-opendata.pref.gifu.lg.jp/dataset/f6bbdb66-1d55-4e55-82cb-15fe1bb24223" target="_blank" rel="noopener">https://gifu-opendata.pref.gifu.lg.jp/dataset/f6bbdb66-1d55-4e55-82cb-15fe1bb24223</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://gifu-opendata.pref.gifu.lg.jp/dataset/f6bbdb66-1d55-4e55-82cb-15fe1bb24223/resource/3c7d862d-a126-4441-a5b1-4839096b2591/download/20250331syokuhin.csv" target="_blank" rel="noopener">https://gifu-opendata.pref.gifu.lg.jp/dataset/f6bbdb66-1d55-4e55-82cb-1…</a></dd>
+          <dd><a href="https://gifu-opendata.pref.gifu.lg.jp/api/3/action/resource_show?id=3c7d862d-a126-4441-a5b1-4839096b2591" target="_blank" rel="noopener">https://gifu-opendata.pref.gifu.lg.jp/api/3/action/resource_show?id=3c7…</a></dd>
         </dl>
         
         <div class="attr">
@@ -1231,7 +1231,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://gifu-opendata.pref.gifu.lg.jp/dataset/2f9f1b1c-be25-4a27-96c6-47b597f1a0bd" target="_blank" rel="noopener">https://gifu-opendata.pref.gifu.lg.jp/dataset/2f9f1b1c-be25-4a27-96c6-47b597f1a0bd</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://gifu-opendata.pref.gifu.lg.jp/dataset/2f9f1b1c-be25-4a27-96c6-47b597f1a0bd/resource/16ef7794-d2b6-4d7d-8353-f55193432530/download/gifushisyokuhinkyokar7.6.1.csv" target="_blank" rel="noopener">https://gifu-opendata.pref.gifu.lg.jp/dataset/2f9f1b1c-be25-4a27-96c6-4…</a></dd>
+          <dd><a href="https://gifu-opendata.pref.gifu.lg.jp/api/3/action/resource_show?id=16ef7794-d2b6-4d7d-8353-f55193432530" target="_blank" rel="noopener">https://gifu-opendata.pref.gifu.lg.jp/api/3/action/resource_show?id=16e…</a></dd>
         </dl>
         
         <div class="attr">
@@ -1309,7 +1309,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://data.city.fukuyama.hiroshima.jp/dataset/61f415c5-88f7-46d0-8ada-4bb8855685a0" target="_blank" rel="noopener">https://data.city.fukuyama.hiroshima.jp/dataset/61f415c5-88f7-46d0-8ada-4bb8855685a0</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://data.city.fukuyama.hiroshima.jp/dataset/61f415c5-88f7-46d0-8ada-4bb8855685a0/resource/21fec913-dc08-4344-94d1-ffb0068ab147/download/2026_3all.csv" target="_blank" rel="noopener">https://data.city.fukuyama.hiroshima.jp/dataset/61f415c5-88f7-46d0-8ada…</a></dd>
+          <dd><a href="https://data.city.fukuyama.hiroshima.jp/api/3/action/resource_show?id=21fec913-dc08-4344-94d1-ffb0068ab147" target="_blank" rel="noopener">https://data.city.fukuyama.hiroshima.jp/api/3/action/resource_show?id=2…</a></dd>
         </dl>
         <span class="badge">元の表記: 公共データ利用規約（第1.0版, PDL1.0）</span>
         <div class="attr">


### PR DESCRIPTION
## 概要

`get` 型で取得URLを直書きしていたソースのうち、CKAN標準ダウンロードURL形状
（`/dataset/{id}/resource/{id}/download/{filename}`）を持つ12件について、
`resource_show` API の実測疎通確認を行い、使えると確認できた10件を `ckan` 型に移行した。

## 移行した10件・見送った2件と理由

**移行した10件**（`get` → `ckan`。既存24件のBODIK型と同じ書き方に統一）:

- tokyo-minato（東京都港区） / sapporo（札幌市） / utsunomiya（宇都宮市） /
  toyama-city（富山市） / gifu-pref（岐阜県） / gifu-city（岐阜市） /
  fukuyama（福山市） / yamaguchi-pref（山口県） / shimonoseki（下関市） /
  sagamihara（相模原市）

いずれも `resource_show?id=<resourceId>` を実測し、HTTP 200・`success: true`・
`result.url` が現行 `sources.yaml` のURLと一致すること（詳細は次項）を確認した上で移行した。

**見送った2件**（`get` のまま変更なし）:

- **tottori-city（鳥取市）** / **tokushima-pref（徳島県）**:
  URLの見た目はCKAN標準形状だが `resourceId` が数値（UUID形式ではない）で、
  実際に該当ホストへ `resource_show` を叩くとJSONではなく独自の404 HTMLページが返った。
  ポータル側がCKAN本体ではない（またはAPIが無効化されている）ため、移行の前提となる
  CKAN APIそのものが存在しないと判断した。

## 移行前後のレコード件数比較

移行10件すべてについて、`node scripts/crawl.js --only=<key>` を移行前（`get`）・移行後
（`ckan`）それぞれで実行し、取得→パース→正規化直後の有効施設数を比較した。
**10件全てで移行前後の件数が完全一致**した（ダウンロードしたファイルのバイト数も一致）。

| ソースキー | 移行前 | 移行後 |
|---|---:|---:|
| tokyo-minato | 5,721件 | 5,721件 |
| sapporo | 24,313件 | 24,313件 |
| utsunomiya | 1,256件 | 1,256件 |
| toyama-city | 5,616件 | 5,616件 |
| gifu-pref | 17,561件 | 17,561件 |
| gifu-city | 4,453件 | 4,453件 |
| fukuyama | 5,880件 | 5,880件 |
| yamaguchi-pref | 2,120件 | 2,120件 |
| shimonoseki | 3,865件 | 3,865件 |
| sagamihara | 5,004件 | 5,004件 |

## 変異注入の結果

移行が実際に機能していることを確認するため、`utsunomiya` の `resourceId` を1文字
（末尾 `0714` → `0000`）壊した状態で `--only=utsunomiya` を実行したところ、
`resource_show failed: 404 NOT FOUND` で該当ソースがスキップされ、有効施設0件になった。
`--allow-empty-sources` を付けない通常実行では、この状態は「施設を1件も取り込めなかった
ソースがあります」でクロール全体が例外を投げて失敗する（`scripts/crawl.js` の
空ソース検知）。これにより、移行後の設定値が壊れた場合に黙って古いデータのまま配信され
続けることはなく、クロールが正しく失敗する設計になっていることを確認した。
確認後、`resourceId` を正しい値に戻し、再度1,256件で正常取得できることも確認済み。

## この移行の意義

`get` 型は `sources.yaml` にファイル名まで含む実URLを直書きしているため、自治体側が
ファイル名を変更（年度更新等でよくある）すると404で取得できなくなり、`sources.yaml` の
手動更新が必要になる。`ckan` 型は `resourceId` のみを保持し、実際のダウンロードURL
（ファイル名を含む）は毎回 `resource_show` API から動的に解決するため、自治体側の
ファイル名変更に自動的に追従する。これにより、移行した10件については直リンク固定に
起因する構造的な404が今後発生しなくなる。

## 補足: sagamihara の `result.url` 表記差について

`sagamihara` のみ、API が返す `result.url` の dataset パス部分が現行設定と異なっていた
（現行: `dataset/eigyo_kyoka/...` ／ API: `dataset/3bd39977-.../...`）。ただし `resourceId`
（`1be0eb65-...`）とファイル名（`04.zip`）は完全一致しており、これはCKANが同一データセットに
対して持つ「名前スラッグでの参照」と「データセットUUIDでの参照」という2つの経路の表記差でしかない。
実際に移行後のダウンロード結果（バイト数・パース後の件数）も移行前と完全一致することを確認して
おり、陳腐化（古いURLを指している）ではないと判断した。

## テスト・検証

- `npm run test:unit`: 全件合格（`site/attribution.html` は `npm run build:attribution` で
  再生成し、生成元との同期を取った）
- `node scripts/crawl.js --only=<各ソース>` による実クロール検証（上記の件数比較）
- 変異注入テスト（上記）
- `npm run build`（フルクロール）は未実行（重いため対象外）

## 変更ファイル

- `config/sources.yaml`: 対象10ソースの `acquire` を `get` → `ckan` に変更
- `site/attribution.html`: 上記変更を `scripts/generate/attribution.js` で再生成（手編集なし）
