### PR TITLE
直リンク20件をresolve型に移行する

### DIFF
--- a/config/sources.yaml
+++ b/config/sources.yaml
@@ -203,8 +203,9 @@ sources:
     license: CC BY 4.0
   - key: osaka-city
     acquire:
-      type: get
-      url: https://www.city.osaka.lg.jp/contents/wdu280/260331zenku.csv
+      type: resolve
+      pageUrl: https://www.city.osaka.lg.jp/kenko/page/0000575579.html
+      linkPattern: 食品営業許可施設一覧
       format: csv
       encoding: shift_jis
     source: 大阪市食品営業許可施設一覧
@@ -463,8 +464,9 @@ sources:
     defaultCity: 青森市
   - key: morioka
     acquire:
-      type: get
-      url: https://www.city.morioka.iwate.jp/_res/projects/default_project/_page_/001/006/689/20260630.csv
+      type: resolve
+      pageUrl: https://www.city.morioka.iwate.jp/kenkou/hokenjo/shokuhineisei/1017014/1006689.html
+      linkPattern: 食品営業許可施設一覧
       format: csv
       encoding: utf-8
     source: 盛岡市食品営業許可施設一覧
@@ -496,8 +498,9 @@ sources:
     defaultCity: 山形市
   - key: fukushima-pref
     acquire:
-      type: get
-      url: https://www.pref.fukushima.lg.jp/uploaded/attachment/743308.xlsx
+      type: resolve
+      pageUrl: https://www.pref.fukushima.lg.jp/sec/21045e/shisetujouhou.html
+      linkPattern: 年度末時点
       format: xlsx
     source: 福島県食品営業許可施設一覧
     sourceUrl: https://www.pref.fukushima.lg.jp/sec/21045e/shisetujouhou.html
@@ -537,8 +540,9 @@ sources:
     defaultCity: 宇都宮市
   - key: takasaki
     acquire:
-      type: get
-      url: https://www.city.takasaki.gunma.jp/uploaded/attachment/40475.xlsx
+      type: resolve
+      pageUrl: https://www.city.takasaki.gunma.jp/page/4527.html
+      linkPattern: '許可施設一覧（.+現在）'
       format: xlsx
     source: 高崎市食品営業許可施設一覧
     sourceUrl: https://www.city.takasaki.gunma.jp/page/4527.html
@@ -547,8 +551,9 @@ sources:
     defaultCity: 高崎市
   - key: kawaguchi
     acquire:
-      type: get
-      url: https://www.city.kawaguchi.lg.jp/material/files/group/232/R0803zenshisetsuichiran.xls
+      type: resolve
+      pageUrl: https://www.city.kawaguchi.lg.jp/soshiki/01090/027/shokuhin/oshirasetop/shisetsuichiran/index.html
+      linkPattern: '^食品営業施設一覧'
       format: xls
     source: 川口市食品衛生営業許可施設一覧
     sourceUrl: https://www.city.kawaguchi.lg.jp/soshiki/01090/027/shokuhin/oshirasetop/shisetsuichiran/index.html
@@ -557,8 +562,9 @@ sources:
     defaultCity: 川口市
   - key: chuo-ku
     acquire:
-      type: get
-      url: https://www.city.chuo.lg.jp/documents/984/syokuhineigyoukyoka.csv
+      type: resolve
+      pageUrl: https://www.city.chuo.lg.jp/kusei/gaiyou/toukeidate/opendata.html
+      linkPattern: 食品等営業許可・届出一覧
       format: csv
       encoding: shift_jis
     source: 東京都中央区食品等営業許可・届出一覧
@@ -579,8 +585,9 @@ sources:
     defaultCity: 新宿区
   - key: taito-ku
     acquire:
-      type: get
-      url: https://www.city.taito.lg.jp/kenkohukusi/kenkokikikanrieisei/food/syokuhin-sisetu/index.files/2026ALL-IND-CSV.csv
+      type: resolve
+      pageUrl: https://www.city.taito.lg.jp/kenkohukusi/kenkokikikanrieisei/food/syokuhin-sisetu/index.html
+      hrefPattern: '2026ALL-IND-CSV\.csv$'
       format: csv
       encoding: shift_jis
     source: 東京都台東区食品衛生営業施設一覧
@@ -601,8 +608,9 @@ sources:
     defaultCity: 江東区
   - key: shinagawa-ku
     acquire:
-      type: get
-      url: https://www.city.shinagawa.tokyo.jp/contentshozon2026/R6-7.csv
+      type: resolve
+      pageUrl: https://www.city.shinagawa.tokyo.jp/PC/kenkou/kenkou-eisei/kenkou-eisei-syokuhin/opendate.html
+      linkPattern: '年度\s*許可施設一覧'
       format: csv
       encoding: shift_jis
     source: 東京都品川区食品衛生許可施設
@@ -623,8 +631,9 @@ sources:
     defaultCity: 中野区
   - key: setagaya-ku
     acquire:
-      type: get
-      url: https://www.city.setagaya.lg.jp/documents/3246/zenkenr080331.csv
+      type: resolve
+      pageUrl: https://www.city.setagaya.lg.jp/02245/online_tetsuzuki/3246.html
+      linkPattern: '^全件許可施設一覧'
       format: csv
       encoding: shift_jis
     source: 東京都世田谷区食品衛生営業許可施設
@@ -735,8 +744,9 @@ sources:
     defaultCity: 福井市
   - key: yamanashi-pref
     acquire:
-      type: get
-      url: https://www.pref.yamanashi.jp/documents/23776/190004_food_business_all.csv
+      type: resolve
+      pageUrl: https://www.pref.yamanashi.jp/eisei-ykm/itiranhyou1.html
+      linkPattern: 営業許可施設一覧（オープンデータ）
       format: csv
       encoding: shift_jis
     source: 山梨県営業許可施設一覧
@@ -745,8 +755,9 @@ sources:
     defaultPref: 山梨県
   - key: nagano-city
     acquire:
-      type: get
-      url: https://www.city.nagano.nagano.jp/documents/1948/202011_food_business_202605.csv
+      type: resolve
+      pageUrl: https://www.city.nagano.nagano.jp/n023500/contents/p004876.html
+      linkPattern: 営業許可施設（食品営業）
       format: csv
       encoding: utf-8
     source: 長野市食品営業許可施設
@@ -789,8 +800,10 @@ sources:
     defaultCity: 岐阜市
   - key: hamamatsu
     acquire:
-      type: get
-      url: https://static.hamamatsu.odpf.net/opendata/v01/syokuhineiseidaityou202401/syokuhineiseidaityou202401.csv
+      type: resolve
+      pageUrl: https://opendata.pref.shizuoka.jp/dataset/11921.html
+      hrefScan: true
+      hrefPattern: 'https://static\.hamamatsu\.odpf\.net/opendata/v01/syokuhineiseidaityou\d{6}/syokuhineiseidaityou\d{6}\.csv'
       format: csv
       encoding: shift_jis
     source: 浜松市食品衛生台帳（新規）
@@ -811,8 +824,9 @@ sources:
     defaultPref: 愛知県
   - key: ichinomiya
     acquire:
-      type: get
-      url: https://www.city.ichinomiya.aichi.jp/_res/projects/default_project/_page_/001/040/636/232033_Food_Business_All_20260331.csv
+      type: resolve
+      pageUrl: https://www.city.ichinomiya.aichi.jp/hokenjo/hoken-eisei/1044314/1039899/1040636.html
+      linkPattern: 食品営業許可台帳（.+時点）
       format: csv
       encoding: auto
     source: 一宮市食品営業許可台帳
@@ -822,8 +836,9 @@ sources:
     defaultCity: 一宮市
   - key: otsu
     acquire:
-      type: get
-      url: https://www.city.otsu.lg.jp/material/files/group/4/od_2605.csv
+      type: resolve
+      pageUrl: https://www.city.otsu.lg.jp/soshiki/021/1441/od/02594.html
+      linkPattern: 食品営業許可施設一覧（.+月末時点）
       format: csv
       encoding: utf-8
     source: 大津市食品営業許可施設一覧
@@ -833,8 +848,9 @@ sources:
     defaultCity: 大津市
   - key: hirakata
     acquire:
-      type: get
-      url: https://www.city.hirakata.osaka.jp/cmsfiles/contents/0000023/23479/272108_food_business_all_202603_end.csv
+      type: resolve
+      pageUrl: https://www.city.hirakata.osaka.jp/0000023479.html
+      linkPattern: 全ての許可施設
       format: csv
       encoding: shift_jis
     source: 枚方市食品等営業許可施設一覧
@@ -844,8 +860,9 @@ sources:
     defaultCity: 枚方市
   - key: suita
     acquire:
-      type: get
-      url: https://www.city.suita.osaka.jp/_res/projects/default_project/_page_/001/017/170/20260331new.xlsx
+      type: resolve
+      pageUrl: https://www.city.suita.osaka.jp/home/soshiki/div-kenkoiryo/eiseikanri/opendata.html
+      linkPattern: 食品営業許可施設一覧（令和\d+年\d+月\d+日時点）（改正後
       format: xlsx
     source: 吹田市食品営業許可施設一覧
     sourceUrl: https://www.city.suita.osaka.jp/home/soshiki/div-kenkoiryo/eiseikanri/opendata.html
@@ -892,8 +909,9 @@ sources:
     defaultCity: 西宮市
   - key: nara-city
     acquire:
-      type: get
-      url: https://www.city.nara.lg.jp/uploaded/attachment/203480.csv
+      type: resolve
+      pageUrl: https://www.city.nara.lg.jp/soshiki/97/10411.html
+      linkPattern: オープンデータ
       format: csv
       encoding: utf-8
     source: 奈良市食品営業許可施設
@@ -958,8 +976,9 @@ sources:
     defaultPref: 徳島県
   - key: takamatsu
     acquire:
-      type: get
-      url: https://opendata.takamatsu-fact.com/licensed_food_business_facility_list/data.csv
+      type: resolve
+      pageUrl: https://opendata.smartcity-takamatsu.jp/ckan/dataset/licensed_food_business_facility_list
+      linkPattern: ダウンロード
       format: csv
       encoding: utf-8
     source: 高松市食品等営業許可施設一覧
@@ -970,10 +989,10 @@ sources:
     defaultCity: 高松市
   - key: matsuyama
     acquire:
-      type: get
-      urls:
-        - https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.files/382019_food_business_all_2026031.csv
-        - https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.files/382019_food_business_all_2026032.csv
+      type: resolve
+      pageUrl: https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.html
+      hrefPattern: '382019_food_business_all_\d+\.csv$'
+      multi: true
       format: csv
       encoding: utf-8
     source: 松山市食品営業許可全施設一覧
@@ -995,10 +1014,10 @@ sources:
     defaultCity: 熊本市
   - key: oita-city
     acquire:
-      type: get
-      urls:
-        - https://www.city.oita.oita.jp/o095/kenko/hoken/documents/r080601allkyoka.csv
-        - https://www.city.oita.oita.jp/o095/kenko/hoken/documents/r080601alltodoke.csv
+      type: resolve
+      pageUrl: https://www.city.oita.oita.jp/o095/kenko/hoken/20220908.html
+      hrefPattern: 'r080601all(?:kyoka|todoke)\.csv$'
+      multi: true
       format: csv
       encoding: auto
     source: 大分市食品営業許可・届出施設一覧

--- a/site/attribution.html
+++ b/site/attribution.html
@@ -197,7 +197,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://www.city.ichinomiya.aichi.jp/hokenjo/hoken-eisei/1044314/1039899/1040636.html" target="_blank" rel="noopener">https://www.city.ichinomiya.aichi.jp/hokenjo/hoken-eisei/1044314/1039899/1040636.html</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://www.city.ichinomiya.aichi.jp/_res/projects/default_project/_page_/001/040/636/232033_Food_Business_All_20260331.csv" target="_blank" rel="noopener">https://www.city.ichinomiya.aichi.jp/_res/projects/default_project/_pag…</a></dd>
+          <dd><a href="https://www.city.ichinomiya.aichi.jp/hokenjo/hoken-eisei/1044314/1039899/1040636.html" target="_blank" rel="noopener">https://www.city.ichinomiya.aichi.jp/hokenjo/hoken-eisei/1044314/103989…</a></dd>
         </dl>
         
         <div class="attr">
@@ -365,7 +365,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://www.city.takasaki.gunma.jp/page/4527.html" target="_blank" rel="noopener">https://www.city.takasaki.gunma.jp/page/4527.html</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://www.city.takasaki.gunma.jp/uploaded/attachment/40475.xlsx" target="_blank" rel="noopener">https://www.city.takasaki.gunma.jp/uploaded/attachment/40475.xlsx</a></dd>
+          <dd><a href="https://www.city.takasaki.gunma.jp/page/4527.html" target="_blank" rel="noopener">https://www.city.takasaki.gunma.jp/page/4527.html</a></dd>
         </dl>
         
         <div class="attr">
@@ -379,7 +379,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://opendata.smartcity-takamatsu.jp/ckan/dataset/licensed_food_business_facility_list" target="_blank" rel="noopener">https://opendata.smartcity-takamatsu.jp/ckan/dataset/licensed_food_business_facility_list</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://opendata.takamatsu-fact.com/licensed_food_business_facility_list/data.csv" target="_blank" rel="noopener">https://opendata.takamatsu-fact.com/licensed_food_business_facility_lis…</a></dd>
+          <dd><a href="https://opendata.smartcity-takamatsu.jp/ckan/dataset/licensed_food_business_facility_list" target="_blank" rel="noopener">https://opendata.smartcity-takamatsu.jp/ckan/dataset/licensed_food_busi…</a></dd>
         </dl>
         
         <div class="attr">
@@ -547,7 +547,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.html" target="_blank" rel="noopener">https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.html</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.files/382019_food_business_all_2026031.csv" target="_blank" rel="noopener">https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.f…</a><br><a href="https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.files/382019_food_business_all_2026032.csv" target="_blank" rel="noopener">https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.f…</a></dd>
+          <dd><a href="https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.html" target="_blank" rel="noopener">https://www.city.matsuyama.ehime.jp/shisei/opendata/metadata/shokuhin.h…</a></dd>
         </dl>
         
         <div class="attr">
@@ -575,7 +575,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://www.city.suita.osaka.jp/home/soshiki/div-kenkoiryo/eiseikanri/opendata.html" target="_blank" rel="noopener">https://www.city.suita.osaka.jp/home/soshiki/div-kenkoiryo/eiseikanri/opendata.html</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://www.city.suita.osaka.jp/_res/projects/default_project/_page_/001/017/170/20260331new.xlsx" target="_blank" rel="noopener">https://www.city.suita.osaka.jp/_res/projects/default_project/_page_/00…</a></dd>
+          <dd><a href="https://www.city.suita.osaka.jp/home/soshiki/div-kenkoiryo/eiseikanri/opendata.html" target="_blank" rel="noopener">https://www.city.suita.osaka.jp/home/soshiki/div-kenkoiryo/eiseikanri/o…</a></dd>
         </dl>
         
         <div class="attr">
@@ -589,7 +589,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://www.city.setagaya.lg.jp/02245/online_tetsuzuki/3246.html" target="_blank" rel="noopener">https://www.city.setagaya.lg.jp/02245/online_tetsuzuki/3246.html</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://www.city.setagaya.lg.jp/documents/3246/zenkenr080331.csv" target="_blank" rel="noopener">https://www.city.setagaya.lg.jp/documents/3246/zenkenr080331.csv</a></dd>
+          <dd><a href="https://www.city.setagaya.lg.jp/02245/online_tetsuzuki/3246.html" target="_blank" rel="noopener">https://www.city.setagaya.lg.jp/02245/online_tetsuzuki/3246.html</a></dd>
         </dl>
         
         <div class="attr">
@@ -603,7 +603,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://www.city.morioka.iwate.jp/kenkou/hokenjo/shokuhineisei/1017014/1006689.html" target="_blank" rel="noopener">https://www.city.morioka.iwate.jp/kenkou/hokenjo/shokuhineisei/1017014/1006689.html</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://www.city.morioka.iwate.jp/_res/projects/default_project/_page_/001/006/689/20260630.csv" target="_blank" rel="noopener">https://www.city.morioka.iwate.jp/_res/projects/default_project/_page_/…</a></dd>
+          <dd><a href="https://www.city.morioka.iwate.jp/kenkou/hokenjo/shokuhineisei/1017014/1006689.html" target="_blank" rel="noopener">https://www.city.morioka.iwate.jp/kenkou/hokenjo/shokuhineisei/1017014/…</a></dd>
         </dl>
         
         <div class="attr">
@@ -687,7 +687,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://www.city.taito.lg.jp/kusei/online/opendata/kenko/shokuhineisei.html" target="_blank" rel="noopener">https://www.city.taito.lg.jp/kusei/online/opendata/kenko/shokuhineisei.html</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://www.city.taito.lg.jp/kenkohukusi/kenkokikikanrieisei/food/syokuhin-sisetu/index.files/2026ALL-IND-CSV.csv" target="_blank" rel="noopener">https://www.city.taito.lg.jp/kenkohukusi/kenkokikikanrieisei/food/syoku…</a></dd>
+          <dd><a href="https://www.city.taito.lg.jp/kenkohukusi/kenkokikikanrieisei/food/syokuhin-sisetu/index.html" target="_blank" rel="noopener">https://www.city.taito.lg.jp/kenkohukusi/kenkokikikanrieisei/food/syoku…</a></dd>
         </dl>
         
         <div class="attr">
@@ -701,7 +701,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://www.city.osaka.lg.jp/kenko/page/0000575579.html" target="_blank" rel="noopener">https://www.city.osaka.lg.jp/kenko/page/0000575579.html</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://www.city.osaka.lg.jp/contents/wdu280/260331zenku.csv" target="_blank" rel="noopener">https://www.city.osaka.lg.jp/contents/wdu280/260331zenku.csv</a></dd>
+          <dd><a href="https://www.city.osaka.lg.jp/kenko/page/0000575579.html" target="_blank" rel="noopener">https://www.city.osaka.lg.jp/kenko/page/0000575579.html</a></dd>
         </dl>
         
         <div class="attr">
@@ -715,7 +715,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://www.city.otsu.lg.jp/soshiki/021/1441/od/02594.html" target="_blank" rel="noopener">https://www.city.otsu.lg.jp/soshiki/021/1441/od/02594.html</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://www.city.otsu.lg.jp/material/files/group/4/od_2605.csv" target="_blank" rel="noopener">https://www.city.otsu.lg.jp/material/files/group/4/od_2605.csv</a></dd>
+          <dd><a href="https://www.city.otsu.lg.jp/soshiki/021/1441/od/02594.html" target="_blank" rel="noopener">https://www.city.otsu.lg.jp/soshiki/021/1441/od/02594.html</a></dd>
         </dl>
         
         <div class="attr">
@@ -743,7 +743,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://www.city.chuo.lg.jp/kusei/gaiyou/toukeidate/opendata.html" target="_blank" rel="noopener">https://www.city.chuo.lg.jp/kusei/gaiyou/toukeidate/opendata.html</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://www.city.chuo.lg.jp/documents/984/syokuhineigyoukyoka.csv" target="_blank" rel="noopener">https://www.city.chuo.lg.jp/documents/984/syokuhineigyoukyoka.csv</a></dd>
+          <dd><a href="https://www.city.chuo.lg.jp/kusei/gaiyou/toukeidate/opendata.html" target="_blank" rel="noopener">https://www.city.chuo.lg.jp/kusei/gaiyou/toukeidate/opendata.html</a></dd>
         </dl>
         
         <div class="attr">
@@ -799,7 +799,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://www.city.nagano.nagano.jp/n023500/contents/p004876.html" target="_blank" rel="noopener">https://www.city.nagano.nagano.jp/n023500/contents/p004876.html</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://www.city.nagano.nagano.jp/documents/1948/202011_food_business_202605.csv" target="_blank" rel="noopener">https://www.city.nagano.nagano.jp/documents/1948/202011_food_business_2…</a></dd>
+          <dd><a href="https://www.city.nagano.nagano.jp/n023500/contents/p004876.html" target="_blank" rel="noopener">https://www.city.nagano.nagano.jp/n023500/contents/p004876.html</a></dd>
         </dl>
         
         <div class="attr">
@@ -897,7 +897,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://www.city.shinagawa.tokyo.jp/PC/kenkou/kenkou-eisei/kenkou-eisei-syokuhin/opendate.html" target="_blank" rel="noopener">https://www.city.shinagawa.tokyo.jp/PC/kenkou/kenkou-eisei/kenkou-eisei-syokuhin/opendate.html</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://www.city.shinagawa.tokyo.jp/contentshozon2026/R6-7.csv" target="_blank" rel="noopener">https://www.city.shinagawa.tokyo.jp/contentshozon2026/R6-7.csv</a></dd>
+          <dd><a href="https://www.city.shinagawa.tokyo.jp/PC/kenkou/kenkou-eisei/kenkou-eisei-syokuhin/opendate.html" target="_blank" rel="noopener">https://www.city.shinagawa.tokyo.jp/PC/kenkou/kenkou-eisei/kenkou-eisei…</a></dd>
         </dl>
         
         <div class="attr">
@@ -911,7 +911,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://opendata.pref.shizuoka.jp/dataset/11921.html" target="_blank" rel="noopener">https://opendata.pref.shizuoka.jp/dataset/11921.html</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://static.hamamatsu.odpf.net/opendata/v01/syokuhineiseidaityou202401/syokuhineiseidaityou202401.csv" target="_blank" rel="noopener">https://static.hamamatsu.odpf.net/opendata/v01/syokuhineiseidaityou2024…</a></dd>
+          <dd><a href="https://opendata.pref.shizuoka.jp/dataset/11921.html" target="_blank" rel="noopener">https://opendata.pref.shizuoka.jp/dataset/11921.html</a></dd>
         </dl>
         
         <div class="attr">
@@ -1059,7 +1059,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://www.pref.yamanashi.jp/eisei-ykm/itiranhyou1.html" target="_blank" rel="noopener">https://www.pref.yamanashi.jp/eisei-ykm/itiranhyou1.html</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://www.pref.yamanashi.jp/documents/23776/190004_food_business_all.csv" target="_blank" rel="noopener">https://www.pref.yamanashi.jp/documents/23776/190004_food_business_all.…</a></dd>
+          <dd><a href="https://www.pref.yamanashi.jp/eisei-ykm/itiranhyou1.html" target="_blank" rel="noopener">https://www.pref.yamanashi.jp/eisei-ykm/itiranhyou1.html</a></dd>
         </dl>
         
         <div class="attr">
@@ -1087,7 +1087,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://www.city.kawaguchi.lg.jp/soshiki/01090/027/shokuhin/oshirasetop/shisetsuichiran/index.html" target="_blank" rel="noopener">https://www.city.kawaguchi.lg.jp/soshiki/01090/027/shokuhin/oshirasetop/shisetsuichiran/index.html</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://www.city.kawaguchi.lg.jp/material/files/group/232/R0803zenshisetsuichiran.xls" target="_blank" rel="noopener">https://www.city.kawaguchi.lg.jp/material/files/group/232/R0803zenshise…</a></dd>
+          <dd><a href="https://www.city.kawaguchi.lg.jp/soshiki/01090/027/shokuhin/oshirasetop/shisetsuichiran/index.html" target="_blank" rel="noopener">https://www.city.kawaguchi.lg.jp/soshiki/01090/027/shokuhin/oshirasetop…</a></dd>
         </dl>
         
         <div class="attr">
@@ -1101,7 +1101,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://www.city.oita.oita.jp/o095/kenko/hoken/20220908.html" target="_blank" rel="noopener">https://www.city.oita.oita.jp/o095/kenko/hoken/20220908.html</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://www.city.oita.oita.jp/o095/kenko/hoken/documents/r080601allkyoka.csv" target="_blank" rel="noopener">https://www.city.oita.oita.jp/o095/kenko/hoken/documents/r080601allkyok…</a><br><a href="https://www.city.oita.oita.jp/o095/kenko/hoken/documents/r080601alltodoke.csv" target="_blank" rel="noopener">https://www.city.oita.oita.jp/o095/kenko/hoken/documents/r080601alltodo…</a></dd>
+          <dd><a href="https://www.city.oita.oita.jp/o095/kenko/hoken/20220908.html" target="_blank" rel="noopener">https://www.city.oita.oita.jp/o095/kenko/hoken/20220908.html</a></dd>
         </dl>
         
         <div class="attr">
@@ -1129,7 +1129,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://www.city.nara.lg.jp/soshiki/97/10411.html" target="_blank" rel="noopener">https://www.city.nara.lg.jp/soshiki/97/10411.html</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://www.city.nara.lg.jp/uploaded/attachment/203480.csv" target="_blank" rel="noopener">https://www.city.nara.lg.jp/uploaded/attachment/203480.csv</a></dd>
+          <dd><a href="https://www.city.nara.lg.jp/soshiki/97/10411.html" target="_blank" rel="noopener">https://www.city.nara.lg.jp/soshiki/97/10411.html</a></dd>
         </dl>
         
         <div class="attr">
@@ -1171,7 +1171,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://www.pref.fukushima.lg.jp/sec/21045e/shisetujouhou.html" target="_blank" rel="noopener">https://www.pref.fukushima.lg.jp/sec/21045e/shisetujouhou.html</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://www.pref.fukushima.lg.jp/uploaded/attachment/743308.xlsx" target="_blank" rel="noopener">https://www.pref.fukushima.lg.jp/uploaded/attachment/743308.xlsx</a></dd>
+          <dd><a href="https://www.pref.fukushima.lg.jp/sec/21045e/shisetujouhou.html" target="_blank" rel="noopener">https://www.pref.fukushima.lg.jp/sec/21045e/shisetujouhou.html</a></dd>
         </dl>
         
         <div class="attr">
@@ -1199,7 +1199,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://www.city.hirakata.osaka.jp/0000023479.html" target="_blank" rel="noopener">https://www.city.hirakata.osaka.jp/0000023479.html</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://www.city.hirakata.osaka.jp/cmsfiles/contents/0000023/23479/272108_food_business_all_202603_end.csv" target="_blank" rel="noopener">https://www.city.hirakata.osaka.jp/cmsfiles/contents/0000023/23479/2721…</a></dd>
+          <dd><a href="https://www.city.hirakata.osaka.jp/0000023479.html" target="_blank" rel="noopener">https://www.city.hirakata.osaka.jp/0000023479.html</a></dd>
         </dl>
         
         <div class="attr">


### PR DESCRIPTION
## 概要

掲載ページに直リンクしていた `get` 型ソースのうち、掲載ページから最新のダウンロードURLを解決できる **20件** を `resolve` 型に移行した。

## 移行した20件

| # | ソースキー | 一意特定方法 |
|---|---|---|
| 1 | osaka-city | linkPattern 一意一致 |
| 2 | morioka | linkPattern 一意一致 |
| 3 | fukushima-pref | linkPattern 一意一致 |
| 4 | takasaki | linkPattern 一意一致 |
| 5 | kawaguchi | linkPattern 前方一致 |
| 6 | chuo-ku | linkPattern 一意一致 |
| 7 | shinagawa-ku | linkPattern 一意一致 |
| 8 | setagaya-ku | linkPattern 前方一致（複数一致・同一href、後述） |
| 9 | yamanashi-pref | linkPattern 一意一致 |
| 10 | nagano-city | linkPattern 一意一致 |
| 11 | ichinomiya | linkPattern 一意一致 |
| 12 | otsu | linkPattern 一意一致 |
| 13 | hirakata | linkPattern 一意一致 |
| 14 | suita | linkPattern 一意一致（改正後/改正前を区別） |
| 15 | nara-city | linkPattern 一意一致 |
| 16 | takamatsu | linkPattern 一意一致 |
| 17 | matsuyama | hrefPattern + multi:true（2ファイル） |
| 18 | oita-city | hrefPattern + multi:true（2ファイル） |
| 19 | hamamatsu | hrefScan:true（西宮市で既に稼働中の方式を適用） |
| 20 | taito-ku | pageUrl をsourceUrlとは別の実データ掲載ページに変更＋hrefPattern |

`source` / `sourceUrl` / `license` / `defaultPref` / `defaultCity` 等の他フィールドは変更していない（taito-ku の `acquire.pageUrl` のみ、福井市の既存 resolve 型と同様に `sourceUrl` とは別ページを指定）。

## 【最重要】盛岡市・大津市の陳腐化解消

18件は移行前後でレコード件数が完全一致したが、**盛岡市（morioka）・大津市（otsu）の2件は before が0件（＝設定URLが404で完全に取得できていない状態）だった**。resolve化によりこれが解消し、それぞれ **3,584件・4,482件** が取得できるようになった。

| ソース | before | after |
|---|---:|---:|
| morioka | 0件（404） | **3,584件** |
| otsu | 0件（404） | **4,482件** |

- 盛岡市: 設定URLが `20260630.csv` のまま固定されていたが、掲載ページの現行リンクは `20260731.csv` に進んでいた
- 大津市: 設定URLが `od_2605.csv` のまま固定されていたが、掲載ページの現行リンクは `od_2607.csv` に進んでいた

**この2件は本番では `--allow-empty-sources` により404が握りつぶされ、欠落したまま配信され続けていた。** 404ベースの死活監視ではこの種の「設定URL自体の陳腐化」は検知できず、サイレントに欠落データが配信され続ける構造的な問題だった。resolve化はこの問題そのものを解消する。

## 移行前後のレコード件数比較（全20件）

`node scripts/crawl.js --only=<key> --no-geocode` を移行前後それぞれ1回ずつ実行し比較。

| ソース | before | after | 差分 |
|---|---:|---:|---|
| osaka-city | 65,517 | 65,517 | 一致 |
| morioka | 0（404） | 3,584 | ★陳腐化解消 |
| fukushima-pref | 13,351 | 13,351 | 一致 |
| takasaki | 5,167 | 5,167 | 一致 |
| kawaguchi | 8,034 | 8,034 | 一致 |
| chuo-ku | 2,548 | 2,548 | 一致 |
| shinagawa-ku | 1,983 | 1,983 | 一致 |
| setagaya-ku | 7,428 | 7,428 | 一致 |
| yamanashi-pref | 2,333 | 2,333 | 一致 |
| nagano-city | 6,142 | 6,142 | 一致 |
| ichinomiya | 2,815 | 2,815 | 一致 |
| otsu | 0（404） | 4,482 | ★陳腐化解消 |
| hirakata | 3,175 | 3,175 | 一致 |
| suita | 3,353 | 3,353 | 一致 |
| nara-city | 1,341 | 1,341 | 一致 |
| takamatsu | 7,350 | 7,350 | 一致 |
| matsuyama | 7,687 | 7,687 | 一致 |
| oita-city | 6,150 | 6,150 | 一致 |
| hamamatsu | 5,280 | 5,280 | 一致 |
| taito-ku | 7,676 | 7,676 | 一致 |

setagaya-ku のみ「2件一致。先頭を採用」という警告が出るが、DOM上に同一hrefが2箇所重複表示されているだけで実URLは1つであり、実害はない。それ以外のソースでは複数一致の警告は出ていない。

## 移行しなかったもの・見送った理由

- **福井県（fukui-pref）**: 先行調査では「pageUrl を別ページに差し替えれば済む」という位置づけだったが、実際に確認したところ、776.csv と 777.csv は別々のCKANデータセットページに分かれており、1ページに両方のリンクが載っているわけではなかった。現行の `resolve` 型は `pageUrl` を1つしか持てない設計のため、コード改修なしでは実現できない。先行調査の前提が実態と食い違っていたため見送った（設定は変更していない）。
- **コード改修が前提の5件（いわき市・神戸市・渋谷区・東京都保健医療局・熊本市）**: 依頼のスコープ外として今回は手を出していない。東京都保健医療局は盛岡市・大津市と同種の陳腐化（3件目）があるが、拡張子なしhrefのため `format` フィルタが機能しない等のコード改修が前提であり、今回は着手していない。
- **「条件付き」の残りと「できない」9件**: いずれも依頼の禁止事項に従い変更していない。

## 変異注入テスト

`osaka-city` の `linkPattern` を存在しない文言に意図的に書き換えて `node scripts/crawl.js --only=osaka-city` を実行し、以下を確認した後に元に戻した。

```
⚠ osaka-city をスキップ: リンク解決に失敗: https://www.city.osaka.lg.jp/kenko/page/0000575579.html
  に「存在しない文言XXXMUTATIONXXX」に一致する .csv リンクが見つかりません
❌ エラー: 施設を1件も取り込めなかったソースが 1件 あります（--allow-empty-sources 無しでは中断）
```

期待通り、リンク解決失敗として明確に検知され、`--allow-empty-sources` を付けない限りパイプライン全体が中断されることを確認した。

## その他の変更

- `site/attribution.html` を `npm run build:attribution` で再生成した（`resolve` 型は固定の取得URLを持たないため「取得URL」欄が `pageUrl` 表示に変わる。生成元の `config/sources.yaml` 以外は手で編集していない）

## テスト

- `npm run test:unit`: 全18スイート合格
- `node scripts/crawl.js --only=<20キー> --no-geocode`: 移行前後で比較（上表）
- `npm run build`（フルクロール）は実行していない
