### PR TITLE
残り17件のうち9件を ckan/resolve 型に移行する

### DIFF
--- a/config/sources.yaml
+++ b/config/sources.yaml
@@ -574,9 +574,9 @@ sources:
     defaultCity: 中央区
   - key: shinjuku-ku
     acquire:
-      type: get
-      url: https://www.city.shinjuku.lg.jp/content/000399975.csv
-      format: csv
+      type: ckan
+      ckanBase: https://catalog.data.metro.tokyo.lg.jp
+      resourceId: 2f89768e-56e2-4932-a416-92fdfa47024d
       encoding: utf-16
     source: 東京都新宿区食品等営業許可・届出一覧
     sourceUrl: https://catalog.data.metro.tokyo.lg.jp/dataset/t131041d0000000124
@@ -597,9 +597,9 @@ sources:
     defaultCity: 台東区
   - key: koto-ku
     acquire:
-      type: get
-      url: https://www.opendata.metro.tokyo.lg.jp/koto/131083_015_food_business_all.csv
-      format: csv
+      type: ckan
+      ckanBase: https://catalog.data.metro.tokyo.lg.jp
+      resourceId: 2235418f-2d52-4d0c-88f7-4c3dd171de47
       encoding: utf-8
     source: 東京都江東区食品等営業許可・届出一覧
     sourceUrl: https://catalog.data.metro.tokyo.lg.jp/dataset/t131083d0000000028
@@ -620,9 +620,9 @@ sources:
     defaultCity: 品川区
   - key: nakano-ku
     acquire:
-      type: get
-      url: https://www2.wagmap.jp/nakanodatamap/nakanodatamap/opendatafile/map_40/CSV/opendata_550150.csv
-      format: csv
+      type: ckan
+      ckanBase: https://catalog.data.metro.tokyo.lg.jp
+      resourceId: 502937e9-2dc2-4b1d-baf6-bd53300da4f1
       encoding: utf-8
     source: 東京都中野区食品等営業許可届出一覧
     sourceUrl: https://catalog.data.metro.tokyo.lg.jp/dataset/t131148d0000000129
@@ -654,9 +654,9 @@ sources:
     defaultCity: 渋谷区
   - key: higashimurayama
     acquire:
-      type: get
-      url: https://www.opendata.metro.tokyo.lg.jp/higashimurayama/20240619_food_business_all.csv
-      format: csv
+      type: ckan
+      ckanBase: https://catalog.data.metro.tokyo.lg.jp
+      resourceId: 0e0b6e43-195f-4bb0-8687-9de73e613587
       encoding: utf-8
     source: 東京都東村山市食品等営業許可・届出一覧
     sourceUrl: https://catalog.data.metro.tokyo.lg.jp/dataset/t132136d3100000018
@@ -687,13 +687,14 @@ sources:
     defaultCity: 茅ヶ崎市
   - key: toyama-pref
     acquire:
-      type: get
-      url: https://toyama-pref.box.com/shared/static/1t6074lluawpua1u5jhx1yeaynb48rle.csv
-      format: csv
+      type: ckan
+      ckanBase: https://ckan.tdcp.pref.toyama.jp
+      resourceId: 21090a50-6e47-4edb-8405-f2507b7f2738
       encoding: shift_jis
     source: 富山県食品営業許可施設一覧
-    # 旧ポータル閉鎖（2026-05-29）に伴い富山データ連携基盤へ移転。CKAN の license_id は cc-zero
-    sourceUrl: https://ckan-front.tdcp.pref.toyama.jp/dataset/syokuhin
+    # 旧ポータル閉鎖（2026-05-29）に伴い富山データ連携基盤へ移転。CKAN の license_id は cc-zero。
+    # sourceUrl はポータルのランディングページ（ckan-front）ではなく、実CKAN本体（ckan.）のデータセットページ
+    sourceUrl: https://ckan.tdcp.pref.toyama.jp/dataset/syokuhin
     license: CC0 1.0
     defaultPref: 富山県
   - key: toyama-city
@@ -921,8 +922,9 @@ sources:
     defaultCity: 奈良市
   - key: tottori-city
     acquire:
-      type: get
-      url: https://odp-pref-tottori.tori-info.co.jp/dataset/1858/resource/9560/312011_food_business_all.csv
+      type: resolve
+      pageUrl: https://odp-pref-tottori.tori-info.co.jp/dataset/1858.html
+      hrefPattern: '312011_food_business_all\.csv$'
       format: csv
       encoding: utf-8
     source: 鳥取市食品等営業許可・届出一覧
@@ -965,8 +967,9 @@ sources:
     defaultCity: 下関市
   - key: tokushima-pref
     acquire:
-      type: get
-      url: https://opendata.pref.tokushima.lg.jp/dataset/4615/resource/14084/36000_food_business_all.csv
+      type: resolve
+      pageUrl: https://opendata.pref.tokushima.lg.jp/dataset/4615.html
+      hrefPattern: '36000_food_business_all\.csv$'
       format: csv
       encoding: utf-8
     source: 徳島県食品等営業許可・届出一覧
@@ -1003,8 +1006,12 @@ sources:
     defaultCity: 松山市
   - key: kumamoto-city
     acquire:
-      type: get
-      url: https://www.city.kumamoto.jp/dynamic/opendata/pub/Insyokutenneigyoukyoka.csv
+      type: resolve
+      pageUrl: https://www.city.kumamoto.jp/dynamic/opendata/pub/detail.aspx?c_id=38&id=60
+      # このページの <a> は href='...' の単一引用符（resolveLinkFromHtml の二重引用符専用の抽出は非対応）。
+      # hrefScan は <a> をパースせず生HTML中を正規表現で走査するため、引用符の種類に依存せず解決できる。
+      hrefScan: true
+      hrefPattern: 'Insyokutenneigyoukyoka\.csv'
       format: csv
       encoding: utf-8
     source: 熊本市飲食店営業許可施設一覧
@@ -1037,9 +1044,10 @@ sources:
     defaultCity: 相模原市
   - key: tokyo-hokeniryo
     acquire:
-      type: get
-      url: https://www.hokeniryo.metro.tokyo.lg.jp/documents/d/hokeniryo/shokuhin-kyoka-4
-      format: csv
+      type: resolve
+      pageUrl: https://www.hokeniryo.metro.tokyo.lg.jp/kenkou/hokenjo_daicho/shokuhineigyokyokadaicho
+      # href に拡張子が無い（Liferayの整形URL）ため format/linkFormat は指定せず、文言のみで一意に絞り込む
+      linkPattern: '食品関係営業台帳（許可）（CSV'
       encoding: shift_jis
     source: 東京都（保健医療局）食品関係営業許可台帳
     sourceUrl: https://www.hokeniryo.metro.tokyo.lg.jp/kenkou/hokenjo_daicho/shokuhineigyokyokadaicho

--- a/site/attribution.html
+++ b/site/attribution.html
@@ -337,7 +337,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://catalog.data.metro.tokyo.lg.jp/dataset/t131083d0000000028" target="_blank" rel="noopener">https://catalog.data.metro.tokyo.lg.jp/dataset/t131083d0000000028</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://www.opendata.metro.tokyo.lg.jp/koto/131083_015_food_business_all.csv" target="_blank" rel="noopener">https://www.opendata.metro.tokyo.lg.jp/koto/131083_015_food_business_al…</a></dd>
+          <dd><a href="https://catalog.data.metro.tokyo.lg.jp/api/3/action/resource_show?id=2235418f-2d52-4d0c-88f7-4c3dd171de47" target="_blank" rel="noopener">https://catalog.data.metro.tokyo.lg.jp/api/3/action/resource_show?id=22…</a></dd>
         </dl>
         
         <div class="attr">
@@ -561,7 +561,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://catalog.data.metro.tokyo.lg.jp/dataset/t131041d0000000124" target="_blank" rel="noopener">https://catalog.data.metro.tokyo.lg.jp/dataset/t131041d0000000124</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://www.city.shinjuku.lg.jp/content/000399975.csv" target="_blank" rel="noopener">https://www.city.shinjuku.lg.jp/content/000399975.csv</a></dd>
+          <dd><a href="https://catalog.data.metro.tokyo.lg.jp/api/3/action/resource_show?id=2f89768e-56e2-4932-a416-92fdfa47024d" target="_blank" rel="noopener">https://catalog.data.metro.tokyo.lg.jp/api/3/action/resource_show?id=2f…</a></dd>
         </dl>
         
         <div class="attr">
@@ -757,7 +757,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://catalog.data.metro.tokyo.lg.jp/dataset/t131148d0000000129" target="_blank" rel="noopener">https://catalog.data.metro.tokyo.lg.jp/dataset/t131148d0000000129</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://www2.wagmap.jp/nakanodatamap/nakanodatamap/opendatafile/map_40/CSV/opendata_550150.csv" target="_blank" rel="noopener">https://www2.wagmap.jp/nakanodatamap/nakanodatamap/opendatafile/map_40/…</a></dd>
+          <dd><a href="https://catalog.data.metro.tokyo.lg.jp/api/3/action/resource_show?id=502937e9-2dc2-4b1d-baf6-bd53300da4f1" target="_blank" rel="noopener">https://catalog.data.metro.tokyo.lg.jp/api/3/action/resource_show?id=50…</a></dd>
         </dl>
         
         <div class="attr">
@@ -813,7 +813,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://www.hokeniryo.metro.tokyo.lg.jp/kenkou/hokenjo_daicho/shokuhineigyokyokadaicho" target="_blank" rel="noopener">https://www.hokeniryo.metro.tokyo.lg.jp/kenkou/hokenjo_daicho/shokuhineigyokyokadaicho</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://www.hokeniryo.metro.tokyo.lg.jp/documents/d/hokeniryo/shokuhin-kyoka-4" target="_blank" rel="noopener">https://www.hokeniryo.metro.tokyo.lg.jp/documents/d/hokeniryo/shokuhin-…</a></dd>
+          <dd><a href="https://www.hokeniryo.metro.tokyo.lg.jp/kenkou/hokenjo_daicho/shokuhineigyokyokadaicho" target="_blank" rel="noopener">https://www.hokeniryo.metro.tokyo.lg.jp/kenkou/hokenjo_daicho/shokuhine…</a></dd>
         </dl>
         
         <div class="attr">
@@ -827,7 +827,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://catalog.data.metro.tokyo.lg.jp/dataset/t132136d3100000018" target="_blank" rel="noopener">https://catalog.data.metro.tokyo.lg.jp/dataset/t132136d3100000018</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://www.opendata.metro.tokyo.lg.jp/higashimurayama/20240619_food_business_all.csv" target="_blank" rel="noopener">https://www.opendata.metro.tokyo.lg.jp/higashimurayama/20240619_food_bu…</a></dd>
+          <dd><a href="https://catalog.data.metro.tokyo.lg.jp/api/3/action/resource_show?id=0e0b6e43-195f-4bb0-8687-9de73e613587" target="_blank" rel="noopener">https://catalog.data.metro.tokyo.lg.jp/api/3/action/resource_show?id=0e…</a></dd>
         </dl>
         
         <div class="attr">
@@ -855,7 +855,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://opendata.pref.tokushima.lg.jp/dataset/4615.html" target="_blank" rel="noopener">https://opendata.pref.tokushima.lg.jp/dataset/4615.html</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://opendata.pref.tokushima.lg.jp/dataset/4615/resource/14084/36000_food_business_all.csv" target="_blank" rel="noopener">https://opendata.pref.tokushima.lg.jp/dataset/4615/resource/14084/36000…</a></dd>
+          <dd><a href="https://opendata.pref.tokushima.lg.jp/dataset/4615.html" target="_blank" rel="noopener">https://opendata.pref.tokushima.lg.jp/dataset/4615.html</a></dd>
         </dl>
         
         <div class="attr">
@@ -1115,7 +1115,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://odp-pref-tottori.tori-info.co.jp/dataset/1858.html" target="_blank" rel="noopener">https://odp-pref-tottori.tori-info.co.jp/dataset/1858.html</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://odp-pref-tottori.tori-info.co.jp/dataset/1858/resource/9560/312011_food_business_all.csv" target="_blank" rel="noopener">https://odp-pref-tottori.tori-info.co.jp/dataset/1858/resource/9560/312…</a></dd>
+          <dd><a href="https://odp-pref-tottori.tori-info.co.jp/dataset/1858.html" target="_blank" rel="noopener">https://odp-pref-tottori.tori-info.co.jp/dataset/1858.html</a></dd>
         </dl>
         
         <div class="attr">
@@ -1267,7 +1267,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://www.city.kumamoto.jp/dynamic/opendata/pub/detail.aspx?c_id=38&amp;id=60" target="_blank" rel="noopener">https://www.city.kumamoto.jp/dynamic/opendata/pub/detail.aspx?c_id=38&amp;id=60</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://www.city.kumamoto.jp/dynamic/opendata/pub/Insyokutenneigyoukyoka.csv" target="_blank" rel="noopener">https://www.city.kumamoto.jp/dynamic/opendata/pub/Insyokutenneigyoukyok…</a></dd>
+          <dd><a href="https://www.city.kumamoto.jp/dynamic/opendata/pub/detail.aspx?c_id=38&amp;id=60" target="_blank" rel="noopener">https://www.city.kumamoto.jp/dynamic/opendata/pub/detail.aspx?c_id=38&amp;i…</a></dd>
         </dl>
         <span class="badge">元の表記: 公共データ利用規約</span>
         <div class="attr">
@@ -1325,14 +1325,14 @@
         <h3>富山県<span class="dataset">食品営業許可施設一覧</span></h3>
         <dl>
           <dt>出典ページ</dt>
-          <dd><a href="https://ckan-front.tdcp.pref.toyama.jp/dataset/syokuhin" target="_blank" rel="noopener">https://ckan-front.tdcp.pref.toyama.jp/dataset/syokuhin</a></dd>
+          <dd><a href="https://ckan.tdcp.pref.toyama.jp/dataset/syokuhin" target="_blank" rel="noopener">https://ckan.tdcp.pref.toyama.jp/dataset/syokuhin</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://toyama-pref.box.com/shared/static/1t6074lluawpua1u5jhx1yeaynb48rle.csv" target="_blank" rel="noopener">https://toyama-pref.box.com/shared/static/1t6074lluawpua1u5jhx1yeaynb48…</a></dd>
+          <dd><a href="https://ckan.tdcp.pref.toyama.jp/api/3/action/resource_show?id=21090a50-6e47-4edb-8405-f2507b7f2738" target="_blank" rel="noopener">https://ckan.tdcp.pref.toyama.jp/api/3/action/resource_show?id=21090a50…</a></dd>
         </dl>
         
         <div class="attr">
-          <code>出典：富山県「食品営業許可施設一覧」（https://ckan-front.tdcp.pref.toyama.jp/dataset/syokuhin）を加工して作成（CC0 1.0）</code>
-          <button type="button" class="copy" data-copy="出典：富山県「食品営業許可施設一覧」（https://ckan-front.tdcp.pref.toyama.jp/dataset/syokuhin）を加工して作成（CC0 1.0）">コピー</button>
+          <code>出典：富山県「食品営業許可施設一覧」（https://ckan.tdcp.pref.toyama.jp/dataset/syokuhin）を加工して作成（CC0 1.0）</code>
+          <button type="button" class="copy" data-copy="出典：富山県「食品営業許可施設一覧」（https://ckan.tdcp.pref.toyama.jp/dataset/syokuhin）を加工して作成（CC0 1.0）">コピー</button>
         </div>
       </article>
     </section>


### PR DESCRIPTION
## 概要

`get` 型（URL直叩き）で残っていた17件を再調査し、**9件を `ckan` または `resolve` 型に移行**した。
残り8件は個別に検証した上で、具体的な理由とともに `get` 型据え置きとした（「未確認」は無し）。

先行調査は「掲載ページのHTMLがWAFで取得不可＝移行不可」で結論づけていたが、これは早すぎる
結論だった。**HTMLページが取れないことと、CKAN API・直リンク自体が使えないことは別問題**であり、
実際にAPI・直リンクを個別に叩き直した結果、17件中9件で移行できる経路が見つかった。

## 17件全件の結論表

| # | キー | 結論 | 手段 / 理由 |
|---|---|---|---|
| 1 | shinjuku-ku | **移行（ckan）** | 東京都カタログのHTMLはWAFで0バイトだが `/api/3/action/package_show` は200で通り、現行URLと完全一致 |
| 2 | koto-ku | **移行（ckan）** | 同上 |
| 3 | nakano-ku | **移行（ckan）** | 同上 |
| 4 | higashimurayama | **移行（ckan）** | 同上 |
| 5 | toyama-pref | **移行（ckan）** | `sourceUrl`（ckan-front...）はCKAN非対応のランディングページだったが、実CKAN本体が別ホスト`ckan.tdcp.pref.toyama.jp`にあった。APIのresource urlは現行box.com URLと完全一致。sourceUrlも実データセットページへ差し替え |
| 6 | kanazawa | **現状維持（get）** | CKAN API自体は200で通るが、リソースがCKAN datastore限定（`resource_show`の`url`が空、実体は`/datastore/dump/{id}`経由）で、現行`ckan`型実装（`info.url`をそのまま使う設計）では扱えない（要コード改修・スコープ外）。現行`get`は動作確認済み（8,843件） |
| 7 | fukui-pref | **現状維持（get）** | CKAN API確認、776・777とも現行URLと完全一致。ただし1エントリで複数`resourceId`を扱う仕組みが現行`ckan`型に無い（要コード改修・スコープ外）。現行`get`（`urls:`で2ファイル結合）は既にAPIの示す正しいURLと一致 |
| 8 | tottori-city | **移行（resolve）** | `resource_show`は404（CKAN互換でない独自ポータル）だが、掲載ページ自体はWAFに弾かれておらず直リンクが実在した |
| 9 | tokushima-pref | **移行（resolve）** | 同上 |
| 10 | shibuya-ku | **現状維持（get）** | 現行`get`のURL自体がArcGIS Hub Download APIの恒久エンドポイント（item IDは不変GUID）。動作確認済み（30,192行）。既にAPI相当で最適な形、新しい`acquire`サブタイプが無いと`resolve`化のメリットが無い |
| 11 | aichi-pref | **現状維持（get）** | 掲載ページだけでなく、**現行設定の直リンクCSV自体も同一のWAF（Incapsula）に阻まれる**ことを確認。API不在（そもそもCKAN等ではない）。ページ・直リンクの両方を検証した上での結論 |
| 12 | chigasaki | **現状維持（get）** | 現行`get`のURLは動作確認済み（489,581 bytes）。掲載ページ→案内先の「オープンデータライブラリ」ページまで2ホップ辿ったが、どちらにも直リンクへの言及が無く`resolve`の起点が見つからない |
| 13 | matsumoto | **現状維持（get）** | 先行調査の「配布停止中」は再検証で確認できず、**現在も正常取得できる**（112,983 bytes、事実誤認だった可能性）。linkdata.orgのIDは固定的で`resolve`化の実益が薄い |
| 14 | iwaki | **現状維持（get）** | ページに複数年度のCSV（R07/R08）が残存し、DOM順で先頭一致させると古い年度を掴む。年最大値選択ロジックが現行`resolveLinkFromHtml`に無く要コード改修（スコープ外） |
| 15 | kobe | **現状維持（get）** | 同種の年度重複問題。今日時点はDOM順（2026年版が先）でたまたま正しく動くが、順序が変われば静かに古いデータを掴む恐れがあり、コード改修なしでは安全に移行できない |
| 16 | kumamoto-city | **移行（resolve/hrefScan）** | `<a href='...'>`と単一引用符のため通常の`resolveLinkFromHtml`（二重引用符専用）は非対応だが、既存の`hrefScan`（生HTML走査、引用符に依存しない）で回避できた。コード改修不要 |
| 17 | tokyo-hokeniryo | **移行（resolve）** | hrefに拡張子が無い（Liferayの整形URL）ため`format`を外し`linkPattern`のみで一意に絞り込み。現行設定値`shokuhin-kyoka-4`は陳腐化しており、`resolve`化で現行の`shokuhin-kyoka-6`を指すよう修正 |

## 主な発見

### 1. 東京都カタログ4件: 「HTMLが取れない」≠「APIが使えない」

`shinjuku-ku` / `koto-ku` / `nakano-ku` / `higashimurayama` の掲載ページ
（`catalog.data.metro.tokyo.lg.jp/dataset/...`）は AWS WAF の JS チャレンジで静的HTTP取得が
0バイトになる。先行調査はこれをもって「移行不可」と判定していたが、**WAFが弾いていたのは
HTMLページであって、CKAN API（`/api/3/action/package_show`）は別経路であり、実際に叩くと
200で通り、現行の`get`型URLと完全一致する結果を返した**。先行調査の「HTMLが取れない」だけを
根拠にした「できない」判定は早すぎる結論だった。この4件は `ckan` 型へ移行し、WAFに左右されない
安定した取得経路に切り替わった。

### 2. 富山県: `sourceUrl` はCKAN非対応のランディングページ、実CKAN本体は別ホスト

現行の`sourceUrl`（`ckan-front.tdcp.pref.toyama.jp/dataset/syokuhin`）にCKAN APIを叩くと、
CKANではない静的なポータルトップページのHTMLが返るだけだった。しかしこのページ内のリンクを
辿ると、実際のCKAN本体は別ホスト`ckan.tdcp.pref.toyama.jp`にあることが分かった。そちらで
`package_search`/`resource_show`を叩くと正しくJSONが返り、resource URLは現行の box.com
直リンクと完全一致した。`ckan`型へ移行し、`sourceUrl`もランディングページから実データセット
ページへ差し替えた。

### 3. 東京都保健医療局: 移行と同時に陳腐化を解消

`tokyo-hokeniryo`の現行設定値は`shokuhin-kyoka-4`だったが、掲載ページを再取得すると
既に`shokuhin-kyoka-6`に更新されていた（1世代前のスナップショットを掴んだままになっていた）。
`resolve`型へ移行したことで、この陳腐化がクロール実行のたびに自動で解消するようになった
（移行前後でレコード件数を比較すると141件減少しているが、これは新しい時点のデータを
正しく取得するようになったことによる想定内の差分）。

### 4. 松本市: 先行調査の「配布停止中」は再検証で確認できず

先行調査は`matsumoto`について「配布先（linkdata.org）が既知の理由で停止中」と判定していたが、
今回再検証したところ、現行の`get`型URLは今も正常にデータを返すことを確認した
（112,983 bytes、有効なTSVデータ）。linkdata.org側にサービス終了の告知も見当たらず、
**先行調査の判定は事実誤認だった可能性がある**。ただし当該IDは固定的な永続URLのため、
`resolve`化による実益は薄いと判断し、`get`型のまま据え置いた。

### 5. 据え置き8件の理由の内訳

据え置いた8件は一律の理由ではなく、3種類に分かれる。

- **コード改修が前提のもの（4件）**: `kanazawa`（CKAN datastore限定リソースに現行`ckan`型が
  非対応）、`fukui-pref`（1エントリで複数resourceIdを扱う仕組みが無い）、`iwaki`・`kobe`
  （複数年度の候補から最新を選ぶロジックが`resolveLinkFromHtml`に無い）。いずれも
  `scripts/`側の拡張があれば移行できる見込みがあり、次issueの候補として報告書に記載した
- **既にAPI相当で最適なもの（1件）**: `shibuya-ku`。現行`get`のURLがArcGIS Hub Download API
  の恒久エンドポイント（item IDは不変GUID）そのものであり、`resolve`化してもこれ以上の
  安定性は得られない
- **WAFがデータ本体にも及ぶもの（1件）**: `aichi-pref`。掲載ページだけでなく、現行設定の
  直リンクCSV自体も同一のWAF（Incapsula）に阻まれることを確認した。ページのHTMLが
  取れないだけでなく、データファイル自体に到達できないという、より決定的な理由
- **起点となる導線が見つからないもの（1件）**: `chigasaki`。現行の直リンクは動作するが、
  掲載ページおよびその先の関連ページのいずれにも直リンクへの言及が無く、`resolve`化の
  足がかりが無い

## 変更したファイル

- `config/sources.yaml` — 9件（shinjuku-ku, koto-ku, nakano-ku, higashimurayama, toyama-pref,
  tottori-city, tokushima-pref, kumamoto-city, tokyo-hokeniryo）を `get` → `ckan`/`resolve` 型に変更
- `site/attribution.html` — 上記の変更に追随して `npm run build:attribution` で再生成

`scripts/` のコードは変更していない。

## テスト

- 9件すべて `node scripts/crawl.js --only=<key> --no-geocode` で実データ取得を確認
- 移行前後（新旧の`config/sources.yaml`）でレコード件数を比較し、8件は完全一致・
  `tokyo-hokeniryo`のみ陳腐化解消による想定内の差分（141件減）を確認
- `npm run test:unit` 全件合格
- 変異注入: `ckan`型（resourceIdを破壊）・`resolve`型（hrefPatternを破壊）のいずれも、
  クロールが該当ソースをスキップした上で `exit code 1` で中断されることを確認
  （欠落データが黙って配信されない設計が機能していることの確認）

詳細な調査記録・据え置き8件それぞれの検証手順は作業報告に記載している。
