### PR TITLE
acquireを拡張しいわき市・神戸市・金沢市・福井県をckan/resolve型に移行する

### DIFF
--- a/config/sources.yaml
+++ b/config/sources.yaml
@@ -11,6 +11,11 @@
 #   key            一意キー（キャッシュ名・--only 指定に使用）
 #   acquire        取得方法:
 #     { type: ckan, ckanBase, resourceId }        CKAN resource_show でURL解決
+#         resourceId は単一文字列でも配列でもよい（配列なら1エントリで複数リソースを結合して取得。
+#           例: 福井県は776/777の2 resourceId を1ソースにまとめている）
+#         result.url が空で datastore_active:true のリソース（filestoreに実体が無く CKAN の
+#           datastore テーブルにしかデータが無いもの）は `<ckanBase>/datastore/dump/<resourceId>`
+#           に自動でフォールバックする（例: 金沢市）
 #     { type: get,  url|urls, format?, encoding? } URLを直接GET（urls は複数結合）
 #     { type: post, url, body, format? }           フォームPOSTで取得（京都市 等）
 #     { type: resolve, pageUrl, linkPattern?, hrefPattern?, format } 掲載ページから最新の実URLを解決
@@ -20,6 +25,11 @@
 #         hrefScan: true <a> に限らず生HTML中で hrefPattern に一致するURL/パスを拾う
 #                        （<button value="..."> 等 アンカー以外にURLが埋まっているページ向け）
 #         linkFormat     リンク抽出時の拡張子フィルタ（省略時は format。拡張子とパース形式が違う時に使う）
+#         pickLatest: true 複数一致したとき DOM順の先頭ではなく日付が最大の候補を採用する
+#                        （同一ページに複数年度のファイルが並存し、DOM順に依存すると古いデータを
+#                        静かに掴む危険がある自治体向け。例: いわき市・神戸市。日付の抽出は
+#                        西暦4/6/8桁・和暦(R08 / R0803 / R080331)に対応。西暦と和暦が候補間で
+#                        混在している場合や日付を抽出できる候補が1件も無い場合は例外を投げる）
 #     { type: i2fasglob }                          .cache/i2fas/*.csv を一括取込（厚労省 i2fas）
 #     format:   csv | tsv | xlsx | xls（省略時はURL/CKAN情報から推定）
 #     encoding: utf-8 | shift_jis | utf-16 | auto（既定 auto）
@@ -518,10 +528,16 @@ sources:
     defaultPref: 福島県
     defaultCity: 福島市
   - key: iwaki
+    # 掲載ページに複数年度のCSV（R07/R08 等）が並存し、年1回ファイル名の和暦年が繰り上がる。
+    # DOM順の先頭を採用すると古い年度を掴む危険があるため pickLatest で最新年度を選ぶ。
+    # hrefPattern は「Shokuhin_itiran_R + 2桁 + .csv」の年ベースファイルのみに絞り、
+    # 同じページに並ぶ月次差分（Shokuhin_itiran_R0604.csv 等、年+月4桁）を除外する。
     acquire:
-      type: get
-      url: https://www.city.iwaki.lg.jp/www/contents/1652661537484/simple/Shokuhin_itiran_R08.csv
+      type: resolve
+      pageUrl: https://www.city.iwaki.lg.jp/www/contents/1652661537484/index.html
+      hrefPattern: 'Shokuhin_itiran_R\d{2}\.csv$'
       format: csv
+      pickLatest: true
       encoding: utf-8
     source: いわき市食品営業許可施設一覧
     sourceUrl: https://www.city.iwaki.lg.jp/www/contents/1652661537484/index.html
@@ -709,9 +725,13 @@ sources:
     defaultPref: 富山県
     defaultCity: 富山市
   - key: kanazawa
+    # CKAN API（resource_show）は200で通るが、返る result.url は空文字。
+    # datastore_active:true が立っている datastore 専用リソースで、実体はfilestoreではなく
+    # CKAN の datastore テーブル側にしか無い。acquire.js 側で datastore/dump にフォールバックする。
     acquire:
-      type: get
-      url: https://catalog-data.city.kanazawa.ishikawa.jp/datastore/dump/09a49521-cabf-40b4-978b-bd61ef02f650?bom=true
+      type: ckan
+      ckanBase: https://catalog-data.city.kanazawa.ishikawa.jp
+      resourceId: 09a49521-cabf-40b4-978b-bd61ef02f650
       format: csv
       encoding: utf-8
     source: 金沢市食品衛生関係営業許可施設一覧
@@ -720,11 +740,14 @@ sources:
     defaultPref: 石川県
     defaultCity: 金沢市
   - key: fukui-pref
+    # 776/777 の2データセットを1ソースとして結合する。ckan.odp.jig.jp で resource_show を実際に
+    # 叩いて確認済み: 各 resourceId が返す result.url は現行の直リンクURLと完全一致する。
     acquire:
-      type: get
-      urls:
-        - https://data.odp.jig.jp/viewcsv/jp/fukui/776.csv
-        - https://data.odp.jig.jp/viewcsv/jp/fukui/777.csv
+      type: ckan
+      ckanBase: https://ckan.odp.jig.jp
+      resourceId:
+        - fdc03bef-3212-46f7-8768-907adf08eee0 # https://data.odp.jig.jp/viewcsv/jp/fukui/776.csv
+        - 77c101ac-47b0-49ed-9fba-e8cfdecec602 # https://data.odp.jig.jp/viewcsv/jp/fukui/777.csv
       format: csv
       encoding: utf-8
     source: 福井県食品営業許可取得施設
@@ -871,10 +894,18 @@ sources:
     defaultPref: 大阪府
     defaultCity: 吹田市
   - key: kobe
+    # 掲載ページに「全ての許可施設」の現行版（2026年3月末現在）と改正前旧法版（2021年5月末現在）が
+    # 同じ文言テンプレで並存する。現状はDOM順（現行版が先）でたまたま正しいが、
+    # 順序が変われば静かに5年前のデータを取り始めるため pickLatest で最新日付を選ぶ。
+    # linkPattern はどちらも先頭が「全ての許可施設」で始まる（月次の新規許可施設一覧・
+    # 理容所等の他施設一覧とはここで区別できる）。日付はリンク文言中の「YYYY年M月」から抽出する
+    # （href側は現行版が14桁タイムスタンプ・旧法版が和暦ファイル名で表記が揃っておらず比較できない）。
     acquire:
-      type: get
-      url: https://www.city.kobe.lg.jp/documents/6359/20260407150739.csv
+      type: resolve
+      pageUrl: https://www.city.kobe.lg.jp/a99427/kenko/health/hygiene/dataset.html
+      linkPattern: '^全ての許可施設'
       format: csv
+      pickLatest: true
       encoding: shift_jis
     source: 神戸市食品営業許可施設一覧
     sourceUrl: https://www.city.kobe.lg.jp/a99427/kenko/health/hygiene/dataset.html

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:attribution": "node scripts/generate/attribution.js",
     "build:llms": "node scripts/generate/llms.js",
     "fetch:i2fas": "node scripts/tools/fetch-i2fas.js",
-    "test:unit": "node scripts/crawl.test.js && node scripts/lib/config.test.js && node scripts/lib/geocode.test.js && node scripts/lib/coord-quality.test.js && node scripts/lib/pref-boundary.test.js && node scripts/lib/name-cluster.test.js && node scripts/lib/crawl-summary.test.js && node scripts/lib/notify-slack.test.js && node scripts/build/merged-csv.test.js && node scripts/build/prefecture-csv.test.js && node scripts/build/tiles.test.js && node scripts/preview-map.test.js && node scripts/map-filter.test.js && node scripts/generate/readme-stats.test.js && node scripts/generate/llms.test.js && node scripts/generate/attribution.test.js && node scripts/workflows.test.js && node scripts/crawler-contract.test.js",
+    "test:unit": "node scripts/crawl.test.js && node scripts/lib/config.test.js && node scripts/lib/acquire.test.js && node scripts/lib/geocode.test.js && node scripts/lib/coord-quality.test.js && node scripts/lib/pref-boundary.test.js && node scripts/lib/name-cluster.test.js && node scripts/lib/crawl-summary.test.js && node scripts/lib/notify-slack.test.js && node scripts/build/merged-csv.test.js && node scripts/build/prefecture-csv.test.js && node scripts/build/tiles.test.js && node scripts/preview-map.test.js && node scripts/map-filter.test.js && node scripts/generate/readme-stats.test.js && node scripts/generate/llms.test.js && node scripts/generate/attribution.test.js && node scripts/workflows.test.js && node scripts/crawler-contract.test.js",
     "test:api": "node scripts/validate-api.js",
     "test": "npm run test:unit && npm run test:api"
   },

--- a/scripts/lib/acquire.js
+++ b/scripts/lib/acquire.js
@@ -30,6 +30,19 @@ export async function fetchCkanResourceInfo(ckanBase, resourceId, attempt = 0) {
   return json.result; // { url, format, ... }
 }
 
+// CKAN resource_show の結果から、実際にダウンロードすべきURLを決める。
+// 通常は result.url をそのまま使うが、datastore 専用リソース（ファイルストアに実体が無く、
+// CKAN の datastore テーブルにしかデータが無いもの）は result.url が空文字になる。
+// この場合 datastore_active:true が立っているので、それを条件に
+// `<ckanBase>/datastore/dump/<resourceId>` へフォールバックする（url が空というだけで
+// 分岐すると、取得失敗など別の理由で空になったケースを誤って datastore 扱いしてしまうため、
+// 必ず datastore_active を見る）。どちらの条件にも当てはまらない場合は黙って諦めず例外を投げる。
+export function resolveCkanDownloadUrl(ckanBase, resourceId, info) {
+  if (info.url) return info.url;
+  if (info.datastore_active) return `${ckanBase}/datastore/dump/${encodeURIComponent(resourceId)}`;
+  throw new Error(`CKAN resource の url が空で datastore も無効です（フォールバック不可）: ${resourceId}`);
+}
+
 // キャッシュ済みファイルを拡張子から探す（dry-run で CKAN 問い合わせ・リンク解決を避けるため）。
 // `key.ext` に加え、multi 取得の `key-0.ext` `key-1.ext` … も拾う。
 function findCachedFiles(cacheDir, key) {
@@ -87,14 +100,113 @@ function decodeHtmlEntities(s) {
     .replace(/&nbsp;/g, ' ');
 }
 
+// 候補文字列（href または リンク表示テキスト）から日付を抽出し、比較可能な数値に正規化する。
+// 対応する表記（優先順に試す。先に一致したものを採用する）:
+//   西暦+漢字   2026年3月(末現在)   -> 20260300（掲載ページの説明文に多い）
+//   和暦(日付)  R080331 / r080331   -> 令和8年3月31日 = 20260331（区切りなし、年2桁固定）
+//   和暦(年月)  R0803 / r0803       -> 令和8年3月     = 20260300
+//   和暦(年)    R08 / R7 / r08      -> 令和8年 / 令和7年 = 20260000 / 20250000
+//   西暦8桁     20260331            -> 20260331（14桁タイムスタンプの先頭8桁も拾う）
+//   西暦6桁     202603              -> 20260300
+//   西暦4桁     2026                -> 20260000
+// 一致しなければ null。どちらの元号体系（'western'|'wareki'）で一致したかも返す
+// （pickLatest で西暦と和暦が混在した候補を検出するために使う）。
+export function extractDateToken(str) {
+  const s = String(str);
+
+  // 西暦+漢字（例: 「2026年3月末現在」）。リンク文言での日付表記はこの形が多いため最優先で試す。
+  let m = s.match(/(19|20)\d{2}年(\d{1,2})月/);
+  if (m) {
+    const year = Number(m[0].match(/(19|20)\d{2}/)[0]);
+    const month = Number(m[2]);
+    return { era: 'western', value: year * 10000 + month * 100, raw: m[0] };
+  }
+
+  // 和暦「年月日まで」: R080331 / r080331（区切りなし、年は2桁固定・月日各2桁）
+  m = s.match(/[Rr]0?(\d{1,2})(\d{2})(\d{2})(?!\d)/);
+  if (m) {
+    const year = 2018 + Number(m[1]); // 令和元年(R1) = 2019年
+    const month = Number(m[2]);
+    const day = Number(m[3]);
+    return { era: 'wareki', value: year * 10000 + month * 100 + day, raw: m[0] };
+  }
+
+  // 和暦「年月まで」: R0803 / r0803
+  m = s.match(/[Rr]0?(\d{1,2})(\d{2})(?!\d)/);
+  if (m) {
+    const year = 2018 + Number(m[1]);
+    const month = Number(m[2]);
+    return { era: 'wareki', value: year * 10000 + month * 100, raw: m[0] };
+  }
+
+  // 和暦「年のみ」: R08 / R7 / r08
+  m = s.match(/[Rr]0?(\d{1,2})(?!\d)/);
+  if (m) {
+    const year = 2018 + Number(m[1]);
+    return { era: 'wareki', value: year * 10000, raw: m[0] };
+  }
+
+  // 西暦8桁: 20260331
+  m = s.match(/(?:19|20)\d{6}/);
+  if (m) return { era: 'western', value: Number(m[0]), raw: m[0] };
+
+  // 西暦6桁: 202603
+  m = s.match(/(?:19|20)\d{4}(?!\d)/);
+  if (m) return { era: 'western', value: Number(m[0]) * 100, raw: m[0] };
+
+  // 西暦4桁: 2026
+  m = s.match(/(?:19|20)\d{2}(?!\d)/);
+  if (m) return { era: 'western', value: Number(m[0]) * 10000, raw: m[0] };
+
+  return null;
+}
+
+// 候補 [{url, text}, ...] の中から「日付が最大のもの」を選ぶ（resolveLinkFromHtml の pickLatest 用）。
+// 日付抽出は各候補について text を優先し、無ければ url を試す（掲載ページの説明文には
+// 西暦の日付が書かれているがファイル名は和暦、ということがあるため。同一ソース内では
+// text 側の表記が一貫していれば text 側だけで揃う）。
+// 日付を抽出できない候補は比較対象から除外する（skipped で返す）。
+// 比較対象になった候補の元号体系（西暦/和暦）が混在している場合は、桁数の解釈が変わり
+// 単純比較できないため例外を投げる。比較対象が1件も無い場合も例外を投げる
+// （「選べなかったときに黙って先頭を返す」を避けるため）。
+export function selectLatestCandidate(candidates) {
+  const dated = [];
+  const skipped = [];
+  for (const c of candidates) {
+    const token = extractDateToken(c.text) || extractDateToken(c.url);
+    if (!token) {
+      skipped.push(c);
+      continue;
+    }
+    dated.push({ ...c, token });
+  }
+  if (dated.length === 0) {
+    throw new Error(
+      `pickLatest: 候補 ${candidates.length}件のいずれからも日付を抽出できませんでした: ` +
+        `[${candidates.map((c) => c.text || c.url).join(', ')}]`,
+    );
+  }
+  const eras = new Set(dated.map((d) => d.token.era));
+  if (eras.size > 1) {
+    throw new Error(
+      `pickLatest: 候補間で日付表記（西暦/和暦）が混在しており比較できません: ` +
+        dated.map((d) => `${d.token.raw}(${d.token.era})`).join(', '),
+    );
+  }
+  dated.sort((x, y) => y.token.value - x.token.value);
+  return { winner: dated[0], skipped };
+}
+
 // HTML から、条件に一致する <a href> を解決する。
 //   pattern      リンク表示テキストにマッチさせる正規表現文字列（任意）
 //   hrefPattern  href にマッチさせる正規表現文字列（任意。ファイル名で全件/差分を区別する場合に使う）
 //   format       href の拡張子で絞り込む（'xlsx' 等。任意）
 //   baseUrl      相対 href を絶対化する基準
+//   pickLatest   true のとき、複数一致した場合に DOM順の先頭ではなく「日付が最大の候補」を選ぶ
+//                （日付の抽出は extractDateToken / selectLatestCandidate を参照）
 // 返り値: { url, text, count, all }（一致0件なら null）。
-//   url/text は先頭一致。all は全一致の [{url,text}]（multi 取得に使う）。
-export function resolveLinkFromHtml(htmlText, { pattern, hrefPattern, format, baseUrl } = {}) {
+//   url/text は通常は先頭一致、pickLatest 指定時は日付最大の候補。all は全一致の [{url,text}]（multi 取得に使う）。
+export function resolveLinkFromHtml(htmlText, { pattern, hrefPattern, format, baseUrl, pickLatest } = {}) {
   const textRe = pattern ? new RegExp(pattern, 'i') : null;
   const hrefRe = hrefPattern ? new RegExp(hrefPattern, 'i') : null;
   const extRe = format ? new RegExp(`\\.${format}(?:$|[?#])`, 'i') : null;
@@ -112,6 +224,20 @@ export function resolveLinkFromHtml(htmlText, { pattern, hrefPattern, format, ba
   if (candidates.length === 0) return null;
   const toUrl = (c) => ({ url: baseUrl ? new URL(c.href, baseUrl).toString() : c.href, text: c.text });
   const all = candidates.map(toUrl);
+
+  // pickLatest: 既定の「先頭を採用」ではなく、日付が最大の候補を採用する。
+  // 既定の挙動（pickLatest 未指定）はここに一切触れないため変わらない。
+  if (pickLatest) {
+    const { winner, skipped } = selectLatestCandidate(all);
+    if (skipped.length > 0) {
+      console.log(
+        `  ⚠ pickLatest: 日付を抽出できない候補 ${skipped.length}件を比較対象から除外: ` +
+          `${skipped.map((s) => s.text || s.url).join(', ')}`,
+      );
+    }
+    return { url: winner.url, text: winner.text, count: candidates.length, all };
+  }
+
   return { ...all[0], count: candidates.length, all };
 }
 
@@ -142,7 +268,10 @@ export async function acquire(source, { cacheDir, dryRun = false } = {}) {
     return files.map((f) => ({ cachePath: path.join(dir, f), format: 'csv' }));
   }
 
-  const urls = a.urls || (a.url ? [a.url] : [null]); // ckan は url なしで resourceId 解決
+  // ckan: resourceId は単一文字列でも配列でもよい（配列なら1エントリで複数リソースを結合して取得する。
+  // 例: 福井県は776・777の2 resourceId を1ソースとして結合する）。
+  const ckanResourceIds = a.type === 'ckan' ? (Array.isArray(a.resourceId) ? a.resourceId : [a.resourceId]) : null;
+  const urls = a.urls || (a.url ? [a.url] : ckanResourceIds ? ckanResourceIds.map(() => null) : [null]); // ckan は url なしで resourceId 解決
   const results = [];
 
   // 1URLを取得して .cache に保存し {cachePath, format} を返す。
@@ -199,8 +328,9 @@ export async function acquire(source, { cacheDir, dryRun = false } = {}) {
     const format = (a.format || '').toLowerCase();
 
     if (a.type === 'ckan') {
-      const info = await fetchCkanResourceInfo(a.ckanBase, a.resourceId);
-      downloadUrl = info.url;
+      const resourceId = ckanResourceIds[i];
+      const info = await fetchCkanResourceInfo(a.ckanBase, resourceId);
+      downloadUrl = resolveCkanDownloadUrl(a.ckanBase, resourceId, info);
       results.push(await downloadOne(downloadUrl, key, format || (info.format || '').toLowerCase()));
       continue;
     }
@@ -210,6 +340,9 @@ export async function acquire(source, { cacheDir, dryRun = false } = {}) {
     //   multi:true   一致した全リンクを取得（全件が複数ファイルに分割された自治体）
     //   hrefScan:true <a> に限らず生HTML中で hrefPattern に一致するURL/パスを拾う
     //                 （<button value="..."> 等 アンカー以外にURLが埋まっているページ向け）
+    //   pickLatest:true 複数一致したとき DOM順の先頭ではなく日付が最大の候補を採用する
+    //                 （同一ページに複数年度のファイルが並存し、DOM順への依存が危険な自治体向け。
+    //                 日付抽出・比較の仕様は extractDateToken / selectLatestCandidate を参照）
     if (a.type === 'resolve') {
       console.log(`  リンク解決中: ${a.pageUrl}`);
       const html = Buffer.from(await fetchWithRetry(a.pageUrl, { headers: { ...DEFAULT_HEADERS } })).toString('utf-8');
@@ -228,7 +361,13 @@ export async function acquire(source, { cacheDir, dryRun = false } = {}) {
         }
         console.log(`  リンク解決(hrefScan): ${resolvedUrls.length}件`);
       } else {
-        const hit = resolveLinkFromHtml(html, { pattern: a.linkPattern, hrefPattern: a.hrefPattern, format: linkFmt, baseUrl: a.pageUrl });
+        const hit = resolveLinkFromHtml(html, {
+          pattern: a.linkPattern,
+          hrefPattern: a.hrefPattern,
+          format: linkFmt,
+          baseUrl: a.pageUrl,
+          pickLatest: a.pickLatest,
+        });
         if (!hit) {
           throw new Error(
             `リンク解決に失敗: ${a.pageUrl} に「${a.linkPattern || a.hrefPattern || '(指定なし)'}」に一致する` +
@@ -237,7 +376,10 @@ export async function acquire(source, { cacheDir, dryRun = false } = {}) {
         }
         resolvedUrls = a.multi ? hit.all.map((h) => h.url) : [hit.url];
         if (a.multi) console.log(`  リンク解決: ${hit.count}件を取得`);
-        else {
+        else if (hit.count > 1 && a.pickLatest) {
+          // pickLatest: DOM順の先頭ではなく日付最大の候補を採用したことが分かるようログを変える。
+          console.log(`  リンク解決(pickLatest): ${hit.count}件中、日付が最大のものを採用: 「${hit.text}」 -> ${hit.url}`);
+        } else {
           if (hit.count > 1) console.log(`  ⚠ ${hit.count}件一致。先頭を採用: 「${hit.text}」`);
           console.log(`  リンク解決: 「${hit.text}」 -> ${hit.url}`);
         }

--- a/scripts/lib/acquire.test.js
+++ b/scripts/lib/acquire.test.js
@@ -1,0 +1,413 @@
+// acquire.js のユニットテスト（自前 assert、node scripts/lib/acquire.test.js で実行）。
+//
+// 対象:
+//   - extractDateToken / selectLatestCandidate: 日付抽出・最新候補選択の純粋ロジック
+//   - resolveLinkFromHtml: 複数候補からのリンク解決（既定挙動 と pickLatest オプション）
+//   - resolveCkanDownloadUrl: CKAN datastore 専用リソースへのフォールバック
+//   - acquire(): ckan の resourceId 配列対応・datastore フォールバック・resolve pickLatest の結合動作
+//     （global.fetch を一時的に差し替えてネットワークなしで検証する）
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  extractDateToken,
+  selectLatestCandidate,
+  resolveLinkFromHtml,
+  resolveCkanDownloadUrl,
+  acquire,
+} from './acquire.js';
+
+let failures = 0;
+/** 条件を検証して結果を出力する（失敗数を数える）。 */
+function check(cond, msg) {
+  if (cond) {
+    console.log(`  ✓ ${msg}`);
+  } else {
+    console.error(`  ✗ ${msg}`);
+    failures++;
+  }
+}
+
+/** 例外が投げられることを検証する。 */
+function assertThrows(fn, msg) {
+  try {
+    fn();
+    console.error(`  ✗ ${msg}（例外が投げられなかった）`);
+    failures++;
+  } catch (e) {
+    console.log(`  ✓ ${msg}: ${e.message}`);
+  }
+}
+
+console.log('acquire テスト\n');
+
+// ============================================================
+// extractDateToken
+// ============================================================
+console.log('--- extractDateToken ---');
+
+check(extractDateToken('Shokuhin_itiran_R08.csv')?.value === 20260000, '和暦「年のみ」R08 -> 20260000（令和8年=2026年）');
+check(extractDateToken('Shokuhin_itiran_R07.csv')?.value === 20250000, '和暦「年のみ」R07 -> 20250000（令和7年=2025年）');
+check(extractDateToken('Shokuhin_itiran_R08.csv')?.era === 'wareki', '和暦「年のみ」の era は wareki');
+check(extractDateToken('zenkenr080331.csv')?.value === 20260331, '和暦「年月日」r080331 -> 20260331');
+check(extractDateToken('R0803zenshisetsuichiran.xls')?.value === 20260300, '和暦「年月」R0803 -> 20260300');
+check(extractDateToken('232033_Food_Business_All_20260331.csv')?.value === 20260331, '西暦8桁 20260331 -> 20260331');
+check(extractDateToken('20260407150739.csv')?.value === 20260407, '西暦8桁+時刻14桁の先頭8桁を採用: 20260407150739 -> 20260407');
+check(extractDateToken('syokuhineiseidaityou202401.csv')?.value === 20240100, '西暦6桁 202401 -> 20240100');
+check(extractDateToken('2026ALL-IND-CSV.csv')?.value === 20260000, '西暦4桁 2026 -> 20260000');
+check(
+  extractDateToken('全ての許可施設（2026年3月末現在）')?.value === 20260300,
+  '西暦+漢字「2026年3月末現在」-> 20260300',
+);
+check(
+  extractDateToken('全ての許可施設（2021年5月末現在）')?.value === 20210500,
+  '西暦+漢字「2021年5月末現在」-> 20210500',
+);
+check(extractDateToken('syokuhineigyoukyoka.csv') === null, '日付が全く含まれない文字列は null');
+check(extractDateToken('r30531_all_.csv')?.value === 20210531, '和暦「年月日」r30531（1桁年、区切りなし）-> 20210531');
+check(extractDateToken('r30531_all_.csv')?.era === 'wareki', 'r30531 の era は wareki');
+
+// ============================================================
+// selectLatestCandidate
+// ============================================================
+console.log('\n--- selectLatestCandidate ---');
+
+{
+  const r08first = [
+    { url: 'https://x/Shokuhin_itiran_R08.csv', text: '' },
+    { url: 'https://x/Shokuhin_itiran_R07.csv', text: '' },
+  ];
+  const r07first = [
+    { url: 'https://x/Shokuhin_itiran_R07.csv', text: '' },
+    { url: 'https://x/Shokuhin_itiran_R08.csv', text: '' },
+  ];
+  check(
+    selectLatestCandidate(r08first).winner.url.endsWith('R08.csv'),
+    '和暦 R08 vs R07（R08が先）: R08 が選ばれる',
+  );
+  check(
+    selectLatestCandidate(r07first).winner.url.endsWith('R08.csv'),
+    '和暦 R08 vs R07（R07が先、DOM順逆転）: それでも R08 が選ばれる',
+  );
+}
+
+{
+  // 西暦8桁の候補同士で正しく最大値が選ばれることを固定する。
+  const cands = [
+    { url: 'https://x/a_20250630.csv', text: '' },
+    { url: 'https://x/a_20260331.csv', text: '' },
+    { url: 'https://x/a_20251231.csv', text: '' },
+  ];
+  check(selectLatestCandidate(cands).winner.url.endsWith('20260331.csv'), '西暦8桁3候補: 最大の20260331が選ばれる');
+}
+
+assertThrows(
+  () =>
+    selectLatestCandidate([
+      { url: 'https://x/a_20260331.csv', text: '' },
+      { url: 'https://x/Shokuhin_itiran_R08.csv', text: '' },
+    ]),
+  '西暦と和暦が候補間で混在すると比較できず例外',
+);
+
+assertThrows(
+  () =>
+    selectLatestCandidate([
+      { url: 'https://x/opaque-id-1.csv', text: '' },
+      { url: 'https://x/opaque-id-2.csv', text: '' },
+    ]),
+  '日付を抽出できる候補が1件も無いと例外（黙って先頭を返さない）',
+);
+
+{
+  // 日付を抽出できる候補と抽出できない候補が混在するとき、抽出できないものは除外して比較する。
+  const cands = [
+    { url: 'https://x/opaque-id.csv', text: '' },
+    { url: 'https://x/a_20260331.csv', text: '' },
+    { url: 'https://x/a_20250101.csv', text: '' },
+  ];
+  const { winner, skipped } = selectLatestCandidate(cands);
+  check(winner.url.endsWith('20260331.csv'), '日付なし候補混在: 日付ありの中から最大が選ばれる');
+  check(skipped.length === 1 && skipped[0].url.endsWith('opaque-id.csv'), '日付なし候補混在: 除外された候補が skipped に入る');
+}
+
+// ============================================================
+// resolveLinkFromHtml（既定挙動: pickLatest 未指定）
+// ============================================================
+console.log('\n--- resolveLinkFromHtml（既定挙動） ---');
+
+{
+  // 既存32件の resolve が依存している「DOM順の先頭を採用」を固定する。
+  // pickLatest を渡さない限り、旧いリンクが先にあっても先頭がそのまま採用されるべき。
+  const html = `
+    <a href="/old.csv">古いファイル</a>
+    <a href="/new.csv">新しいファイル</a>
+  `;
+  const hit = resolveLinkFromHtml(html, { format: 'csv' });
+  check(hit.url === '/old.csv', '既定挙動: 複数一致でも DOM順の先頭を採用する（回帰防止）');
+  check(hit.count === 2, '既定挙動: count は一致件数の合計');
+  check(hit.all.length === 2, '既定挙動: all に全候補が入る');
+}
+
+check(resolveLinkFromHtml('<p>no links here</p>', { format: 'csv' }) === null, '一致0件のとき null を返す');
+
+// ============================================================
+// resolveLinkFromHtml（pickLatest: true）
+// ============================================================
+console.log('\n--- resolveLinkFromHtml（pickLatest: true） ---');
+
+// いわき市を模したフィクスチャ: 年ベースのCSV（R07/R08）と、同じページに並ぶ月次差分（R0604等、4桁）。
+// hrefPattern は「Shokuhin_itiran_R + 2桁のみ + .csv」に絞り、月次差分を除外する。
+const iwakiHtmlOldFirst = `
+  <a href="/simple/Shokuhin_itiran_R07.csv">（CSV type）（796KB）</a>
+  <a href="/simple/Shokuhin_itiran_R08.csv">（CSV type）（1008KB）</a>
+  <a href="/simple/Shokuhin_itiran_R0604.csv">（CSV type）（4KB）</a>
+  <a href="/simple/Shokuhin_itiran_R0803.csv">（CSV type）（6KB）</a>
+`;
+const iwakiHtmlNewFirst = `
+  <a href="/simple/Shokuhin_itiran_R08.csv">（CSV type）（1008KB）</a>
+  <a href="/simple/Shokuhin_itiran_R07.csv">（CSV type）（796KB）</a>
+  <a href="/simple/Shokuhin_itiran_R0604.csv">（CSV type）（4KB）</a>
+  <a href="/simple/Shokuhin_itiran_R0803.csv">（CSV type）（6KB）</a>
+`;
+{
+  const opts = { hrefPattern: 'Shokuhin_itiran_R\\d{2}\\.csv$', format: 'csv', pickLatest: true, baseUrl: 'https://city.iwaki.example/index.html' };
+  const hitOld = resolveLinkFromHtml(iwakiHtmlOldFirst, opts);
+  const hitNew = resolveLinkFromHtml(iwakiHtmlNewFirst, opts);
+  check(hitOld.url.endsWith('Shokuhin_itiran_R08.csv'), 'いわき市想定: hrefPattern で月次差分を除外しR08(最新)が選ばれる（古い→新しい順）');
+  check(hitNew.url.endsWith('Shokuhin_itiran_R08.csv'), 'いわき市想定: DOM順を入れ替えても同じR08が選ばれる（新しい→古い順）');
+  check(hitOld.count === 2, 'いわき市想定: hrefPattern一致は2件（R07/R08。月次差分は候補にすら入らない）');
+}
+
+// 神戸市を模したフィクスチャ: 現行版（2026年）と改正前旧法版（2021年）が同じ文言テンプレで並存。
+// href は現行版が14桁タイムスタンプ、旧法版が和暦ファイル名で表記が揃っていないため、
+// 日付はリンク文言（西暦+漢字）から取る前提のフィクスチャ。
+const kobeHtmlCurrentFirst = `
+  <a href="/documents/6359/20260407150739.csv">全ての許可施設（2026年3月末現在。同時点で許可満了日を過ぎている施設を除く。）（CSV：3,777KB）</a>
+  <a href="/documents/6359/0804_syokuhin.csv">2026年4月新規許可施設（CSV：60KB）</a>
+  <a href="/documents/6359/r30531_all_.csv">全ての許可施設（2021年5月末現在。同時点で許可満了日を過ぎている施設を除く。）（CSV：5,840KB）</a>
+`;
+// 「意図的に候補順を入れ替えたケース」（回帰の本丸）: 2021年版を先頭に持ってくる。
+const kobeHtmlOldFirst = `
+  <a href="/documents/6359/r30531_all_.csv">全ての許可施設（2021年5月末現在。同時点で許可満了日を過ぎている施設を除く。）（CSV：5,840KB）</a>
+  <a href="/documents/6359/0804_syokuhin.csv">2026年4月新規許可施設（CSV：60KB）</a>
+  <a href="/documents/6359/20260407150739.csv">全ての許可施設（2026年3月末現在。同時点で許可満了日を過ぎている施設を除く。）（CSV：3,777KB）</a>
+`;
+{
+  const opts = { pattern: '^全ての許可施設', format: 'csv', pickLatest: true, baseUrl: 'https://city.kobe.example/dataset.html' };
+  const hitCurrentFirst = resolveLinkFromHtml(kobeHtmlCurrentFirst, opts);
+  const hitOldFirst = resolveLinkFromHtml(kobeHtmlOldFirst, opts);
+  check(
+    hitCurrentFirst.url.endsWith('20260407150739.csv'),
+    '神戸市想定（現行版が先）: 2026年版が選ばれる',
+  );
+  check(
+    hitOldFirst.url.endsWith('20260407150739.csv'),
+    '神戸市想定【回帰の本丸】: 候補順を意図的に入れ替え（2021年版を先頭）ても、2026年版が選ばれる',
+  );
+  check(hitOldFirst.count === 2, '神戸市想定: linkPattern一致は2件（月次新規許可施設は含まれない）');
+}
+
+// 日付の表記（西暦/和暦）が混在すると比較不能として resolveLinkFromHtml 経由でも例外になることを固定する。
+assertThrows(() => {
+  const html = `
+    <a href="/a_20260331.csv">a</a>
+    <a href="/Shokuhin_itiran_R08.csv">b</a>
+  `;
+  resolveLinkFromHtml(html, { format: 'csv', pickLatest: true });
+}, 'pickLatest: 西暦/和暦混在の候補は resolveLinkFromHtml 経由でも例外');
+
+// 日付を抽出できる候補が1件も無いと例外になることを固定する（黙って先頭を返さない）。
+assertThrows(() => {
+  const html = `
+    <a href="/opaque-a.csv">a</a>
+    <a href="/opaque-b.csv">b</a>
+  `;
+  resolveLinkFromHtml(html, { format: 'csv', pickLatest: true });
+}, 'pickLatest: 日付を抽出できる候補が1件も無いと例外');
+
+// ============================================================
+// resolveCkanDownloadUrl
+// ============================================================
+console.log('\n--- resolveCkanDownloadUrl ---');
+
+check(
+  resolveCkanDownloadUrl('https://ckan.example', 'abc', { url: 'https://files.example/a.csv', datastore_active: false }) ===
+    'https://files.example/a.csv',
+  'result.url があればそれをそのまま使う（既定挙動、既存39件の ckan を壊さない）',
+);
+check(
+  resolveCkanDownloadUrl('https://catalog-data.city.kanazawa.ishikawa.jp', '09a49521-cabf-40b4-978b-bd61ef02f650', {
+    url: '',
+    datastore_active: true,
+  }) === 'https://catalog-data.city.kanazawa.ishikawa.jp/datastore/dump/09a49521-cabf-40b4-978b-bd61ef02f650',
+  'url が空で datastore_active:true なら datastore/dump にフォールバック（金沢市の実際のAPI応答で確認済み）',
+);
+assertThrows(
+  () => resolveCkanDownloadUrl('https://ckan.example', 'abc', { url: '', datastore_active: false }),
+  'url が空でも datastore_active が無ければ（別の理由で空の可能性があるため）誤動作せず例外',
+);
+assertThrows(
+  () => resolveCkanDownloadUrl('https://ckan.example', 'abc', { url: '' }),
+  'url が空で datastore_active フィールド自体が無いケースも例外（黙って空URLを使わない）',
+);
+
+// ============================================================
+// acquire()（結合動作。global.fetch を一時差し替えてネットワークなしで検証）
+// ============================================================
+console.log('\n--- acquire()（ckan resourceId 配列 / datastore フォールバック / resolve pickLatest） ---');
+
+/** テスト用の一時 cacheDir を作る。 */
+function makeTmpCacheDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'acquire-test-'));
+}
+
+/** global.fetch を差し替えて実行し、必ず元に戻す。 */
+async function withMockFetch(impl, fn) {
+  const original = globalThis.fetch;
+  globalThis.fetch = impl;
+  try {
+    return await fn();
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
+await (async () => {
+  // 既存の ckan（resourceId が単一文字列）が、これまでどおり1回だけ resource_show を叩き、
+  // その id がそのまま使われることを固定する（既存39件の回帰防止）。
+  const calls = [];
+  await withMockFetch(
+    async (url) => {
+      calls.push(String(url));
+      if (String(url).includes('resource_show')) {
+        return { ok: true, json: async () => ({ success: true, result: { url: 'https://files.example/single.csv', format: 'CSV' } }) };
+      }
+      return { ok: true, arrayBuffer: async () => new TextEncoder().encode('a,b\n1,2\n').buffer };
+    },
+    async () => {
+      const cacheDir = makeTmpCacheDir();
+      const source = { key: 'existing-ckan', acquire: { type: 'ckan', ckanBase: 'https://ckan.example', resourceId: 'single-id' } };
+      const results = await acquire(source, { cacheDir });
+      check(results.length === 1, 'ckan(単一resourceId・既存挙動): 結果は1件');
+      check(
+        calls.some((u) => u.includes('id=single-id')),
+        'ckan(単一resourceId・既存挙動): resource_show に元のIDがそのまま渡る',
+      );
+    },
+  );
+})();
+
+await (async () => {
+  // ckan の resourceId を配列にしたとき（福井県想定）、2つとも resource_show が叩かれ、
+  // 2ファイルとも取得されることを固定する。
+  const calls = [];
+  await withMockFetch(
+    async (url) => {
+      calls.push(String(url));
+      const m = String(url).match(/id=([^&]+)/);
+      if (String(url).includes('resource_show')) {
+        return {
+          ok: true,
+          json: async () => ({ success: true, result: { url: `https://files.example/${m[1]}.csv`, format: 'CSV' } }),
+        };
+      }
+      return { ok: true, arrayBuffer: async () => new TextEncoder().encode('a,b\n1,2\n').buffer };
+    },
+    async () => {
+      const cacheDir = makeTmpCacheDir();
+      const source = {
+        key: 'fukui-pref-like',
+        acquire: { type: 'ckan', ckanBase: 'https://ckan.example', resourceId: ['res-776', 'res-777'], format: 'csv' },
+      };
+      const results = await acquire(source, { cacheDir });
+      check(results.length === 2, 'ckan(resourceId配列): 2つのresourceIdから2ファイル取得できる');
+      check(
+        calls.filter((u) => u.includes('resource_show')).length === 2,
+        'ckan(resourceId配列): resource_show が2回（各IDごとに1回）呼ばれる',
+      );
+      // 2回とも同じ resourceId で呼ばれていないか（配列の2件目以降を無視していないか）を明示的に確認する。
+      check(
+        calls.some((u) => u.includes('resource_show') && u.includes('id=res-776')) &&
+          calls.some((u) => u.includes('resource_show') && u.includes('id=res-777')),
+        'ckan(resourceId配列): resource_show が res-776 / res-777 それぞれ別のIDで呼ばれている（2件目以降を無視していない）',
+      );
+      check(
+        fs.existsSync(path.join(cacheDir, 'fukui-pref-like-0.csv')) && fs.existsSync(path.join(cacheDir, 'fukui-pref-like-1.csv')),
+        'ckan(resourceId配列): key-0 / key-1 でキャッシュされる（get型のurls複数指定と同じ命名規則）',
+      );
+    },
+  );
+})();
+
+await (async () => {
+  // 金沢市想定: resource_show が url="" + datastore_active:true を返すとき、
+  // 実際にダウンロードされる URL が datastore/dump にフォールバックしていることを固定する。
+  const downloadedUrls = [];
+  await withMockFetch(
+    async (url) => {
+      const s = String(url);
+      if (s.includes('resource_show')) {
+        return { ok: true, json: async () => ({ success: true, result: { url: '', format: 'CSV', datastore_active: true } }) };
+      }
+      downloadedUrls.push(s);
+      return { ok: true, arrayBuffer: async () => new TextEncoder().encode('a,b\n1,2\n').buffer };
+    },
+    async () => {
+      const cacheDir = makeTmpCacheDir();
+      const source = {
+        key: 'kanazawa-like',
+        acquire: { type: 'ckan', ckanBase: 'https://catalog-data.example', resourceId: 'kanazawa-resource-id', format: 'csv' },
+      };
+      const results = await acquire(source, { cacheDir });
+      check(results.length === 1, 'ckan(datastoreフォールバック): 結果は1件取得できる');
+      check(
+        downloadedUrls.some((u) => u === 'https://catalog-data.example/datastore/dump/kanazawa-resource-id'),
+        'ckan(datastoreフォールバック): 実際に datastore/dump URL からダウンロードされている',
+      );
+    },
+  );
+})();
+
+await (async () => {
+  // resolve + pickLatest: 神戸市想定のページ（候補順を意図的に入れ替え＝2021年版が先）から、
+  // 実際にダウンロードされる URL が2026年版（最新）になっていることを acquire() を通して固定する。
+  const downloadedUrls = [];
+  await withMockFetch(
+    async (url) => {
+      const s = String(url);
+      if (s.includes('dataset.html')) {
+        return { ok: true, arrayBuffer: async () => new TextEncoder().encode(kobeHtmlOldFirst).buffer };
+      }
+      downloadedUrls.push(s);
+      return { ok: true, arrayBuffer: async () => new TextEncoder().encode('a,b\n1,2\n').buffer };
+    },
+    async () => {
+      const cacheDir = makeTmpCacheDir();
+      const source = {
+        key: 'kobe-like',
+        acquire: {
+          type: 'resolve',
+          pageUrl: 'https://city.kobe.example/dataset.html',
+          linkPattern: '^全ての許可施設',
+          format: 'csv',
+          pickLatest: true,
+        },
+      };
+      const results = await acquire(source, { cacheDir });
+      check(results.length === 1, 'resolve+pickLatest(結合): 結果は1件取得できる');
+      check(
+        downloadedUrls.some((u) => u.endsWith('/documents/6359/20260407150739.csv')),
+        'resolve+pickLatest(結合)【回帰の本丸】: 候補順を入れ替えたページでも実際にダウンロードされるのは2026年版',
+      );
+      check(
+        !downloadedUrls.some((u) => u.endsWith('r30531_all_.csv')),
+        'resolve+pickLatest(結合): 2021年版（旧法）は取得されない',
+      );
+    },
+  );
+})();
+
+console.log(failures === 0 ? '\n✅ すべて成功' : `\n❌ ${failures}件 失敗`);
+process.exit(failures === 0 ? 0 : 1);

--- a/site/attribution.html
+++ b/site/attribution.html
@@ -183,7 +183,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://www.city.iwaki.lg.jp/www/contents/1652661537484/index.html" target="_blank" rel="noopener">https://www.city.iwaki.lg.jp/www/contents/1652661537484/index.html</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://www.city.iwaki.lg.jp/www/contents/1652661537484/simple/Shokuhin_itiran_R08.csv" target="_blank" rel="noopener">https://www.city.iwaki.lg.jp/www/contents/1652661537484/simple/Shokuhin…</a></dd>
+          <dd><a href="https://www.city.iwaki.lg.jp/www/contents/1652661537484/index.html" target="_blank" rel="noopener">https://www.city.iwaki.lg.jp/www/contents/1652661537484/index.html</a></dd>
         </dl>
         
         <div class="attr">
@@ -1073,7 +1073,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://www.city.kobe.lg.jp/a99427/kenko/health/hygiene/dataset.html" target="_blank" rel="noopener">https://www.city.kobe.lg.jp/a99427/kenko/health/hygiene/dataset.html</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://www.city.kobe.lg.jp/documents/6359/20260407150739.csv" target="_blank" rel="noopener">https://www.city.kobe.lg.jp/documents/6359/20260407150739.csv</a></dd>
+          <dd><a href="https://www.city.kobe.lg.jp/a99427/kenko/health/hygiene/dataset.html" target="_blank" rel="noopener">https://www.city.kobe.lg.jp/a99427/kenko/health/hygiene/dataset.html</a></dd>
         </dl>
         
         <div class="attr">
@@ -1143,7 +1143,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://ckan.odp.jig.jp/dataset/jp-fukui-776-odp" target="_blank" rel="noopener">https://ckan.odp.jig.jp/dataset/jp-fukui-776-odp</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://data.odp.jig.jp/viewcsv/jp/fukui/776.csv" target="_blank" rel="noopener">https://data.odp.jig.jp/viewcsv/jp/fukui/776.csv</a><br><a href="https://data.odp.jig.jp/viewcsv/jp/fukui/777.csv" target="_blank" rel="noopener">https://data.odp.jig.jp/viewcsv/jp/fukui/777.csv</a></dd>
+          <dd><a href="https://ckan.odp.jig.jp/api/3/action/resource_show?id=fdc03bef-3212-46f7-8768-907adf08eee0,77c101ac-47b0-49ed-9fba-e8cfdecec602" target="_blank" rel="noopener">https://ckan.odp.jig.jp/api/3/action/resource_show?id=fdc03bef-3212-46f…</a></dd>
         </dl>
         
         <div class="attr">
@@ -1249,7 +1249,7 @@
           <dt>出典ページ</dt>
           <dd><a href="https://catalog-data.city.kanazawa.ishikawa.jp/dataset/172014-syokuhineisei-kyokashisetsu" target="_blank" rel="noopener">https://catalog-data.city.kanazawa.ishikawa.jp/dataset/172014-syokuhineisei-kyokashisetsu</a></dd>
           <dt>取得URL</dt>
-          <dd><a href="https://catalog-data.city.kanazawa.ishikawa.jp/datastore/dump/09a49521-cabf-40b4-978b-bd61ef02f650?bom=true" target="_blank" rel="noopener">https://catalog-data.city.kanazawa.ishikawa.jp/datastore/dump/09a49521-…</a></dd>
+          <dd><a href="https://catalog-data.city.kanazawa.ishikawa.jp/api/3/action/resource_show?id=09a49521-cabf-40b4-978b-bd61ef02f650" target="_blank" rel="noopener">https://catalog-data.city.kanazawa.ishikawa.jp/api/3/action/resource_sh…</a></dd>
         </dl>
         <span class="badge">元の表記: CC BY</span>
         <div class="attr">


### PR DESCRIPTION
## 概要

`scripts/lib/acquire.js` に3つの機能を追加し、これまで `get` 型据え置きだった4件
（いわき市 / 神戸市 / 金沢市 / 福井県）を `resolve`/`ckan` 型に移行する。

## 3つの拡張とそれぞれが必要だった理由

### 1. `resolve` の `pickLatest` オプション（対象: いわき市・神戸市）

`resolveLinkFromHtml` は複数一致したとき DOM順の先頭を採用する仕様で、同一ページに複数年度の
CSVが並存する自治体では古い年度・古いデータを静かに掴む危険があった。

- **いわき市**: 掲載ページに `Shokuhin_itiran_R07.csv`（前年度）と `R08.csv`（当年度）が並存し、
  同じページに月次差分ファイル（`R0604.csv`〜`R0807.csv`、年+月4桁）も混在する。
- **神戸市**: 「全ての許可施設」の現行版（2026年3月末現在）と、食品衛生法改正前の旧法版
  （2021年5月末現在）が同一テンプレ文言で並存する。現状はDOM順で現行版がたまたま先に
  出現するため動いているだけで、順序が変われば静かに5年前のデータを取り始める。

`pickLatest: true` を指定したときだけ、候補のURL（またはリンク文言）から日付を抽出し
最大のものを選ぶようにした（`extractDateToken` / `selectLatestCandidate`）。対応する日付表記は
西暦4/6/8桁と和暦（`R08` / `R0803` / `R080331`）。和暦は西暦に正規化して比較する。

### 2. `ckan` の datastore 専用リソース対応（対象: 金沢市）

金沢市の `resource_show` は200で通るが `result.url` が空文字で、実体は CKAN の datastore
テーブル側にしか無く `/datastore/dump/{resourceId}` 経由でのみ取得できる。

### 3. `ckan` の `resourceId` 配列対応（対象: 福井県）

福井県は2つの `resourceId` を1ソースとして結合する必要があるが、`ckan` 型は単一指定にしか
対応していなかった。

## 既定の挙動は変えていない（既存 ckan 39件・resolve 32件への影響なし）

3つとも新オプション・新入力形式（`pickLatest` / `resourceId` 配列）を指定したときだけ有効になる
opt-in の拡張で、指定しない限り一切パスが変わらない。

- `pickLatest` 未指定なら `resolveLinkFromHtml` は従来どおり DOM順の先頭を返す
  （`scripts/lib/acquire.test.js` の「既定挙動」セクションで固定）。
- `resourceId` が単一文字列なら `resource_show` は従来どおり1回だけ、そのIDのまま叩かれる
  （同テストの「ckan(単一resourceId・既存挙動)」で固定）。
- `resolveCkanDownloadUrl` は `result.url` があれば従来どおりそれをそのまま使う。

## 神戸市: 日付抽出をリンク文言（西暦表記）から取る設計にした理由

神戸市の2候補は href 側のファイル名フォーマットが揃っていない
（現行版 `20260407150739.csv` = 14桁タイムスタンプ、旧法版 `r30531_all_.csv` = 和暦）。
この2つを日付として比較すると「西暦8桁」と「和暦」という異なる表記体系の混在になり、
`selectLatestCandidate` は表記混在を検出すると比較不能として例外を投げる仕様にしている
（表記が不揃いなときに誤った桁合わせで比較してしまう事故を避けるため）。

一方、両候補のリンク表示テキストは「全ての許可施設（2026年3月末現在...）」
「全ての許可施設（2021年5月末現在...）」といずれも西暦で統一されている。そのため
`extractDateToken` は候補ごとに **text を優先し、無ければ url を試す** 順で日付を抽出するようにし、
神戸市は自然と表記の揃っているリンク文言側から日付が取れるようにした
（いわき市はリンク文言に日付が無いため href 側の和暦フォールバックが使われる）。

## DOM順を入れ替えても同じ結果になることをテストで固定

`scripts/lib/acquire.test.js` に、神戸市を模したフィクスチャで **候補順を意図的に入れ替えた
ケース**（2021年版を先頭に置く）を用意し、それでも2026年版が選ばれることを固定した
（`resolveLinkFromHtml` 単体テストと、`acquire()` を通した結合テストの両方に用意。回帰の本丸）。
いわき市についても DOM順「古い→新しい」「新しい→古い」の両方で同じ最新年度が選ばれることを固定した。

## 金沢市: url が空という条件だけで判定しなかった理由

依頼段階で実際に `resource_show` API を叩いて `result` の中身を確認したところ、
`result.url` は空文字だが `result.datastore_active: true` が判定に使えるフィールドとして
存在していた。`url` が空というだけで datastore 扱いに倒すと、取得失敗など別の理由で
たまたま空になっているケースを誤って datastore フォールバックしてしまう恐れがあるため、
`datastore_active` を明示的に見て判定するようにした（`resolveCkanDownloadUrl`）。
`url` が空で `datastore_active` も立っていない場合は、黙って空URLを使わず例外を投げる。

## 福井県: 依頼文の前提の誤りを訂正した

依頼文にあった「776・777の2つの resourceId」は、実際には CKAN の resourceId（UUID）ではなく
`https://data.odp.jig.jp/viewcsv/jp/fukui/776.csv` のURL末尾の番号だった。実装前に
`ckan.odp.jig.jp` の `package_show`（`jp-fukui-776-odp` / `jp-fukui-777-odp`）を実際に叩いて
実resourceId（UUID）を特定した:

- 776 → `fdc03bef-3212-46f7-8768-907adf08eee0`
- 777 → `77c101ac-47b0-49ed-9fba-e8cfdecec602`

いずれも `resource_show` の `result.url` は現行の直リンクURLと完全一致することを確認済み。

## 4件の移行前後のレコード件数（完全一致）

`node scripts/crawl.js --only=iwaki,kobe,kanazawa,fukui-pref --no-geocode` を新設定・旧設定
それぞれで実行して比較（旧設定は `git show HEAD:config/sources.yaml` を一時的に書き戻して実行）。

| キー | 旧設定（get） | 新設定（resolve/ckan） | 差分 |
|---|---|---|---|
| iwaki | 4,375件 | 4,375件 | 完全一致 |
| kobe | 26,704件 | 26,704件 | 完全一致 |
| kanazawa | 8,842件 | 8,842件 | 完全一致 |
| fukui-pref | 16,284件 | 16,284件 | 完全一致 |

## 変異注入の結果

3パターンとも「意図的に壊す→対応テストが落ちる→戻す」を実施済み:

1. **pickLatestの比較方向反転**（最大ではなく最小を選ぶよう `sort` を壊す）:
   10件のテストが確実に失敗（和暦比較・西暦8桁比較・いわき市/神戸市フィクスチャ・
   resolve+pickLatest結合テストを含む）。
2. **`datastore_active` を見ない実装**（`result.url` が空なら常にdatastore/dumpへフォールバック）:
   2件のテストが確実に失敗（url空+datastore_active無しでも例外を期待するテスト）。
3. **`resourceId` 配列の2件目以降を無視する実装**（常に配列の先頭だけを使う）:
   最初、件数や呼び出し回数だけを見るテストでは検出できなかった（同じIDを2回呼んでも
   見た目上は通ってしまうため）。**この抜けをテストの穴として扱い**、2回の `resource_show`
   呼び出しがそれぞれ異なるIDで行われていることを明示的に確認するアサーションを追加した上で、
   再度壊してテストが落ちることを確認してから戻した。

## テスト

- `scripts/lib/acquire.test.js`（新設）: `extractDateToken` / `selectLatestCandidate` /
  `resolveLinkFromHtml`（既定挙動固定・`pickLatest`）/ `resolveCkanDownloadUrl` / `acquire()` の
  結合動作（`global.fetch` を一時差し替えてネットワークなしで検証）を網羅
- `npm run test:unit`: 合格（失敗0件）
- `npm run build`（フルクロール）は実行していない

## スコープ外にしたもの

- 金沢市の datastore/dump URL に `?bom=true` を付けなかった（依頼文どおり素直な形にした。
  `parse.js` が既にBOM文字をヘッダー判定時にストリップする作りのため実害なし。実データ比較でも
  件数完全一致で確認済み）
- 既存の潜在バグ（`parse.js` が `source.acquire.encoding` ではなく `source.encoding` を参照している
  疑いのある件、worker/12 発見）は本タスクのスコープ外のため未対応
