### PR TITLE
クロール失敗をSlackに通知する仕組みを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:attribution": "node scripts/generate/attribution.js",
     "build:llms": "node scripts/generate/llms.js",
     "fetch:i2fas": "node scripts/tools/fetch-i2fas.js",
-    "test:unit": "node scripts/crawl.test.js && node scripts/lib/config.test.js && node scripts/lib/geocode.test.js && node scripts/lib/coord-quality.test.js && node scripts/lib/pref-boundary.test.js && node scripts/lib/name-cluster.test.js && node scripts/build/merged-csv.test.js && node scripts/build/prefecture-csv.test.js && node scripts/build/tiles.test.js && node scripts/preview-map.test.js && node scripts/map-filter.test.js && node scripts/generate/readme-stats.test.js && node scripts/generate/llms.test.js && node scripts/generate/attribution.test.js && node scripts/workflows.test.js && node scripts/crawler-contract.test.js",
+    "test:unit": "node scripts/crawl.test.js && node scripts/lib/config.test.js && node scripts/lib/geocode.test.js && node scripts/lib/coord-quality.test.js && node scripts/lib/pref-boundary.test.js && node scripts/lib/name-cluster.test.js && node scripts/lib/crawl-summary.test.js && node scripts/lib/notify-slack.test.js && node scripts/build/merged-csv.test.js && node scripts/build/prefecture-csv.test.js && node scripts/build/tiles.test.js && node scripts/preview-map.test.js && node scripts/map-filter.test.js && node scripts/generate/readme-stats.test.js && node scripts/generate/llms.test.js && node scripts/generate/attribution.test.js && node scripts/workflows.test.js && node scripts/crawler-contract.test.js",
     "test:api": "node scripts/validate-api.js",
     "test": "npm run test:unit && npm run test:api"
   },

--- a/scripts/crawl.js
+++ b/scripts/crawl.js
@@ -48,11 +48,33 @@ import { buildPrefectureCsvs } from './build/prefecture-csv.js';
 import { generateTiles } from './build/tiles.js';
 import { generateReadmeStats } from './generate/readme-stats.js';
 import { generateLlmsFiles } from './generate/llms.js';
+import { buildSourceSummary, detectProblems, shouldPersistSummary, summaryToMap } from './lib/crawl-summary.js';
+import { buildSlackMessage, sendSlackNotification } from './lib/notify-slack.js';
 
 const CACHE_DIR = path.join(ROOT, '.cache');
 const API_DIR = path.join(ROOT, 'api');
 const CSV_PATH = path.join(API_DIR, 'facilities-all.csv');
 const PREF_CSV_DIR = path.join(API_DIR, 'prefectures');
+// 前回クロールのソース別件数（前回結果との比較用）。本番クロール（Fargate）は
+// .cache を S3 と同期しているため、ここに保存すれば週をまたいで比較できる。
+const SUMMARY_PATH = path.join(CACHE_DIR, 'crawl-summary.json');
+
+// 前回のクロールサマリを読み込む。無い（初回実行）・壊れている場合は null
+// （detectProblems は previousByKey が null なら drop 判定をスキップする）。
+function loadPreviousSummary(summaryPath = SUMMARY_PATH) {
+  try {
+    const json = JSON.parse(fs.readFileSync(summaryPath, 'utf-8'));
+    return summaryToMap(json.sources || []);
+  } catch {
+    return null;
+  }
+}
+
+// 今回のクロールサマリを次回比較用に保存する。
+function saveSummary(summary, summaryPath = SUMMARY_PATH) {
+  fs.mkdirSync(path.dirname(summaryPath), { recursive: true });
+  fs.writeFileSync(summaryPath, JSON.stringify({ updatedAt: new Date().toISOString(), sources: summary }, null, 2));
+}
 
 const DRY_RUN = process.argv.includes('--dry-run');
 const NO_GEOCODE = process.argv.includes('--no-geocode');
@@ -123,6 +145,7 @@ async function main() {
   console.log(`対象ソース: ${sources.length}件${ONLY ? `（--only=${[...ONLY].join(',')}）` : ''}\n`);
 
   const keptBySource = new Map(); // source.key -> 取り込めた施設数
+  const errorBySource = new Map(); // source.key -> 例外メッセージ（Slack通知用。成功時は未登録）
   // ソースごとの取り込み結果。facilities への結合はソース定義順で行い、
   // 並列実行でも出力（CSV の行順・重複除去の勝ち負け）を決定的に保つ。
   const resultBySource = new Map(); // source.key -> facility[]
@@ -158,6 +181,7 @@ async function main() {
       lines.push(`  有効施設: ${kept}件`);
     } catch (err) {
       lines.push(`  ⚠ ${source.key} をスキップ: ${err.message}`);
+      errorBySource.set(source.key, err.message);
     }
     console.log(lines.join('\n'));
     keptBySource.set(source.key, kept);
@@ -186,6 +210,23 @@ async function main() {
   }
 
   console.log(`\n有効な施設: 合計 ${facilities.length}件`);
+
+  // クロール結果のサマリを集計し、問題（0件・エラー・前回比の大幅減）があれば Slack に通知する。
+  // --allow-empty-sources が本番で既定有効のため、下の emptySources チェックは実質
+  // 素通りする（warning ログが残るだけ）。ここが「壊れても人に気づかせる」唯一の経路になる。
+  const summary = buildSourceSummary(sources, keptBySource, errorBySource);
+  const previousByKey = loadPreviousSummary();
+  const problems = detectProblems(summary, previousByKey);
+  if (problems.length > 0) {
+    console.log(`\n⚠ 問題を検知: ${problems.length}件（Slack通知を試行）`);
+    const message = buildSlackMessage(problems, { totalSources: sources.length, updatedAt: new Date().toISOString() });
+    const result = await sendSlackNotification(message);
+    if (result.skipped) console.log('  Slack通知: SLACK_WEBHOOK_URL 未設定のためスキップ');
+    else if (result.ok) console.log('  Slack通知: 送信しました');
+    else console.warn(`  ⚠ Slack通知に失敗（クロールは続行）: ${result.error || result.status}`);
+  }
+  // --dry-run / --only は本番の実測件数ではないため、次回比較の基準を汚さないよう保存しない。
+  if (shouldPersistSummary({ dryRun: DRY_RUN, only: ONLY })) saveSummary(summary);
 
   // 施設を1件も取り込めなかったソースがあれば失敗させ、api/ を書き換えない。
   // 取得失敗が黙って欠落データに化けるのを防ぐ。--allow-empty-sources で無効化。

--- a/scripts/lib/crawl-summary.js
+++ b/scripts/lib/crawl-summary.js
@@ -1,0 +1,125 @@
+// クロール結果のサマリ集計・前回結果との比較（純粋関数のみ）。
+//
+// 目的: 「壊れても誰も気づけない」問題への対策。本番クロールは
+// --allow-empty-sources がデフォルトで有効（japan-facilities-crawler 側の
+// entrypoint.sh）なため、取得0件のソースがあってもクロール自体は成功扱いになり、
+// ログの warning に埋もれて人には届かない（実例: PR #80 で15ソース・約13万件が
+// 数週間気づかれず欠落）。ここで検知した「問題」は notify-slack.js で Slack に通知する。
+//
+// 「問題」は3種類:
+//   zero  取得0件（--allow-empty-sources で握りつぶされている分）
+//   error 取得/パースで例外が発生し処理をスキップしたソース
+//   drop  前回のクロール結果より件数が大きく減ったソース（後述の閾値で判定）
+//
+// drop の閾値についての根拠:
+//   東京都保健医療局のように新URLも旧URLも200を返す「404が出ない陳腐化」は、
+//   0件にもエラーにもならず curl の死活監視では原理的に検出できない
+//   （commander/20260822-1058-jff-issue93/workers/2/REPORT.md の調査で判明）。
+//   これを拾うには前回件数との比較が唯一の手段。
+//   閾値は「30%以上の減少」かつ「前回20件以上」とした:
+//     - 30%: 自治体データは廃業等で自然減することがあるため、数%の減少まで拾うと
+//       ノイズ（誤検知）が多くなる。一方で一部データ欠落（例: 15ソース中の一部URL
+//       だけ404化）は数十%単位で減ることが多く、30%なら実害のある欠落を取り逃さず
+//       自然減のノイズも避けられる、という経験則上のバランス値。
+//     - 前回20件以上: 母数が小さいソース（数件〜十数件）は1〜2件の増減で
+//       比率が跳ね上がり誤検知になりやすいため、判定対象から除外する。
+export const DEFAULT_DROP_THRESHOLD = 0.3;
+export const DEFAULT_DROP_MIN_PREVIOUS = 20;
+
+/**
+ * 各ソースの取得結果を { key, name, count, error } の配列にまとめる。
+ * @param {Array} sources config/sources.yaml の sources 配列（フィルタ後）
+ * @param {Map<string, number>} keptBySource source.key -> 取り込めた施設数
+ * @param {Map<string, string>} errorBySource source.key -> 例外メッセージ（例外が無ければ未登録）
+ * @returns {Array<{key: string, name: string, count: number, error: string|null}>}
+ */
+export function buildSourceSummary(sources, keptBySource, errorBySource) {
+  return sources.map((s) => ({
+    key: s.key,
+    name: s.source,
+    count: keptBySource.get(s.key) || 0,
+    error: (errorBySource && errorBySource.get(s.key)) || null,
+  }));
+}
+
+/**
+ * 今回のサマリと前回のサマリを比較し、「問題」の一覧を返す。
+ * previousByKey が無い（初回実行）場合は drop 判定をスキップする（誤検知防止）。
+ * @param {Array<{key,name,count,error}>} summary 今回のサマリ（buildSourceSummary の出力）
+ * @param {Map<string, {count: number}>|null} previousByKey 前回のサマリ（key -> {count}）
+ * @param {{dropThreshold?: number, dropMinPrevious?: number}} [options]
+ * @returns {Array<{key,name,type:'zero'|'error'|'drop',count,previousCount,dropRatio,error}>}
+ */
+export function detectProblems(summary, previousByKey, options = {}) {
+  const dropThreshold = options.dropThreshold ?? DEFAULT_DROP_THRESHOLD;
+  const dropMinPrevious = options.dropMinPrevious ?? DEFAULT_DROP_MIN_PREVIOUS;
+  const problems = [];
+
+  for (const entry of summary) {
+    // エラーで処理をスキップしたソース（HTTPエラー・パース失敗など）を最優先で報告する。
+    if (entry.error) {
+      problems.push({
+        key: entry.key,
+        name: entry.name,
+        type: 'error',
+        count: entry.count,
+        previousCount: null,
+        dropRatio: null,
+        error: entry.error,
+      });
+      continue;
+    }
+    // 取得0件（--allow-empty-sources で握りつぶされている分）。
+    if (entry.count === 0) {
+      problems.push({
+        key: entry.key,
+        name: entry.name,
+        type: 'zero',
+        count: 0,
+        previousCount: previousByKey?.get(entry.key)?.count ?? null,
+        dropRatio: null,
+        error: null,
+      });
+      continue;
+    }
+    // 前回結果との比較（前回サマリが無い＝初回実行のときはスキップ）。
+    const previous = previousByKey?.get(entry.key);
+    if (!previous || previous.count < dropMinPrevious) continue;
+    const dropRatio = (previous.count - entry.count) / previous.count;
+    if (dropRatio >= dropThreshold) {
+      problems.push({
+        key: entry.key,
+        name: entry.name,
+        type: 'drop',
+        count: entry.count,
+        previousCount: previous.count,
+        dropRatio,
+        error: null,
+      });
+    }
+  }
+  return problems;
+}
+
+/**
+ * 今回のサマリを次回比較用に永続化してよいかどうかを判定する。
+ * --only（部分実行）はソース全体を処理していないため、処理対象外のソースが
+ * 「前回結果が消えた」ように見えてしまう。--dry-run はローカル動作確認用で
+ * 本番の実測件数ではないため、いずれも本番比較の基準（ベースライン）を
+ * 汚さないよう保存をスキップする。
+ * @param {{dryRun: boolean, only: Set|null}} opts
+ * @returns {boolean}
+ */
+export function shouldPersistSummary({ dryRun, only }) {
+  return !dryRun && !only;
+}
+
+/**
+ * サマリ配列を previousByKey（Map）と同じ形の Map に変換する。
+ * detectProblems・保存済みJSONの読み込み後の変換に使う。
+ * @param {Array<{key,count}>} summary
+ * @returns {Map<string, {count: number}>}
+ */
+export function summaryToMap(summary) {
+  return new Map(summary.map((s) => [s.key, { count: s.count }]));
+}

--- a/scripts/lib/crawl-summary.test.js
+++ b/scripts/lib/crawl-summary.test.js
@@ -1,0 +1,129 @@
+// crawl-summary のユニットテスト。
+//   node scripts/lib/crawl-summary.test.js
+// 「取得0件」「取得エラー」「前回比の大幅減」の3種類の問題検知ロジックを固定入力で検証する。
+
+import assert from 'node:assert/strict';
+import {
+  buildSourceSummary,
+  detectProblems,
+  shouldPersistSummary,
+  summaryToMap,
+  DEFAULT_DROP_THRESHOLD,
+  DEFAULT_DROP_MIN_PREVIOUS,
+} from './crawl-summary.js';
+
+let passed = 0;
+function test(name, fn) {
+  fn();
+  passed++;
+  console.log(`  ✓ ${name}`);
+}
+
+// --- buildSourceSummary ---
+test('buildSourceSummary: 件数とエラーをソース定義順にまとめる', () => {
+  const sources = [
+    { key: 'a', source: 'A市' },
+    { key: 'b', source: 'B市' },
+  ];
+  const kept = new Map([['a', 100]]); // b は未登録（0件扱い）
+  const errors = new Map([['b', 'ダウンロード失敗: 404 Not Found']]);
+  const summary = buildSourceSummary(sources, kept, errors);
+  assert.deepEqual(summary, [
+    { key: 'a', name: 'A市', count: 100, error: null },
+    { key: 'b', name: 'B市', count: 0, error: 'ダウンロード失敗: 404 Not Found' },
+  ]);
+});
+
+// --- detectProblems: 取得0件 ---
+test('detectProblems: 取得0件は zero として検知する', () => {
+  const summary = [{ key: 'a', name: 'A市', count: 0, error: null }];
+  const problems = detectProblems(summary, null);
+  assert.equal(problems.length, 1);
+  assert.equal(problems[0].type, 'zero');
+  assert.equal(problems[0].key, 'a');
+});
+
+// --- detectProblems: エラー ---
+test('detectProblems: 取得エラーは error として検知し、0件チェックより優先する', () => {
+  const summary = [{ key: 'a', name: 'A市', count: 0, error: 'timeout' }];
+  const problems = detectProblems(summary, null);
+  assert.equal(problems.length, 1);
+  assert.equal(problems[0].type, 'error');
+  assert.equal(problems[0].error, 'timeout');
+});
+
+// --- detectProblems: 大幅減（drop） ---
+test('detectProblems: 前回比30%以上の減少は drop として検知する', () => {
+  const summary = [{ key: 'a', name: 'A市', count: 60, error: null }]; // 100 -> 60 は40%減
+  const previous = summaryToMap([{ key: 'a', count: 100 }]);
+  const problems = detectProblems(summary, previous);
+  assert.equal(problems.length, 1);
+  assert.equal(problems[0].type, 'drop');
+  assert.equal(problems[0].previousCount, 100);
+  assert.ok(Math.abs(problems[0].dropRatio - 0.4) < 1e-9);
+});
+
+test('detectProblems: 閾値未満の減少（30%未満）は検知しない', () => {
+  const summary = [{ key: 'a', name: 'A市', count: 80, error: null }]; // 100 -> 80 は20%減
+  const previous = summaryToMap([{ key: 'a', count: 100 }]);
+  assert.deepEqual(detectProblems(summary, previous), []);
+});
+
+test('detectProblems: 前回件数が閾値未満（20件未満）の母数は drop 判定から除外する', () => {
+  const summary = [{ key: 'a', name: 'A市', count: 1, error: null }]; // 10 -> 1 は90%減だが母数が小さい
+  const previous = summaryToMap([{ key: 'a', count: 10 }]);
+  assert.deepEqual(detectProblems(summary, previous), []);
+});
+
+test('detectProblems: 前回サマリが無い（初回実行）ときは drop 判定をスキップする', () => {
+  const summary = [{ key: 'a', name: 'A市', count: 1, error: null }];
+  assert.deepEqual(detectProblems(summary, null), []);
+});
+
+test('detectProblems: 増加は検知しない', () => {
+  const summary = [{ key: 'a', name: 'A市', count: 150, error: null }];
+  const previous = summaryToMap([{ key: 'a', count: 100 }]);
+  assert.deepEqual(detectProblems(summary, previous), []);
+});
+
+test('detectProblems: 問題の無いソースは混ざっていても無視する', () => {
+  const summary = [
+    { key: 'a', name: 'A市', count: 100, error: null },
+    { key: 'b', name: 'B市', count: 0, error: null },
+  ];
+  const previous = summaryToMap([{ key: 'a', count: 100 }]);
+  const problems = detectProblems(summary, previous);
+  assert.deepEqual(problems.map((p) => p.key), ['b']);
+});
+
+test('detectProblems: 閾値はオプションで上書きできる', () => {
+  const summary = [{ key: 'a', name: 'A市', count: 90, error: null }]; // 100 -> 90 は10%減
+  const previous = summaryToMap([{ key: 'a', count: 100 }]);
+  assert.deepEqual(detectProblems(summary, previous, { dropThreshold: 0.05 }).map((p) => p.key), ['a']);
+  assert.deepEqual(detectProblems(summary, previous, { dropThreshold: 0.2 }), []);
+});
+
+test('既定の閾値定数が想定どおりにexportされている', () => {
+  assert.equal(DEFAULT_DROP_THRESHOLD, 0.3);
+  assert.equal(DEFAULT_DROP_MIN_PREVIOUS, 20);
+});
+
+// --- shouldPersistSummary ---
+test('shouldPersistSummary: 通常実行は保存する', () => {
+  assert.equal(shouldPersistSummary({ dryRun: false, only: null }), true);
+});
+test('shouldPersistSummary: --dry-run は保存しない', () => {
+  assert.equal(shouldPersistSummary({ dryRun: true, only: null }), false);
+});
+test('shouldPersistSummary: --only（部分実行）は保存しない', () => {
+  assert.equal(shouldPersistSummary({ dryRun: false, only: new Set(['a']) }), false);
+});
+
+// --- summaryToMap ---
+test('summaryToMap: key -> {count} の Map に変換する', () => {
+  const map = summaryToMap([{ key: 'a', name: 'A市', count: 5 }]);
+  assert.deepEqual(map.get('a'), { count: 5 });
+  assert.equal(map.get('missing'), undefined);
+});
+
+console.log(`\n✅ crawl-summary.js ユニットテスト: ${passed}件すべて合格`);

--- a/scripts/lib/notify-slack.js
+++ b/scripts/lib/notify-slack.js
@@ -1,0 +1,112 @@
+// クロール失敗時の Slack 通知。
+//
+// メッセージ整形（buildSlackMessage）は純粋関数として切り出し、固定入力でテストする。
+// 送信（sendSlackNotification）だけがネットワークI/Oを持つ副作用関数で、
+//   - Webhook URL が未設定なら何もせず正常終了する（ローカル開発・CI・テストで落ちない）
+//   - 送信自体が失敗しても例外を投げない（通知は補助機能。クロール本体を落とす理由にしない）
+// という2点を必ず守る。Webhook URL はコード・リポジトリに書かず、必ず環境変数
+// （既定 SLACK_WEBHOOK_URL）から読む。
+
+/**
+ * 問題の種別ごとに、人が見て次のアクションが分かる1行を作る。
+ * @param {{key,name,type,count,previousCount,dropRatio,error}} p detectProblems の1要素
+ * @returns {string} Slack mrkdwn 形式の1行
+ */
+function formatProblemLine(p) {
+  const label = `*${p.key}*（${p.name}）`;
+  if (p.type === 'error') {
+    return `:red_circle: ${label} — 取得エラー: ${p.error}`;
+  }
+  if (p.type === 'zero') {
+    const prev = p.previousCount != null ? `（前回 ${p.previousCount}件）` : '';
+    return `:red_circle: ${label} — 取得0件${prev}`;
+  }
+  // type === 'drop'
+  const pct = Math.round(p.dropRatio * 100);
+  return `:large_orange_diamond: ${label} — 前回 ${p.previousCount}件 → 今回 ${p.count}件（${pct}%減）`;
+}
+
+/**
+ * 検知した問題一覧から Slack Incoming Webhook 用のペイロードを組み立てる（純粋関数）。
+ * @param {Array} problems detectProblems の返り値
+ * @param {{totalSources: number, updatedAt: string}} meta 対象ソース総数・実行時刻（ISO文字列）
+ * @returns {{text: string, blocks: Array}|null} 問題が0件なら null（通知不要）
+ */
+export function buildSlackMessage(problems, meta) {
+  if (!problems || problems.length === 0) return null;
+
+  const summaryText = `⚠️ Japan Food Facilities クロールで問題を検知（${problems.length}/${meta.totalSources}ソース）`;
+  const blocks = [
+    {
+      type: 'header',
+      text: { type: 'plain_text', text: '⚠️ クロール警告: japan-food-facilities' },
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `対象 ${meta.totalSources} ソース中 *${problems.length}件* で問題を検知しました（${meta.updatedAt}）`,
+      },
+    },
+    { type: 'divider' },
+    // Slack section の text は最大3000文字。問題が大量にある場合に備え、
+    // 1メッセージあたり最大20件までに絞り、残数を末尾に注記する。
+    ...problems.slice(0, 20).map((p) => ({
+      type: 'section',
+      text: { type: 'mrkdwn', text: formatProblemLine(p) },
+    })),
+    ...(problems.length > 20
+      ? [{ type: 'section', text: { type: 'mrkdwn', text: `…他 ${problems.length - 20}件` } }]
+      : []),
+    {
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: '次のアクション: config/sources.yaml の該当ソースの取得元URL・CKAN resourceId が変わっていないか確認してください。',
+        },
+      ],
+    },
+  ];
+
+  return { text: summaryText, blocks };
+}
+
+/**
+ * Slack Incoming Webhook にメッセージを送信する。
+ * webhookUrl が無ければ何もせず { ok: true, skipped: true } を返す
+ * （環境変数未設定時にローカル開発・CI・テストを落とさないため）。
+ * 送信自体が失敗しても例外は投げず { ok: false, error } を返す
+ * （通知の失敗でクロール全体を止めないため）。
+ * @param {{text: string, blocks: Array}} payload buildSlackMessage の返り値
+ * @param {{webhookUrl?: string, fetchImpl?: Function, timeoutMs?: number}} [options]
+ * @returns {Promise<{ok: boolean, skipped?: boolean, status?: number, error?: string}>}
+ */
+export async function sendSlackNotification(payload, options = {}) {
+  const webhookUrl = options.webhookUrl ?? process.env.SLACK_WEBHOOK_URL;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const timeoutMs = options.timeoutMs ?? 10000;
+
+  if (!webhookUrl) return { ok: true, skipped: true };
+  if (!payload) return { ok: true, skipped: true };
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetchImpl(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      return { ok: false, status: res.status, error: `Slack Webhook failed: ${res.status} ${res.statusText}` };
+    }
+    return { ok: true };
+  } catch (e) {
+    // ネットワーク例外・タイムアウトも含め、ここで必ず握りつぶす。
+    return { ok: false, error: e.message };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/scripts/lib/notify-slack.test.js
+++ b/scripts/lib/notify-slack.test.js
@@ -1,0 +1,126 @@
+// notify-slack のユニットテスト。
+//   node scripts/lib/notify-slack.test.js
+// 実際に Slack へは送信しない（webhookを持っていない）。かわりに:
+//   - buildSlackMessage: 検知した問題からペイロードを組み立てる純粋関数を固定入力で検証
+//   - sendSlackNotification: fetch をモックに差し替え、渡されるペイロード・
+//     未設定時のスキップ・失敗時の非throwを検証する
+
+import assert from 'node:assert/strict';
+import { buildSlackMessage, sendSlackNotification } from './notify-slack.js';
+
+let passed = 0;
+function test(name, fn) {
+  fn();
+  passed++;
+  console.log(`  ✓ ${name}`);
+}
+const asyncTests = [];
+function testAsync(name, fn) {
+  asyncTests.push({ name, fn });
+}
+
+// --- buildSlackMessage ---
+test('buildSlackMessage: 問題が0件なら null（通知不要）', () => {
+  assert.equal(buildSlackMessage([], { totalSources: 10, updatedAt: '2026-08-23T00:00:00.000Z' }), null);
+  assert.equal(buildSlackMessage(null, { totalSources: 10, updatedAt: '2026-08-23T00:00:00.000Z' }), null);
+});
+
+test('buildSlackMessage: zero/error/drop それぞれの内容を1行に含める', () => {
+  const problems = [
+    { key: 'a', name: 'A市', type: 'zero', count: 0, previousCount: 500, dropRatio: null, error: null },
+    { key: 'b', name: 'B市', type: 'error', count: 0, previousCount: null, dropRatio: null, error: '404 Not Found' },
+    { key: 'c', name: 'C市', type: 'drop', count: 60, previousCount: 100, dropRatio: 0.4, error: null },
+  ];
+  const msg = buildSlackMessage(problems, { totalSources: 81, updatedAt: '2026-08-23T00:00:00.000Z' });
+  assert.ok(msg && msg.text && Array.isArray(msg.blocks));
+  const text = JSON.stringify(msg);
+  // どのソースが・どう問題なのか・前回との差、が含まれること
+  assert.ok(text.includes('a') && text.includes('A市') && text.includes('取得0件'));
+  assert.ok(text.includes('b') && text.includes('404 Not Found'));
+  assert.ok(text.includes('c') && text.includes('100件') && text.includes('60件') && text.includes('40%減'));
+  // 次のアクションが分かる文言が含まれること
+  assert.ok(text.includes('sources.yaml'));
+});
+
+test('buildSlackMessage: 問題が21件以上は先頭20件+残数注記に絞る（Slack section 3000文字制限対策）', () => {
+  const problems = Array.from({ length: 25 }, (_, i) => ({
+    key: `s${i}`,
+    name: `市${i}`,
+    type: 'zero',
+    count: 0,
+    previousCount: null,
+    dropRatio: null,
+    error: null,
+  }));
+  const msg = buildSlackMessage(problems, { totalSources: 81, updatedAt: '2026-08-23T00:00:00.000Z' });
+  const text = JSON.stringify(msg);
+  assert.ok(text.includes('他 5件'));
+  assert.ok(text.includes('s19'), '先頭20件目（s19）は含まれる');
+  assert.ok(!text.includes('"s20"'), '21件目（s20）は省略される');
+});
+
+// --- sendSlackNotification ---
+testAsync('sendSlackNotification: webhookUrl未設定はネットワークを叩かずスキップを返す', async () => {
+  let called = false;
+  const fetchImpl = async () => {
+    called = true;
+    throw new Error('呼ばれてはいけない');
+  };
+  const result = await sendSlackNotification({ text: 'x' }, { webhookUrl: undefined, fetchImpl });
+  assert.deepEqual(result, { ok: true, skipped: true });
+  assert.equal(called, false);
+});
+
+testAsync('sendSlackNotification: payloadがnull（問題なし）はスキップする', async () => {
+  const result = await sendSlackNotification(null, { webhookUrl: 'https://hooks.slack.example/x' });
+  assert.deepEqual(result, { ok: true, skipped: true });
+});
+
+testAsync('sendSlackNotification: 正しいURL・メソッド・JSON本文でPOSTする', async () => {
+  let capturedUrl, capturedOpts;
+  const fetchImpl = async (url, opts) => {
+    capturedUrl = url;
+    capturedOpts = opts;
+    return { ok: true, status: 200, statusText: 'OK' };
+  };
+  const payload = { text: 'hello', blocks: [] };
+  const result = await sendSlackNotification(payload, {
+    webhookUrl: 'https://hooks.slack.example/services/x',
+    fetchImpl,
+  });
+  assert.equal(result.ok, true);
+  assert.equal(capturedUrl, 'https://hooks.slack.example/services/x');
+  assert.equal(capturedOpts.method, 'POST');
+  assert.equal(capturedOpts.headers['Content-Type'], 'application/json');
+  assert.deepEqual(JSON.parse(capturedOpts.body), payload);
+});
+
+testAsync('sendSlackNotification: Slackが非2xxを返しても例外を投げず ok:false を返す', async () => {
+  const fetchImpl = async () => ({ ok: false, status: 500, statusText: 'Internal Server Error' });
+  const result = await sendSlackNotification({ text: 'x' }, { webhookUrl: 'https://hooks.slack.example/x', fetchImpl });
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 500);
+});
+
+testAsync('sendSlackNotification: fetchが例外を投げても呼び出し元には伝播しない', async () => {
+  const fetchImpl = async () => {
+    throw new Error('network down');
+  };
+  const result = await sendSlackNotification({ text: 'x' }, { webhookUrl: 'https://hooks.slack.example/x', fetchImpl });
+  assert.equal(result.ok, false);
+  assert.equal(result.error, 'network down');
+});
+
+const runAsync = async () => {
+  for (const { name, fn } of asyncTests) {
+    await fn();
+    passed++;
+    console.log(`  ✓ ${name}`);
+  }
+  console.log(`\n✅ notify-slack.js ユニットテスト: ${passed}件すべて合格`);
+};
+
+runAsync().catch((err) => {
+  console.error('\n❌ テスト失敗:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## なぜ必要か

現在のクロールは「壊れても誰も気づけない」。`scripts/crawl.js` には取得0件のソースがあれば
クロールを中断する安全装置（`ALLOW_EMPTY_SOURCES` チェック）があるが、本番の実行基盤
（別リポジトリ [japan-facilities-crawler](https://github.com/gl20percentclub/japan-facilities-crawler)
の `docker/entrypoint.sh`）が既定で `CRAWL_ARGS="${CRAWL_ARGS:---allow-empty-sources}"` と、
この安全装置を外している。結果、1ソースが全滅してもクロールは成功扱いで終わり、ログに warning
が出るだけで人には通知されない。

**実例: PR #80 で15ソース・約13万件が数週間気づかれずに欠落していた。**

さらに、404すら出ない壊れ方が3件見つかっている（大津市・盛岡市・東京都保健医療局）。
特に東京都保健医療局は**新旧どちらのURLも200を返す**ため、死活監視（HTTPステータス確認）
では原理的に検出できない。この種の劣化を拾うには、前回クロールとの件数比較が唯一の手段になる。

## やったこと

クロール結果のサマリを集計し、「問題」があったときだけ Slack に通知する仕組みを追加した。

### 検知する「問題」（3種類）

- **zero**: 取得0件のソース（`--allow-empty-sources` で握りつぶされている分）
- **error**: HTTPエラー・パース失敗などで処理をスキップしたソース
- **drop**: 前回クロールより件数が大きく減ったソース（404が出ない陳腐化を拾うための唯一の手段）

### drop 検知の閾値と根拠

**前回比30%以上の減少、かつ前回件数が20件以上**のソースを検知対象とした
（`scripts/lib/crawl-summary.js` のコメントに詳細な根拠を記載）。

- 30%: 自治体データは廃業等で自然減することがあるため、数%の減少まで拾うとノイズ
  （誤検知）が多くなる。一方で一部データ欠落は数十%単位で減ることが多く、実害のある
  欠落を取り逃さず自然減のノイズも避けられるバランス値とした。
- 前回20件以上: 母数が小さいソースは1〜2件の増減で比率が跳ね上がり誤検知になりやすいため、
  判定対象から除外した。

前回結果は `.cache/crawl-summary.json` に保存する（本番クロールは `.cache` を S3 と同期して
いるため、週をまたいで比較できる）。`--dry-run` / `--only` の実行結果は本番の実測件数では
ないため保存対象から除外している。

### Slack への送信

- Webhook URL は環境変数 `SLACK_WEBHOOK_URL` からのみ読み、コード・リポジトリには書かない。
- **`SLACK_WEBHOOK_URL` が未設定なら通知をスキップして正常終了する**（ローカル開発・CI・
  テストで落ちない）。
- **送信失敗（Slack側の障害・タイムアウト）でクロール全体を落とさない**（通知は補助機能）。
- メッセージには「どのソースが」「どう問題なのか（0件/エラー内容/前回件数との差）」
  「次のアクション（config/sources.yaml の該当ソースを確認する）」を含める。

## 人間が実施する必要のあるセットアップ手順

このPRだけでは通知は動かない。以下はインフラ側PR
https://github.com/gl20percentclub/japan-facilities-crawler/pull/27 で対応するが、あわせて必要な作業:

1. Slack で Incoming Webhook を発行する（Slack App の作成 → Incoming Webhooks 有効化 →
   通知先チャンネルを選んで発行）。詳細手順はインフラ側PRの README に記載。
2. 発行した Webhook URL を AWS Secrets Manager
   （`japan-facilities-crawler/slack-webhook-url`）に登録する。
3. インフラ側PRをデプロイし、Fargate タスク定義に `SLACK_WEBHOOK_URL` が注入されることを確認する。

未設定のままでも本PRの変更だけでクロールが落ちることはない（通知が「スキップ」になるだけ）。

## 変更したファイル

- `scripts/lib/crawl-summary.js`（新規）: サマリ集計・問題検知（zero/error/drop）の純粋関数
- `scripts/lib/crawl-summary.test.js`（新規）: 上記のユニットテスト
- `scripts/lib/notify-slack.js`（新規）: Slackメッセージ整形（純粋関数）とWebhook送信
- `scripts/lib/notify-slack.test.js`（新規）: 上記のユニットテスト（fetchはモック。実際に
  Slackへは送信していない）
- `scripts/crawl.js`: サマリ集計→問題検知→Slack通知→次回比較用の保存、を追加
- `package.json`: `test:unit` チェーンに新規テストを追加

## テスト

- `npm run test:unit`: 全件PASS（既存284件 + 新規23件 = 307件）
- 変異注入: drop判定条件・webhook未設定時のスキップガードをそれぞれ意図的に壊し、
  対応するテストが確実に失敗することを確認してから復元
- `--dry-run --only=<1ソース>` での統合確認、ローカルHTTPサーバーで実際にPOSTされる
  ペイロードの内容を確認（実Slackへは送信していない）

## 関連PR

- インフラ側（Secrets Manager 経由での Webhook URL 注入）: https://github.com/gl20percentclub/japan-facilities-crawler/pull/27
